### PR TITLE
#442 Update AdapterLog.java

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -212,7 +212,15 @@ public class AdapterLog extends CursorAdapter {
         // Application icon
         ApplicationInfo info = null;
         PackageManager pm = context.getPackageManager();
-        String[] pkg = pm.getPackagesForUid(uid);
+        String[] pkg = null;
+
+        try{
+            pkg = pm.getPackagesForUid(uid);
+        }catch(java.lang.SecurityException ignored){
+            //the package belongs to a different user
+        }
+
+        
         if (pkg != null && pkg.length > 0)
             try {
                 info = pm.getApplicationInfo(pkg[0], 0);


### PR DESCRIPTION
Adding exception handling for application logs from different user profiles. Without this, in a multi-profile environment, an exception is thrown stating missing permissions: android.permission.INTERACT_ACROSS_USERS_FULL
or
android.permission.INTERACT_ACROSS_USERS

instead of elevating this permission, I have added an exception to catch it and not show an icon