### PR TITLE
[codex] Restore install tracker analysis notifications

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -91,7 +91,6 @@ import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
 
-import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -2683,7 +2682,7 @@ public class ServiceSinkhole extends VpnService {
 
                 // Check tracker libraries in app
                 if (br != null)
-                    checkTrackers(packageName, uid, br, builder);
+                    checkTrackers(packageName, uid, name, br, builder);
             }
 
         } catch (PackageManager.NameNotFoundException ex) {
@@ -2694,7 +2693,8 @@ public class ServiceSinkhole extends VpnService {
         }
     }
 
-    private void checkTrackers(String packageName, int uid, BroadcastReceiver br, NotificationCompat.Builder builder) {
+    private void checkTrackers(String packageName, int uid, String appName, BroadcastReceiver br,
+            NotificationCompat.Builder builder) {
         BroadcastReceiver.PendingResult result = br.goAsync();
         new Thread() {
             public void run() {
@@ -2706,13 +2706,12 @@ public class ServiceSinkhole extends VpnService {
                     String cachedResult = manager.getCachedResult(packageName);
                     if (cachedResult != null && !manager.isCacheStale(packageName)) {
                         // Use cached result
-                        int trackerCount = StringUtils.countMatches(cachedResult, "•");
+                        int trackerCount = TrackerAnalysisManager.countTrackers(cachedResult);
                         builder.setContentText(getString(R.string.msg_installed_tracker_libraries_found, trackerCount));
                         NotificationManagerCompat.from(c).notify(uid, builder.build());
                     } else {
-                        // Schedule analysis for later - notification will show generic message
-                        manager.startAnalysis(packageName);
-                        // Don't update notification here, user can check app details for results
+                        // Schedule analysis for later; the worker updates this notification when done.
+                        manager.startAnalysis(packageName, uid, appName);
                     }
                 } catch (Exception e) {
                     e.printStackTrace();

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManager.java
@@ -36,8 +36,8 @@ import androidx.work.WorkManager;
  */
 public class TrackerAnalysisManager {
     private static final String PREFS_NAME = "library_analysis";
-    // Single work name ensures only one analysis runs at a time (prevents OOM)
-    private static final String WORK_NAME = "tracker_analysis";
+    private static final String WORK_NAME_PREFIX = "tracker_analysis_";
+    private static final String ATTEMPTED_VERSION_PREFIX = "attempted_versioncode_";
 
     private static TrackerAnalysisManager instance;
     private final Context mContext;
@@ -68,34 +68,46 @@ public class TrackerAnalysisManager {
 
     /**
      * Starts an analysis for the given package using WorkManager.
-     * Only one analysis runs at a time to prevent OOM; others are queued.
+     * Duplicate requests for the same package are ignored while one is pending.
      * Observe progress via {@link #getWorkInfoByPackageLiveData(String)}.
      *
      * @param packageName The package to analyze
      */
     public void startAnalysis(String packageName) {
-        Data inputData = new Data.Builder()
+        startAnalysis(packageName, -1, null);
+    }
+
+    /**
+     * Starts an analysis and optionally updates an install notification with the
+     * result when the worker finishes.
+     */
+    public void startAnalysis(String packageName, int notificationUid, @Nullable String appName) {
+        markAnalysisAttempted(packageName);
+
+        Data.Builder dataBuilder = new Data.Builder()
                 .putString(TrackerAnalysisWorker.KEY_PACKAGE_NAME, packageName)
-                .build();
+                .putInt(TrackerAnalysisWorker.KEY_NOTIFICATION_UID, notificationUid);
+        if (appName != null)
+            dataBuilder.putString(TrackerAnalysisWorker.KEY_APP_NAME, appName);
+
+        Data inputData = dataBuilder.build();
 
         OneTimeWorkRequest workRequest = new OneTimeWorkRequest.Builder(TrackerAnalysisWorker.class)
                 .setInputData(inputData)
                 .addTag(packageName)
                 .build();
 
-        // Use global work name + APPEND to serialize all analyses (prevents OOM from
-        // concurrent scans)
         workManager.enqueueUniqueWork(
-                WORK_NAME,
-                ExistingWorkPolicy.APPEND_OR_REPLACE,
+                getWorkName(packageName),
+                ExistingWorkPolicy.KEEP,
                 workRequest);
     }
 
     /**
-     * Observe work status for a given package (by tag).
+     * Observe work status for the package's unique analysis work.
      */
     public LiveData<java.util.List<WorkInfo>> getWorkInfoByPackageLiveData(String packageName) {
-        return workManager.getWorkInfosByTagLiveData(packageName);
+        return workManager.getWorkInfosForUniqueWorkLiveData(getWorkName(packageName));
     }
 
     @Nullable
@@ -105,13 +117,18 @@ public class TrackerAnalysisManager {
 
     public boolean isCacheStale(String packageName) {
         try {
-            PackageInfo pkg = mContext.getPackageManager().getPackageInfo(packageName, 0);
+            PackageInfo pkg = getPackageInfo(packageName);
             SharedPreferences prefs = getPrefs();
             int cachedVersionCode = prefs.getInt("versioncode_" + packageName, Integer.MIN_VALUE);
             return pkg.versionCode > cachedVersionCode;
         } catch (PackageManager.NameNotFoundException e) {
             return true;
         }
+    }
+
+    public boolean shouldStartAnalysis(String packageName) {
+        return shouldStartAnalysis(getCachedResult(packageName), isCacheStale(packageName),
+                hasAttemptedCurrentVersion(packageName));
     }
 
     /**
@@ -124,7 +141,55 @@ public class TrackerAnalysisManager {
                 .apply();
     }
 
+    public static int countTrackers(String result) {
+        if (result == null)
+            return 0;
+
+        int count = 0;
+        int index = result.indexOf("•");
+        while (index >= 0) {
+            count++;
+            index = result.indexOf("•", index + 1);
+        }
+
+        return count;
+    }
+
+    static String getWorkName(String packageName) {
+        return WORK_NAME_PREFIX + packageName;
+    }
+
+    static boolean shouldStartAnalysis(@Nullable String cachedResult, boolean cacheStale,
+            boolean attemptedCurrentVersion) {
+        return !attemptedCurrentVersion && (cachedResult == null || cacheStale);
+    }
+
     private SharedPreferences getPrefs() {
         return mContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    private void markAnalysisAttempted(String packageName) {
+        try {
+            PackageInfo pkg = getPackageInfo(packageName);
+            getPrefs().edit()
+                    .putInt(ATTEMPTED_VERSION_PREFIX + packageName, pkg.versionCode)
+                    .apply();
+        } catch (PackageManager.NameNotFoundException ignored) {
+        }
+    }
+
+    private boolean hasAttemptedCurrentVersion(String packageName) {
+        try {
+            PackageInfo pkg = getPackageInfo(packageName);
+            int attemptedVersionCode = getPrefs().getInt(ATTEMPTED_VERSION_PREFIX + packageName,
+                    Integer.MIN_VALUE);
+            return attemptedVersionCode >= pkg.versionCode;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
+    private PackageInfo getPackageInfo(String packageName) throws PackageManager.NameNotFoundException {
+        return mContext.getPackageManager().getPackageInfo(packageName, 0);
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
@@ -17,19 +17,43 @@
 
 package net.kollnig.missioncontrol.analysis;
 
+import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_NAME;
+import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_PACKAGENAME;
+import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_UID;
+
+import android.app.Notification;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.work.Data;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
+import eu.faircode.netguard.PendingIntentCompat;
+import eu.faircode.netguard.Util;
+import net.kollnig.missioncontrol.DetailsActivity;
+import net.kollnig.missioncontrol.R;
+
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.Semaphore;
 
 public class TrackerAnalysisWorker extends Worker {
+    private static final String TAG = TrackerAnalysisWorker.class.getSimpleName();
+    private static final Semaphore ANALYSIS_SEMAPHORE = new Semaphore(1);
+
     public static final String KEY_PACKAGE_NAME = "package_name";
+    public static final String KEY_NOTIFICATION_UID = "notification_uid";
+    public static final String KEY_APP_NAME = "app_name";
     public static final String KEY_RESULT = "result";
     public static final String KEY_ERROR = "error";
     public static final String KEY_PROGRESS = "progress";
@@ -48,9 +72,13 @@ public class TrackerAnalysisWorker extends Worker {
                     .build());
         }
 
+        boolean acquired = false;
         try {
             Context context = getApplicationContext();
             PackageInfo pkg = context.getPackageManager().getPackageInfo(packageName, 0);
+
+            ANALYSIS_SEMAPHORE.acquire();
+            acquired = true;
 
             // Perform analysis with progress reporting
             String result = doAnalysis(context, packageName);
@@ -58,6 +86,8 @@ public class TrackerAnalysisWorker extends Worker {
             // Cache the result
             TrackerAnalysisManager.getInstance(context)
                     .cacheResult(packageName, result, pkg.versionCode);
+
+            updateInstallNotification(context, packageName, result);
 
             return Result.success(new Data.Builder()
                     .putString(KEY_RESULT, result)
@@ -75,6 +105,9 @@ public class TrackerAnalysisWorker extends Worker {
             return Result.failure(new Data.Builder()
                     .putString(KEY_ERROR, e.getMessage() != null ? e.getMessage() : "Unknown error")
                     .build());
+        } finally {
+            if (acquired)
+                ANALYSIS_SEMAPHORE.release();
         }
     }
 
@@ -90,5 +123,55 @@ public class TrackerAnalysisWorker extends Worker {
             }
         });
         return analyser.analyseApp(packageName);
+    }
+
+    private void updateInstallNotification(Context context, String packageName, String result) {
+        int uid = getInputData().getInt(KEY_NOTIFICATION_UID, -1);
+        if (uid < 0 || !Util.canNotify(context))
+            return;
+
+        String appName = getInputData().getString(KEY_APP_NAME);
+        if (appName == null)
+            appName = packageName;
+
+        try {
+            NotificationManagerCompat.from(context).notify(uid,
+                    buildInstallNotification(context, packageName, uid, appName, result));
+        } catch (SecurityException ex) {
+            Log.w(TAG, "SecurityException updating install notification for uid " + uid + ": " + ex.getMessage());
+        }
+    }
+
+    static Notification buildInstallNotification(Context context, String packageName, int uid, String appName,
+            String result) {
+        int trackerCount = TrackerAnalysisManager.countTrackers(result);
+
+        Intent main = new Intent(context, DetailsActivity.class);
+        main.putExtra(INTENT_EXTRA_APP_NAME, appName);
+        main.putExtra(INTENT_EXTRA_APP_PACKAGENAME, packageName);
+        main.putExtra(INTENT_EXTRA_APP_UID, uid);
+        PendingIntent pi = PendingIntentCompat.getActivity(context, uid, main,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, "notify");
+        builder.setSmallIcon(R.drawable.ic_rocket_white)
+                .setContentIntent(pi)
+                .addAction(0, context.getString(R.string.title_activity_detail), pi)
+                .setColor(context.getResources().getColor(R.color.colorTrackerControl))
+                .setAutoCancel(true);
+        builder.setContentTitle(context.getString(R.string.msg_installed, appName))
+                .setContentText(context.getString(R.string.msg_installed_tracker_libraries_found, trackerCount));
+
+        Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        intent.setData(Uri.parse("package:" + packageName));
+        PendingIntent piUninstall = PendingIntentCompat.getActivity(context, uid + 10000, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+        builder.addAction(0, context.getString(R.string.uninstall), piUninstall);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+
+        return builder.build();
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -170,6 +170,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             manager.startAnalysis(mAppId);
             // Fragment's observer will pick up the work state changes
         });
+
+        if (manager.shouldStartAnalysis(mAppId))
+            manager.startAnalysis(mAppId);
     }
 
     /**

--- a/app/src/test/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManagerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManagerTest.java
@@ -1,0 +1,38 @@
+package net.kollnig.missioncontrol.analysis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TrackerAnalysisManagerTest {
+    @Test
+    public void countTrackersCountsBulletPrefixedAnalysisRows() {
+        assertEquals(0, TrackerAnalysisManager.countTrackers(null));
+        assertEquals(0, TrackerAnalysisManager.countTrackers("None"));
+        assertEquals(1, TrackerAnalysisManager.countTrackers("\n• Google"));
+        assertEquals(3, TrackerAnalysisManager.countTrackers("\n• Google\n• Meta\n• Branch"));
+    }
+
+    @Test
+    public void workNameIsUniquePerPackage() {
+        assertEquals("tracker_analysis_org.example.one",
+                TrackerAnalysisManager.getWorkName("org.example.one"));
+        assertEquals("tracker_analysis_org.example.two",
+                TrackerAnalysisManager.getWorkName("org.example.two"));
+    }
+
+    @Test
+    public void analysisStartsWhenCacheIsMissingOrStale() {
+        assertTrue(TrackerAnalysisManager.shouldStartAnalysis(null, false, false));
+        assertTrue(TrackerAnalysisManager.shouldStartAnalysis("\n• Google", true, false));
+        assertFalse(TrackerAnalysisManager.shouldStartAnalysis("\n• Google", false, false));
+    }
+
+    @Test
+    public void analysisDoesNotAutoRepeatForAlreadyAttemptedVersion() {
+        assertFalse(TrackerAnalysisManager.shouldStartAnalysis(null, false, true));
+        assertFalse(TrackerAnalysisManager.shouldStartAnalysis("\n• Google", true, true));
+    }
+}


### PR DESCRIPTION
## Summary

Re-adds tracker library counts to install notifications without doing static analysis directly in the package-added receiver, and automatically starts static analysis when users open an app's details screen if results are missing or stale.

## Changes

- Install notifications now enqueue static tracker analysis when no fresh cached result is available.
- Tracker analysis workers update the install notification with the detected tracker-library count after caching the result.
- App details now auto-start tracker-library analysis when there is no cached result, or when the cached result is stale after an app update.
- Automatic details-open analysis is attempted only once per installed app version, so apps that cannot be analysed do not retry on every details open.
- Manual Analyse/Update analysis still calls the normal analysis path and can retry.
- Fresh cached analysis results are shown immediately and do not trigger extra work.
- Analysis work is deduplicated per package with unique WorkManager names instead of appending duplicate jobs to one global queue.
- A worker-level semaphore keeps DEX scans serialized to preserve the existing OOM/battery guard.
- The details UI observes the package's unique work record instead of tag history.
- Adds focused unit coverage for tracker-count parsing, details-open analysis decisions, one-attempt-per-version behavior, and package-unique work names.

## Validation

- `./gradlew :app:testFdroidDebugUnitTest --tests net.kollnig.missioncontrol.analysis.TrackerAnalysisManagerTest`
- `./gradlew :app:testFdroidDebugUnitTest`

Note: this branch was created from `origin/master` in a clean worktree so unrelated local changes, including the existing `app/build.gradle` version bump in the original checkout, are not included.