### PR TITLE
Fix grammar error in msg_started

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -125,7 +125,7 @@
     <string name="summary_log_logcat">Disables blocking. Communications (and identified trackers) are logged to device log. Retrieve with adb logcat with tag \'TC-Log\'.</string>
 
     <string name="msg_sure">Are you sure?</string>
-    <string name="msg_started">Checking trackers</string>
+    <string name="msg_started">Looking for trackers...</string>
     <string name="msg_waiting">Waiting for event</string>
     <string name="msg_disabled">Use the switch above to enable TrackerControl.</string>
     <string name="msg_revoked">TrackerControl has been disabled, likely by using another VPN based app</string>


### PR DESCRIPTION
I think it sounds better when it's written as "Looking for trackers" rather than "Checking trackers" in the context of a permanent silent notification.

You can also decide whether or not you want to keep the ellipsis at the end of `msg_started` or not.