### PR TITLE
Restore host list settings visibility in minimal blocking mode

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -393,14 +393,8 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             if (p != null) p.setEnabled(false);
         }
 
-        // In minimal mode, hide hosts/blocklist management (not used) and strict_blocking
+        // In minimal mode, hide domain_based_blocking (not used)
         if (BlockingMode.isMinimalMode(this) && cat_advanced != null) {
-            Preference manageBlocklists = cat_advanced.findPreference("manage_blocklists");
-            if (manageBlocklists != null) cat_advanced.removePreference(manageBlocklists);
-            Preference hostsDownload = cat_advanced.findPreference("hosts_download");
-            if (hostsDownload != null) cat_advanced.removePreference(hostsDownload);
-            Preference hostsAutoUpdate = cat_advanced.findPreference("hosts_auto_update");
-            if (hostsAutoUpdate != null) cat_advanced.removePreference(hostsAutoUpdate);
             Preference domainBlocking = cat_advanced.findPreference("domain_based_blocking");
             if (domainBlocking != null) cat_advanced.removePreference(domainBlocking);
         }


### PR DESCRIPTION
The blocking mode feature (commit 6946906) hid manage_blocklists,
hosts_download, and hosts_auto_update preferences when in minimal mode.
Since minimal is the default mode, this made host list management
inaccessible. These settings should be visible in all blocking modes
so users can always add and manage multiple host lists.

https://claude.ai/code/session_01YQ1ZQzBTDC6tqCwWq7dyWP