### PR TITLE
Add option in filter settings to show froxzen (disabled) apps

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -737,6 +737,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 "show_system".equals(name) ||
                 "show_nointernet".equals(name) ||
                 "show_unprotected".equals(name) ||
+                "show_frozen".equals(name) ||
                 "sort".equals(name) ||
                 "imported".equals(name)) {
             if ("sort".equals(name))
@@ -925,6 +926,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
         menu.findItem(R.id.menu_app_nointernet).setChecked(prefs.getBoolean("show_nointernet", true));
         menu.findItem(R.id.menu_app_unprotected).setChecked(prefs.getBoolean("show_unprotected", false));
+        menu.findItem(R.id.menu_app_frozen).setChecked(prefs.getBoolean("show_frozen", false));
 
         String sort = prefs.getString("sort", "trackers_week");
         if ("uid".equals(sort))
@@ -963,6 +965,10 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         } else if (itemId == R.id.menu_app_unprotected) {
             item.setChecked(!item.isChecked());
             prefs.edit().putBoolean("show_unprotected", item.isChecked()).apply();
+            return true;
+        } else if (itemId == R.id.menu_app_frozen) {
+            item.setChecked(!item.isChecked());
+            prefs.edit().putBoolean("show_frozen", item.isChecked()).apply();
             return true;
         } else if (itemId == R.id.menu_sort_name) {
             item.setChecked(true);

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -261,6 +261,7 @@ public class Rule {
             boolean show_system = prefs.getBoolean("show_system", false);
             boolean show_nointernet = prefs.getBoolean("show_nointernet", true);
             boolean show_unprotected = prefs.getBoolean("show_unprotected", false);
+            boolean show_frozen = prefs.getBoolean("show_frozen", false);
             boolean strict_blocking = BlockingMode.isStrictMode(context);
 
             default_screen_wifi = default_screen_wifi && screen_on;
@@ -393,8 +394,7 @@ public class Rule {
                     if (all ||
                             ((rule.system ? show_system : show_user) &&
                                     (show_nointernet || rule.internet) &&
-                                    rule.enabled)) {
-
+                                    (show_frozen || rule.enabled))) {
                         rule.wifi_default = (pre_wifi_blocked.containsKey(info.packageName)
                                 ? pre_wifi_blocked.get(info.packageName)
                                 : default_wifi);

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -27,6 +27,10 @@
                 android:id="@+id/menu_app_unprotected"
                 android:checkable="true"
                 android:title="@string/menu_app_unprotected"/>
+            <item
+                android:id="@+id/menu_app_frozen"
+                android:checkable="true"
+                android:title="@string/menu_app_frozen"/>
         </menu>
     </item>
     <item

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="menu_app_system">Show system apps</string>
     <string name="menu_app_nointernet">Show apps without internet</string>
     <string name="menu_app_unprotected">Show unprotected apps only</string>
+    <string name="menu_app_frozen">Show frozen apps</string>
     <string name="menu_sort">Sort apps</string>
     <string name="menu_sort_name">Sort by name</string>
     <string name="menu_sort_uid">Sort by uid</string>


### PR DESCRIPTION
Closes #433

## Summary
Adds a new "Show frozen apps" filter checkbox to the main app list, 
allowing users to view and configure firewall rules for disabled/frozen 
apps without needing to unfreeze them first.

## Problem
Previously, disabled (frozen) apps were completely hidden from 
TrackerControl's app list. This made it impossible to:
- Pre-configure firewall rules before unfreezing an app
- Verify rules are in place for frozen apps
- Migrate rules from another firewall without temporarily unfreezing 
  every disabled app

## Changes
- `res/menu/main.xml`: Added `menu_app_frozen` checkbox item to the 
  filter submenu, below "Show apps without internet"
- `res/values/strings.xml`: Added `menu_show_frozen` string resource
- `ActivityMain.java` `onPrepareOptionsMenu`: Added checked state for 
  the new checkbox
- `ActivityMain.java` `onOptionsItemSelected`: Added handler that writes 
  `show_frozen` to SharedPreferences when toggled
- `ActivityMain.java` `onSharedPreferenceChanged`: Added `show_frozen` 
  to the preference change listener so the list refreshes automatically 
  when toggled
- `Rule.java` `getRules()`: Added `show_frozen` preference read and 
  updated the filter condition from `rule.enabled` to 
  `(show_frozen || rule.enabled)` so disabled apps are included when 
  the option is on

## Behaviour
- Toggle OFF (default): frozen/disabled apps hidden, existing behaviour 
  preserved
- Toggle ON: disabled apps appear in the list alongside active apps, 
  fully configurable

## Testing
- Disabled a system app via Settings → Apps → Disable
- Verified app was hidden with toggle off
- Verified app appeared in list with toggle on
- Verified firewall rules can be set on the disabled app
- Verified preference persists across app restarts
- Verified no visible change when no disabled apps are present on device