### PR TITLE
fix null pointer exception in Tracker.getName() / DNS name correctly shown in TC-Log output

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2176,7 +2176,7 @@ public class ServiceSinkhole extends VpnService {
                 uidToApp.put(uid, app);
             }
             assert tracker != null;
-            Log.i("TC-Log", app + " " + daddr + " " + ipToHost.get(daddr) + " " + tracker.getName());
+            Log.i("TC-Log", app + " " + daddr + " " + ipToHost.get(daddr).getOrExpired() + " " + tracker.getName());
         } else {
             if (tracker != NO_TRACKER) {
                 TrackerBlocklist b = TrackerBlocklist.getInstance(ServiceSinkhole.this);

--- a/app/src/main/java/net/kollnig/missioncontrol/data/Tracker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/Tracker.java
@@ -71,10 +71,10 @@ public class Tracker {
      * @return Name of tracker company
      */
     public String getName() {
-        if (name.equals("Alphabet"))
+        if (name != null && name.equals("Alphabet"))
             return "Google";
 
-        if (name.equals("Adobe Systems"))
+        if (name != null && name.equals("Adobe Systems"))
             return "Adobe";
 
         return name;


### PR DESCRIPTION
Hey, I noticed when using the adb log output setting that I am getting null pointer exceptions if an app is requesting an IP which is *not* a tracker, and as such the private name variable of the Tracker class is null.

Also, I noticed that the adb log output is not showing the DNS names of the IPs, but only the instance address of the wrapping Expiring class.

This pull request addresses to fix both problems.

cheers
derMart