### PR TITLE
Improve DNS fallback: use Mullvad as secondary, only fall back when list is empty

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,9 @@ android {
         // Secure DNS (DoH) configuration
         buildConfigField "String", "DEFAULT_DOH_ENDPOINT", "\"https://dns.quad9.net/dns-query\""
         buildConfigField "String", "DEFAULT_DNS_IPV4", "\"9.9.9.9\""
-        buildConfigField "String", "DEFAULT_DNS_IPV4_2", "\"149.112.112.112\""
+        buildConfigField "String", "DEFAULT_DNS_IPV4_2", "\"194.242.2.2\""
         buildConfigField "String", "DEFAULT_DNS_IPV6", "\"2620:fe::fe\""
-        buildConfigField "String", "DEFAULT_DNS_IPV6_2", "\"2620:fe::9\""
+        buildConfigField "String", "DEFAULT_DNS_IPV6_2", "\"2a07:e340::2\""
 
         externalNativeBuild {
             cmake {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1390,7 +1390,7 @@ public class ServiceSinkhole extends VpnService {
             }
 
         // Always set DNS servers
-        if (listDns.size() == 0 || listDns.size() < count)
+        if (listDns.size() == 0)
             try {
                 listDns.add(InetAddress.getByName(net.kollnig.missioncontrol.BuildConfig.DEFAULT_DNS_IPV4));
                 listDns.add(InetAddress.getByName(net.kollnig.missioncontrol.BuildConfig.DEFAULT_DNS_IPV4_2));

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1389,7 +1389,7 @@ public class ServiceSinkhole extends VpnService {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }
 
-        // Always set DNS servers
+        // Fallback to default DNS servers if none remain
         if (listDns.size() == 0)
             try {
                 listDns.add(InetAddress.getByName(net.kollnig.missioncontrol.BuildConfig.DEFAULT_DNS_IPV4));


### PR DESCRIPTION
- Change secondary fallback DNS from Quad9 to Mullvad (194.242.2.2) for
  provider diversity while remaining privacy-respecting
- Only trigger fallback DNS when the list is completely empty, not when
  any server was stripped by the LAN filter. If public DNS servers remain
  after filtering, they are sufficient.

https://claude.ai/code/session_013Z8GKoQnj22Bdm3RBpSzey