### PR TITLE
Add bulk exclude/include all apps from tracker monitoring

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -357,6 +357,32 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             });
         }
 
+        Preference pref_exclude_all = screen.findPreference("exclude_all_tracking");
+        if (pref_exclude_all != null) {
+            pref_exclude_all.setOnPreferenceClickListener(preference -> {
+                Util.areYouSure(ActivitySettings.this, R.string.summary_exclude_all_tracking, new Util.DoubtListener() {
+                    @Override
+                    public void onSure() {
+                        setTrackerProtectionForAll(false);
+                    }
+                });
+                return true;
+            });
+        }
+
+        Preference pref_include_all = screen.findPreference("include_all_tracking");
+        if (pref_include_all != null) {
+            pref_include_all.setOnPreferenceClickListener(preference -> {
+                Util.areYouSure(ActivitySettings.this, R.string.summary_include_all_tracking, new Util.DoubtListener() {
+                    @Override
+                    public void onSure() {
+                        setTrackerProtectionForAll(true);
+                    }
+                });
+                return true;
+            });
+        }
+
         if (pref_rcode != null && cat_advanced != null) {
             pref_rcode.setTitle(getString(R.string.setting_rcode, prefs.getString("rcode", "3")));
             cat_advanced.removePreference(pref_rcode);
@@ -393,8 +419,12 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             if (p != null) p.setEnabled(false);
         }
 
-        // In minimal mode, hide hosts/blocklist management (not used) and strict_blocking
+        // In minimal mode, hide hosts/blocklist management (not used) and per-app tracker options
         if (BlockingMode.isMinimalMode(this) && cat_advanced != null) {
+            Preference excludeAll = cat_advanced.findPreference("exclude_all_tracking");
+            if (excludeAll != null) cat_advanced.removePreference(excludeAll);
+            Preference includeAll = cat_advanced.findPreference("include_all_tracking");
+            if (includeAll != null) cat_advanced.removePreference(includeAll);
             Preference manageBlocklists = cat_advanced.findPreference("manage_blocklists");
             if (manageBlocklists != null) cat_advanced.removePreference(manageBlocklists);
             Preference hostsDownload = cat_advanced.findPreference("hosts_download");
@@ -847,6 +877,17 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             pref.setSummary(R.string.summary_blocking_mode_strict);
         else
             pref.setSummary(R.string.summary_blocking_mode_standard);
+    }
+
+    private void setTrackerProtectionForAll(boolean enabled) {
+        SharedPreferences tracker_protect = getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+        SharedPreferences.Editor editor = tracker_protect.edit();
+
+        for (android.content.pm.PackageInfo pkg : Rule.getPackages(this))
+            editor.putBoolean(pkg.packageName, enabled);
+
+        editor.apply();
+        ServiceSinkhole.reload("bulk tracker protect changed", this, false);
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,6 +101,10 @@
     <string name="setting_track_usage">Track network usage</string>
     <string name="setting_reset_usage">Reset network usage</string>
     <string name="setting_show_resolved">Show resolved domain names</string>
+    <string name="setting_exclude_all_tracking">Exclude all apps from tracking</string>
+    <string name="summary_exclude_all_tracking">Disable tracker monitoring for all apps. You can then re-enable it for individual apps.</string>
+    <string name="setting_include_all_tracking">Include all apps in tracking</string>
+    <string name="summary_include_all_tracking">Re-enable tracker monitoring for all apps.</string>
     <string name="setting_block_domains">Enable hosts file</string>
     <string name="setting_rcode">Hosts blocking response: %s</string>
     <string name="setting_vpn4">VPN IPv4: %s</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -113,6 +113,14 @@
                 android:summary="@string/summary_system"
                 android:title="@string/setting_system" />
             <Preference
+                android:key="exclude_all_tracking"
+                android:summary="@string/summary_exclude_all_tracking"
+                android:title="@string/setting_exclude_all_tracking" />
+            <Preference
+                android:key="include_all_tracking"
+                android:summary="@string/summary_include_all_tracking"
+                android:title="@string/setting_include_all_tracking" />
+            <Preference
                 android:key="manage_blocklists"
                 android:summary="@string/summary_manage_blocklists"
                 android:title="@string/title_blocklists" />


### PR DESCRIPTION
## Summary

Addresses #522 — users with many installed apps currently must configure tracker monitoring one app at a time, which is impractical.

This adds two actions in **Advanced Settings** (for experts):

- **Exclude all apps from tracking** — bulk-disables tracker monitoring for all installed apps, so users can then selectively re-enable the ones they care about
- **Include all apps in tracking** — resets all apps back to monitored (the default)

Both actions show a confirmation dialog before proceeding. Both are hidden in minimal blocking mode, where per-app tracker toggles don't apply.

## Changes

- `preferences.xml`: Two new `Preference` buttons in the advanced options screen
- `ActivitySettings.java`: Click handlers with confirmation dialogs + `setTrackerProtectionForAll()` helper that bulk-writes the `tracker_protect` SharedPreferences and reloads the VPN service
- `strings.xml`: Labels and summaries for the new actions

## Design decisions

- Placed in **advanced settings** rather than the main screen to avoid encouraging users to disable protection — tracker monitoring stays on by default for all apps
- Uses the existing `Util.areYouSure()` confirmation pattern
- Reuses `Rule.getPackages()` to enumerate installed apps

## Test plan

- [ ] Open Settings > Advanced options and verify both new buttons appear
- [ ] Tap "Exclude all apps from tracking" → confirm → verify all apps show as unprotected in the main list
- [ ] Tap "Include all apps in tracking" → confirm → verify all apps show as protected again
- [ ] Switch to minimal blocking mode and verify both buttons are hidden
- [ ] Verify newly installed apps after an "exclude all" still default to protected

https://claude.ai/code/session_01Su29k626TdMqFnnNX8iAGK