### PR TITLE
Add Shortcut option

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -79,6 +79,8 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <meta-data android:name="android.app.shortcuts"
+                android:resource="@xml/shortcuts" />
             <intent-filter>
                 <action android:name="android.intent.action.MANAGE_NETWORK_USAGE" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -291,5 +293,26 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
+        <activity
+            android:name="eu.faircode.netguard.ActivityShortcut"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:noHistory="true">
+            <intent-filter>
+                <action android:name="eu.faircode.netguard.SHORTCUT_ON" />
+                <action android:name="eu.faircode.netguard.SHORTCUT_OFF" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+        </activity>
+
+        <receiver
+            android:name="eu.faircode.netguard.ReceiverShortcut"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="eu.faircode.netguard.SHORTCUT_ON" />
+                <action android:name="eu.faircode.netguard.SHORTCUT_OFF" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/java/eu/faircode/netguard/ActivityShortcut.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityShortcut.java
@@ -1,0 +1,40 @@
+package eu.faircode.netguard;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import net.kollnig.missioncontrol.R;
+
+public class ActivityShortcut extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        String action = getIntent().getAction();
+        String nextAction = null;
+        String message = null;
+
+        if ("eu.faircode.netguard.SHORTCUT_ON".equals(action)) {
+            nextAction = WidgetAdmin.INTENT_ON;
+            message = getString(R.string.shortcut_on);
+        } else if ("eu.faircode.netguard.SHORTCUT_OFF".equals(action)) {
+            nextAction = WidgetAdmin.INTENT_OFF;
+            message = getString(R.string.shortcut_off);
+        }
+
+        if (nextAction != null) {
+            Intent toggleIntent = new Intent(nextAction);
+            toggleIntent.setPackage(getPackageName());
+            sendBroadcast(toggleIntent);
+            
+            if (message != null) {
+                Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+            }
+        }
+
+        finish();
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/ReceiverShortcut.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverShortcut.java
@@ -1,0 +1,45 @@
+package eu.faircode.netguard;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.widget.Toast;
+
+import androidx.preference.PreferenceManager;
+
+import net.kollnig.missioncontrol.R;
+
+public class ReceiverShortcut extends BroadcastReceiver {
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        String nextAction = null;
+        String message = null;
+
+        if ("eu.faircode.netguard.SHORTCUT_ON".equals(action)) {
+            nextAction = WidgetAdmin.INTENT_ON;
+            message = context.getString(R.string.shortcut_on);
+        } else if ("eu.faircode.netguard.SHORTCUT_OFF".equals(action)) {
+            nextAction = WidgetAdmin.INTENT_OFF;
+            message = context.getString(R.string.shortcut_off);
+        } else {
+            // Fallback to toggle if needed
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            boolean enabled = prefs.getBoolean("enabled", false);
+            nextAction = (enabled ? WidgetAdmin.INTENT_OFF : WidgetAdmin.INTENT_ON);
+            message = context.getString(enabled ? R.string.shortcut_off : R.string.shortcut_on);
+        }
+
+        if (nextAction != null) {
+            Intent toggleIntent = new Intent(nextAction);
+            toggleIntent.setPackage(context.getPackageName());
+            context.sendBroadcast(toggleIntent);
+
+            if (message != null) {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show();
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -652,4 +652,7 @@ Sincerely,\n\n]]></string>
     <string name="msg_invalid_url">Invalid URL</string>
     <string name="msg_apply_blocklists_failed">Failed to apply host files</string>
     <string name="msg_last_update">Last update: %s</string>
+
+    <string name="shortcut_on">Protection ON</string>
+    <string name="shortcut_off">Protection OFF</string>
 </resources>

--- a/app/src/main/res/xml/shortcuts.xml
+++ b/app/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:shortcutId="protection_on"
+        android:enabled="true"
+        android:icon="@drawable/ic_rocket_white"
+        android:shortcutShortLabel="@string/shortcut_on"
+        android:shortcutLongLabel="@string/shortcut_on">
+        <intent
+            android:action="eu.faircode.netguard.SHORTCUT_ON"
+            android:targetClass="eu.faircode.netguard.ActivityShortcut" />
+    </shortcut>
+    <shortcut
+        android:shortcutId="protection_off"
+        android:enabled="true"
+        android:icon="@drawable/ic_rocket_white"
+        android:shortcutShortLabel="@string/shortcut_off"
+        android:shortcutLongLabel="@string/shortcut_off">
+        <intent
+            android:action="eu.faircode.netguard.SHORTCUT_OFF"
+            android:targetClass="eu.faircode.netguard.ActivityShortcut" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
### Summary

Adds app shortcuts to quickly enable or disable protection directly from the launcher, improving user accessibility and control.

### Changes
- AndroidManifest.xml
	 - Added android.app.shortcuts metadata pointing to res/xml/shortcuts.xml
	 - Declared new ActivityShortcut (translucent, no history, excluded from recents)
	 - Added ReceiverShortcut broadcast receiver for handling shortcut actions
- ActivityShortcut.java
	 - New activity handling launcher shortcut intents (SHORTCUT_ON / SHORTCUT_OFF)
	 - Sends corresponding broadcast to toggle protection
	 - Displays a toast confirmation to the user
- ReceiverShortcut.java
	 - New broadcast receiver handling shortcut actions
	 - Supports explicit ON/OFF actions and fallback toggle based on current state
	 - Sends broadcast to WidgetAdmin and shows user feedback via toast
- res/xml/shortcuts.xml
	 - Defined two launcher shortcuts:
	 	 - "Protection ON"
		  - "Protection OFF"
	 - Both trigger ActivityShortcut with appropriate actions
- strings.xml
	 - Added shortcut_on and shortcut_off string
### Behaviour
- Two new app shortcuts appear in the launcher (long press on app icon)
- Users can directly enable or disable protection without opening the app
- A toast message confirms the action ("Protection ON" / "Protection OFF")
- If triggered via broadcast without explicit state, the receiver toggles based on current status

### Testing
- Verified both shortcuts appear in launcher menu
- Tested "Protection ON" shortcut → correctly enables protection
- Tested "Protection OFF" shortcut → correctly disables protection
- Verified toast messages are displayed correctly
- Tested fallback toggle behaviour via broadcast
- Confirmed no crashes when shortcuts are triggered repeatedly