### PR TITLE
[codex] Add on-device APK patcher

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -166,6 +166,11 @@ android {
             // libwgbridge.so built from wgbridge-rs/ by the wgbridgeBuild task
             jniLibs.srcDirs += "$buildDir/rustJniLibs"
         }
+        // The APK-patcher engine (apksig + ARSCLib) is only compiled into the
+        // fdroid and github flavors. The play flavor excludes it and falls
+        // back to NoOpPatcher at runtime via PatcherFactory.
+        fdroid.java.srcDirs += 'src/patcher/java'
+        github.java.srcDirs += 'src/patcher/java'
     }
 
     externalNativeBuild {
@@ -307,6 +312,17 @@ dependencies {
 
     // OkHttp for DNS-over-HTTPS
     implementation 'com.squareup.okhttp3:okhttp:5.3.2'
+
+    // On-device APK patcher (certificate-pinning circumvention) for HTTPS
+    // content inspection. apksig (Apache-2.0) re-signs patched APKs; dexlib2
+    // (BSD-3) is already a dependency above; ARSCLib (Apache-2.0) edits binary
+    // Android resources (AndroidManifest + res/xml/network_security_config).
+    // Only bundled for the fdroid and github flavors — the play flavor gets a
+    // no-op patcher instead.
+    fdroidImplementation 'com.android.tools.build:apksig:9.0.1'
+    githubImplementation 'com.android.tools.build:apksig:9.0.1'
+    fdroidImplementation 'io.github.reandroid:ARSCLib:1.4.0'
+    githubImplementation 'io.github.reandroid:ARSCLib:1.4.0'
 }
 
 // Fix lint error on release builds

--- a/app/src/fdroid/AndroidManifest.xml
+++ b/app/src/fdroid/AndroidManifest.xml
@@ -2,5 +2,13 @@
     android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <!-- Install the re-signed, patched APK set via PackageInstaller. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+
+    <application android:largeHeap="true">
+        <receiver
+            android:name="net.kollnig.missioncontrol.patch.ApkInstallReceiver"
+            android:exported="false" />
+    </application>
 
 </manifest>

--- a/app/src/github/AndroidManifest.xml
+++ b/app/src/github/AndroidManifest.xml
@@ -2,5 +2,13 @@
     android:installLocation="internalOnly">
 
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <!-- Install the re-signed, patched APK set via PackageInstaller. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES"/>
+
+    <application android:largeHeap="true">
+        <receiver
+            android:name="net.kollnig.missioncontrol.patch.ApkInstallReceiver"
+            android:exported="false" />
+    </application>
 
 </manifest>

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -25,6 +25,7 @@ import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -55,7 +56,11 @@ import net.kollnig.missioncontrol.data.PlayStore;
 import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
+import net.kollnig.missioncontrol.patch.ApkPatcher;
+import net.kollnig.missioncontrol.patch.PatchResult;
+import net.kollnig.missioncontrol.patch.PatcherFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -212,8 +217,114 @@ public class DetailsActivity extends AppCompatActivity {
             intent.setData(Uri.parse("package:" + appPackageName));
             startActivity(intent);
             return true;
+        } else if (itemId == R.id.action_patch_inspection) {
+            startPatchForInspection();
+            return true;
         }
         return super.onOptionsItemSelected(item);
+    }
+
+    /**
+     * Repackage the selected app so its certificate pinning is disabled,
+     * allowing a local TLS-terminating proxy to inspect its HTTPS traffic.
+     */
+    private void startPatchForInspection() {
+        ApkPatcher patcher = PatcherFactory.get();
+        if (!patcher.isAvailable()) {
+            Toast.makeText(this, R.string.patch_unavailable, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        final String sourceDir = resolveSourceApk();
+        if (sourceDir == null) {
+            Toast.makeText(this,
+                    getString(R.string.patch_failed,
+                            getString(R.string.patch_failed_source_missing)),
+                    Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        new androidx.appcompat.app.AlertDialog.Builder(this)
+                .setTitle(getString(R.string.patch_title, appName()))
+                .setMessage(R.string.patch_warning)
+                .setPositiveButton(android.R.string.ok,
+                        (d, w) -> new PatchTask().execute(sourceDir))
+                .setNegativeButton(android.R.string.cancel, null)
+                .show();
+    }
+
+    private String resolveSourceApk() {
+        try {
+            ApplicationInfo ai = getPackageManager()
+                    .getApplicationInfo(appPackageName, 0);
+            return ai.sourceDir;
+        } catch (android.content.pm.PackageManager.NameNotFoundException e) {
+            return null;
+        }
+    }
+
+    private String appName() {
+        return getIntent().getStringExtra(INTENT_EXTRA_APP_NAME);
+    }
+
+    /**
+     * Runs the patcher off the main thread and, on success, offers the
+     * patched APK for installation via the FileProvider.
+     */
+    class PatchTask extends AsyncTask<String, String, PatchResult> {
+        private final ProgressDialog dialog = new ProgressDialog(DetailsActivity.this);
+        private File output;
+
+        @Override
+        protected void onPreExecute() {
+            dialog.setMessage(getString(R.string.patch_progress));
+            dialog.setCancelable(false);
+            dialog.show();
+        }
+
+        @Override
+        protected PatchResult doInBackground(String... args) {
+            File in = new File(args[0]);
+            File dir = new File(getCacheDir(), "apk-patcher");
+            dir.mkdirs();
+            output = new File(dir, appPackageName + "-patched.apk");
+            ApkPatcher p = PatcherFactory.get();
+            return p.patch(DetailsActivity.this, appPackageName, in, output,
+                    msg -> publishProgress(msg));
+        }
+
+        @Override
+        protected void onProgressUpdate(String... values) {
+            if (values.length > 0 && values[0] != null)
+                dialog.setMessage(values[0]);
+        }
+
+        @Override
+        protected void onPostExecute(PatchResult result) {
+            if (running && dialog.isShowing()) dialog.dismiss();
+            if (!running) return;
+            if (result.status == PatchResult.Status.SUCCESS) {
+                offerInstall();
+                View v = findViewById(R.id.view_pager);
+                Snackbar.make(v, getString(R.string.patch_success, result.patchedMethods),
+                        Snackbar.LENGTH_LONG).show();
+            } else {
+                Toast.makeText(DetailsActivity.this,
+                        getString(R.string.patch_failed, result.message),
+                        Toast.LENGTH_LONG).show();
+            }
+        }
+
+        private void offerInstall() {
+            if (output == null || !output.exists()) return;
+            Uri uri = androidx.core.content.FileProvider.getUriForFile(
+                    DetailsActivity.this, getPackageName() + ".provider", output);
+            Intent install = new Intent(Intent.ACTION_VIEW)
+                    .setDataAndType(uri, "application/vnd.android.package-archive")
+                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
+                            | Intent.FLAG_ACTIVITY_NEW_TASK);
+            startActivity(install);
+        }
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -56,11 +56,9 @@ import net.kollnig.missioncontrol.data.PlayStore;
 import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
-import net.kollnig.missioncontrol.patch.ApkPatcher;
-import net.kollnig.missioncontrol.patch.PatchResult;
+import net.kollnig.missioncontrol.patch.ApkPatchWorker;
 import net.kollnig.missioncontrol.patch.PatcherFactory;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -229,8 +227,7 @@ public class DetailsActivity extends AppCompatActivity {
      * allowing a local TLS-terminating proxy to inspect its HTTPS traffic.
      */
     private void startPatchForInspection() {
-        ApkPatcher patcher = PatcherFactory.get();
-        if (!patcher.isAvailable()) {
+        if (!PatcherFactory.get().isAvailable()) {
             Toast.makeText(this, R.string.patch_unavailable, Toast.LENGTH_LONG).show();
             return;
         }
@@ -247,8 +244,11 @@ public class DetailsActivity extends AppCompatActivity {
         new androidx.appcompat.app.AlertDialog.Builder(this)
                 .setTitle(getString(R.string.patch_title, appName()))
                 .setMessage(R.string.patch_warning)
-                .setPositiveButton(android.R.string.ok,
-                        (d, w) -> new PatchTask().execute(sourceDir))
+                .setPositiveButton(android.R.string.ok, (d, w) -> {
+                    ApkPatchWorker.enqueue(this, appPackageName, appName());
+                    Toast.makeText(this, R.string.patch_started_background,
+                            Toast.LENGTH_LONG).show();
+                })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
@@ -265,66 +265,6 @@ public class DetailsActivity extends AppCompatActivity {
 
     private String appName() {
         return getIntent().getStringExtra(INTENT_EXTRA_APP_NAME);
-    }
-
-    /**
-     * Runs the patcher off the main thread and, on success, offers the
-     * patched APK for installation via the FileProvider.
-     */
-    class PatchTask extends AsyncTask<String, String, PatchResult> {
-        private final ProgressDialog dialog = new ProgressDialog(DetailsActivity.this);
-        private File output;
-
-        @Override
-        protected void onPreExecute() {
-            dialog.setMessage(getString(R.string.patch_progress));
-            dialog.setCancelable(false);
-            dialog.show();
-        }
-
-        @Override
-        protected PatchResult doInBackground(String... args) {
-            File in = new File(args[0]);
-            File dir = new File(getCacheDir(), "apk-patcher");
-            dir.mkdirs();
-            output = new File(dir, appPackageName + "-patched.apk");
-            ApkPatcher p = PatcherFactory.get();
-            return p.patch(DetailsActivity.this, appPackageName, in, output,
-                    msg -> publishProgress(msg));
-        }
-
-        @Override
-        protected void onProgressUpdate(String... values) {
-            if (values.length > 0 && values[0] != null)
-                dialog.setMessage(values[0]);
-        }
-
-        @Override
-        protected void onPostExecute(PatchResult result) {
-            if (running && dialog.isShowing()) dialog.dismiss();
-            if (!running) return;
-            if (result.status == PatchResult.Status.SUCCESS) {
-                offerInstall();
-                View v = findViewById(R.id.view_pager);
-                Snackbar.make(v, getString(R.string.patch_success, result.patchedMethods),
-                        Snackbar.LENGTH_LONG).show();
-            } else {
-                Toast.makeText(DetailsActivity.this,
-                        getString(R.string.patch_failed, result.message),
-                        Toast.LENGTH_LONG).show();
-            }
-        }
-
-        private void offerInstall() {
-            if (output == null || !output.exists()) return;
-            Uri uri = androidx.core.content.FileProvider.getUriForFile(
-                    DetailsActivity.this, getPackageName() + ".provider", output);
-            Intent install = new Intent(Intent.ACTION_VIEW)
-                    .setDataAndType(uri, "application/vnd.android.package-archive")
-                    .addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION
-                            | Intent.FLAG_ACTIVITY_NEW_TASK);
-            startActivity(install);
-        }
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/ApkInstallReceiver.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/ApkInstallReceiver.java
@@ -1,0 +1,61 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageInstaller;
+import android.widget.Toast;
+
+import net.kollnig.missioncontrol.R;
+
+/**
+ * Receives the outcome of a {@link SplitApkInstaller} commit. When the system
+ * needs the user to confirm the install it re-launches the supplied
+ * confirmation intent; on terminal outcomes it shows a short toast.
+ */
+public final class ApkInstallReceiver extends BroadcastReceiver {
+
+    public static final String ACTION_INSTALL_STATUS =
+            "net.kollnig.missioncontrol.patch.INSTALL_STATUS";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        int status = intent.getIntExtra(PackageInstaller.EXTRA_STATUS,
+                PackageInstaller.STATUS_FAILURE);
+
+        if (status == PackageInstaller.STATUS_PENDING_USER_ACTION) {
+            Intent confirm = intent.getParcelableExtra(Intent.EXTRA_INTENT);
+            if (confirm != null) {
+                confirm.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                context.startActivity(confirm);
+            }
+            return;
+        }
+
+        if (status == PackageInstaller.STATUS_SUCCESS) {
+            Toast.makeText(context, R.string.patch_install_success,
+                    Toast.LENGTH_LONG).show();
+        } else {
+            String message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE);
+            Toast.makeText(context,
+                    context.getString(R.string.patch_install_failed,
+                            message == null ? String.valueOf(status) : message),
+                    Toast.LENGTH_LONG).show();
+        }
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatchWorker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatchWorker.java
@@ -1,0 +1,225 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_NAME;
+import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_PACKAGENAME;
+
+import android.app.Notification;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.lifecycle.LiveData;
+import androidx.work.Data;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkInfo;
+import androidx.work.WorkManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import eu.faircode.netguard.PendingIntentCompat;
+import eu.faircode.netguard.Util;
+import net.kollnig.missioncontrol.DetailsActivity;
+import net.kollnig.missioncontrol.R;
+
+import java.io.File;
+import java.util.List;
+import java.util.concurrent.Semaphore;
+
+/**
+ * Runs the {@link ApkPatcher} off the UI thread as background WorkManager work,
+ * mirroring {@code TrackerAnalysisWorker}. Progress is surfaced two ways: an
+ * ongoing, silent notification (updated as each phase reports in) and
+ * {@code setProgressAsync}, which any open {@link DetailsActivity} can observe
+ * via {@link #getWorkInfo(Context, String)}. On completion the patched split
+ * set is installed and a final notification is posted.
+ */
+public class ApkPatchWorker extends Worker {
+
+    private static final String TAG = ApkPatchWorker.class.getSimpleName();
+    private static final String WORK_NAME_PREFIX = "apk_patch_";
+    /** Patching is memory/CPU heavy; run at most one at a time. */
+    private static final Semaphore PATCH_SEMAPHORE = new Semaphore(1);
+
+    public static final String KEY_PACKAGE_NAME = "package_name";
+    public static final String KEY_APP_NAME = "app_name";
+    public static final String KEY_ERROR = "error";
+    public static final String KEY_PROGRESS_MESSAGE = "progress_message";
+
+    public ApkPatchWorker(@NonNull Context context, @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    /** Enqueue a background patch for {@code packageName}; duplicates are ignored. */
+    public static void enqueue(@NonNull Context ctx, @NonNull String packageName,
+                               @Nullable String appName) {
+        Data data = new Data.Builder()
+                .putString(KEY_PACKAGE_NAME, packageName)
+                .putString(KEY_APP_NAME, appName == null ? packageName : appName)
+                .build();
+        OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(ApkPatchWorker.class)
+                .setInputData(data)
+                .addTag(packageName)
+                .build();
+        WorkManager.getInstance(ctx).enqueueUniqueWork(
+                WORK_NAME_PREFIX + packageName, ExistingWorkPolicy.KEEP, request);
+    }
+
+    /** Observe the patch work for {@code packageName} (state + progress message). */
+    public static LiveData<List<WorkInfo>> getWorkInfo(@NonNull Context ctx,
+                                                       @NonNull String packageName) {
+        return WorkManager.getInstance(ctx)
+                .getWorkInfosForUniqueWorkLiveData(WORK_NAME_PREFIX + packageName);
+    }
+
+    @NonNull
+    @Override
+    public Result doWork() {
+        Context ctx = getApplicationContext();
+        String packageName = getInputData().getString(KEY_PACKAGE_NAME);
+        if (packageName == null)
+            return Result.failure(error("No package name provided"));
+
+        String appName = getInputData().getString(KEY_APP_NAME);
+        if (appName == null) appName = packageName;
+        final String app = appName;
+        int notifId = (WORK_NAME_PREFIX + packageName).hashCode();
+
+        boolean acquired = false;
+        try {
+            ApkPatcher patcher = PatcherFactory.get();
+            if (!patcher.isAvailable())
+                return Result.failure(error(ctx.getString(R.string.patch_unavailable)));
+
+            ApplicationInfo ai = ctx.getPackageManager().getApplicationInfo(packageName, 0);
+            File base = new File(ai.sourceDir);
+
+            PATCH_SEMAPHORE.acquire();
+            acquired = true;
+
+            notifyProgress(ctx, notifId, app, ctx.getString(R.string.patch_progress));
+
+            File outputDir = new File(ctx.getCacheDir(), "apk-patcher/out");
+            deleteRecursively(outputDir);
+            outputDir.mkdirs();
+
+            PatchResult result = patcher.patch(ctx, packageName, base, outputDir, msg -> {
+                if (msg == null) return;
+                setProgressAsync(new Data.Builder()
+                        .putString(KEY_PROGRESS_MESSAGE, msg).build());
+                notifyProgress(ctx, notifId, app, msg);
+            });
+
+            if (result.status != PatchResult.Status.SUCCESS)
+                return finishFailure(ctx, notifId, app, result.message);
+
+            notifyProgress(ctx, notifId, app, ctx.getString(R.string.patch_installing));
+            SplitApkInstaller.install(ctx, packageName, result.outputFiles);
+
+            notifyDone(ctx, notifId, packageName, app);
+            return Result.success(new Data.Builder()
+                    .putString(KEY_PROGRESS_MESSAGE,
+                            ctx.getString(R.string.patch_installing)).build());
+
+        } catch (Exception e) {
+            String msg = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+            return finishFailure(ctx, notifId, app, msg);
+        } finally {
+            if (acquired) PATCH_SEMAPHORE.release();
+        }
+    }
+
+    private Result finishFailure(Context ctx, int notifId, String appName, String message) {
+        notifyFailed(ctx, notifId, appName, message);
+        return Result.failure(error(message == null ? "Unknown error" : message));
+    }
+
+    private static Data error(String message) {
+        return new Data.Builder().putString(KEY_ERROR, message).build();
+    }
+
+    // --- Notifications ---------------------------------------------------
+
+    /** Ongoing, silent progress notification on the low-importance channel. */
+    private static void notifyProgress(Context ctx, int notifId, String appName, String message) {
+        if (!Util.canNotify(ctx)) return;
+        NotificationCompat.Builder b = new NotificationCompat.Builder(ctx, "foreground")
+                .setSmallIcon(R.drawable.ic_rocket_white)
+                .setColor(ctx.getResources().getColor(R.color.colorTrackerControl))
+                .setContentTitle(ctx.getString(R.string.patch_title, appName))
+                .setContentText(message)
+                .setOngoing(true)
+                .setOnlyAlertOnce(true)
+                .setProgress(0, 0, true)
+                .setPriority(NotificationCompat.PRIORITY_LOW);
+        safeNotify(ctx, notifId, b.build());
+    }
+
+    private static void notifyDone(Context ctx, int notifId, String packageName, String appName) {
+        if (!Util.canNotify(ctx)) return;
+        Intent open = new Intent(ctx, DetailsActivity.class)
+                .putExtra(INTENT_EXTRA_APP_NAME, appName)
+                .putExtra(INTENT_EXTRA_APP_PACKAGENAME, packageName);
+        PendingIntent pi = PendingIntentCompat.getActivity(ctx, notifId, open,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+        NotificationCompat.Builder b = new NotificationCompat.Builder(ctx, "notify")
+                .setSmallIcon(R.drawable.ic_rocket_white)
+                .setColor(ctx.getResources().getColor(R.color.colorTrackerControl))
+                .setContentTitle(ctx.getString(R.string.patch_title, appName))
+                .setContentText(ctx.getString(R.string.patch_install_success))
+                .setContentIntent(pi)
+                .setAutoCancel(true);
+        safeNotify(ctx, notifId, b.build());
+    }
+
+    private static void notifyFailed(Context ctx, int notifId, String appName, String message) {
+        if (!Util.canNotify(ctx)) return;
+        NotificationCompat.Builder b = new NotificationCompat.Builder(ctx, "notify")
+                .setSmallIcon(R.drawable.ic_rocket_white)
+                .setColor(ctx.getResources().getColor(R.color.colorTrackerControl))
+                .setContentTitle(ctx.getString(R.string.patch_title, appName))
+                .setContentText(ctx.getString(R.string.patch_failed,
+                        message == null ? "" : message))
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(
+                        ctx.getString(R.string.patch_failed, message == null ? "" : message)))
+                .setAutoCancel(true);
+        safeNotify(ctx, notifId, b.build());
+    }
+
+    private static void safeNotify(Context ctx, int notifId, Notification n) {
+        try {
+            NotificationManagerCompat.from(ctx).notify(notifId, n);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Cannot post patch notification: " + ex.getMessage());
+        }
+    }
+
+    private static void deleteRecursively(File f) {
+        File[] children = f.listFiles();
+        if (children != null) {
+            for (File child : children) deleteRecursively(child);
+        }
+        f.delete();
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatcher.java
@@ -43,18 +43,24 @@ public interface ApkPatcher {
     }
 
     /**
-     * Patch the given input APK and write a signed, installable result to
-     * {@code outputApk}. This is a long-running, blocking operation and must
-     * be invoked off the main thread.
+     * Patch the given app's base APK and write the signed, installable result(s)
+     * into {@code outputDir}. Only the base APK is patched (dex + resources +
+     * manifest); any config splits (ABI, density, language) are re-signed
+     * unchanged with the same key so the whole set installs together as a
+     * split-install session. This is a long-running, blocking operation and
+     * must be invoked off the main thread.
      *
-     * @return a {@link PatchResult}; on success {@link PatchResult#outputFile}
-     *         equals {@code outputApk}.
+     * @param inputApk  the app's base APK (its config splits are discovered via
+     *                  {@link android.content.pm.PackageManager})
+     * @param outputDir a writable directory to receive the signed APKs
+     * @return a {@link PatchResult}; on success {@link PatchResult#outputFiles}
+     *         lists the base APK first, then any re-signed splits.
      */
     @NonNull
     PatchResult patch(@NonNull Context ctx,
                      @NonNull String packageName,
                      @NonNull File inputApk,
-                     @NonNull File outputApk,
+                     @NonNull File outputDir,
                      @NonNull ProgressListener listener);
 
     /** Whether a real patching engine is available in this build. */

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/ApkPatcher.java
@@ -1,0 +1,62 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+
+/**
+ * Repackages an installed application's APK so that its network traffic can be
+ * intercepted by a local TLS-terminating proxy. Concretely, an implementation
+ * injects a {@code network_security_config.xml} that trusts user-installed
+ * certificate authorities and overrides declared pin sets, and makes the
+ * application debuggable so the debug trust-anchors apply.
+ *
+ * <p>This is the same circumvention offered by apk-mitm and ReVanced Manager's
+ * "Override certificate pinning" patch. It defeats Network Security Config
+ * pinning; applications that pin certificates in code (e.g. OkHttp
+ * {@code CertificatePinner}) need an additional smali patch and will fall back
+ * to pass-through until that is applied.</p>
+ */
+public interface ApkPatcher {
+
+    /** Coarse progress callback. {@code message} is human-readable, may be null. */
+    interface ProgressListener {
+        void onProgress(@Nullable String message);
+    }
+
+    /**
+     * Patch the given input APK and write a signed, installable result to
+     * {@code outputApk}. This is a long-running, blocking operation and must
+     * be invoked off the main thread.
+     *
+     * @return a {@link PatchResult}; on success {@link PatchResult#outputFile}
+     *         equals {@code outputApk}.
+     */
+    @NonNull
+    PatchResult patch(@NonNull Context ctx,
+                     @NonNull String packageName,
+                     @NonNull File inputApk,
+                     @NonNull File outputApk,
+                     @NonNull ProgressListener listener);
+
+    /** Whether a real patching engine is available in this build. */
+    boolean isAvailable();
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/DexPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/DexPatcher.java
@@ -17,21 +17,23 @@ package net.kollnig.missioncontrol.patch;
 
 import androidx.annotation.NonNull;
 
+import org.jf.dexlib2.Opcodes;
 import org.jf.dexlib2.iface.ClassDef;
 import org.jf.dexlib2.iface.DexFile;
 import org.jf.dexlib2.iface.Method;
 import org.jf.dexlib2.iface.MethodImplementation;
 import org.jf.dexlib2.iface.MethodParameter;
 import org.jf.dexlib2.immutable.ImmutableClassDef;
-import org.jf.dexlib2.immutable.ImmutableDexFile;
 import org.jf.dexlib2.immutable.ImmutableMethod;
 import org.jf.dexlib2.immutable.ImmutableMethodImplementation;
 import org.jf.dexlib2.immutable.instruction.ImmutableInstruction;
 
+import java.util.AbstractSet;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Applies the {@link SmaliPatches} declarative method-body replacements to a
@@ -44,25 +46,36 @@ final class DexPatcher {
 
     /** Result of patching one dex file. */
     static final class Result {
-        final ImmutableDexFile dex;
+        final DexFile dex;             // rewritten dex, null when nothing matched
         final byte[] bytes;            // serialized patched dex, null if not yet written
         final int patchedMethods;
 
-        Result(ImmutableDexFile dex, byte[] bytes, int patchedMethods) {
+        Result(DexFile dex, byte[] bytes, int patchedMethods) {
             this.dex = dex;
             this.bytes = bytes;
             this.patchedMethods = patchedMethods;
         }
 
-        Result(ImmutableDexFile dex, int patchedMethods) {
+        Result(DexFile dex, int patchedMethods) {
             this(dex, null, patchedMethods);
         }
     }
 
-    /** Patch every class in {@code dex} and return the rewritten dex + count. */
+    /**
+     * Patch every class in {@code dex} and return the rewritten dex + count.
+     *
+     * <p>Only the classes that actually match a {@link SmaliPatches} selector are
+     * materialized into new {@link ImmutableClassDef}s; every other class is
+     * passed through by reference to its original lazy {@code DexBackedClassDef},
+     * which reads from the backing dex buffer on demand. This keeps peak memory
+     * proportional to the (tiny) set of patched classes rather than to the whole
+     * dex — deep-copying every class was what exhausted the heap on large apps.
+     * When nothing matches, {@link Result#dex} is null so the caller can leave
+     * the original dex untouched.</p>
+     */
     @NonNull
     static Result patchDex(@NonNull DexFile dex) {
-        List<ImmutableClassDef> outClasses = new ArrayList<>();
+        final List<ClassDef> outClasses = new ArrayList<>();
         int patched = 0;
         for (ClassDef classDef : dex.getClasses()) {
             int[] count = {0};
@@ -71,10 +84,37 @@ final class DexPatcher {
                 patched += count[0];
                 outClasses.add(rewritten);
             } else {
-                outClasses.add(ImmutableClassDef.of(classDef));
+                outClasses.add(classDef); // pass-through, lazy — no deep copy
             }
         }
-        return new Result(new ImmutableDexFile(dex.getOpcodes(), outClasses), patched);
+        if (patched == 0) return new Result(null, 0);
+
+        final Opcodes opcodes = dex.getOpcodes();
+        DexFile out = new DexFile() {
+            @NonNull
+            @Override
+            public Set<? extends ClassDef> getClasses() {
+                return new AbstractSet<ClassDef>() {
+                    @NonNull
+                    @Override
+                    public Iterator<ClassDef> iterator() {
+                        return outClasses.iterator();
+                    }
+
+                    @Override
+                    public int size() {
+                        return outClasses.size();
+                    }
+                };
+            }
+
+            @NonNull
+            @Override
+            public Opcodes getOpcodes() {
+                return opcodes;
+            }
+        };
+        return new Result(out, patched);
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/DexPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/DexPatcher.java
@@ -1,0 +1,186 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import androidx.annotation.NonNull;
+
+import org.jf.dexlib2.iface.ClassDef;
+import org.jf.dexlib2.iface.DexFile;
+import org.jf.dexlib2.iface.Method;
+import org.jf.dexlib2.iface.MethodImplementation;
+import org.jf.dexlib2.iface.MethodParameter;
+import org.jf.dexlib2.immutable.ImmutableClassDef;
+import org.jf.dexlib2.immutable.ImmutableDexFile;
+import org.jf.dexlib2.immutable.ImmutableMethod;
+import org.jf.dexlib2.immutable.ImmutableMethodImplementation;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Applies the {@link SmaliPatches} declarative method-body replacements to a
+ * single loaded {@link DexFile}, returning a new immutable dex with matched
+ * method bodies replaced by no-op / always-accept stubs. Uses smali's dexlib2
+ * (already a dependency) — no external patcher required. Only classes that live
+ * in the app's own dex files are patchable; framework classes cannot be touched.
+ */
+final class DexPatcher {
+
+    /** Result of patching one dex file. */
+    static final class Result {
+        final ImmutableDexFile dex;
+        final byte[] bytes;            // serialized patched dex, null if not yet written
+        final int patchedMethods;
+
+        Result(ImmutableDexFile dex, byte[] bytes, int patchedMethods) {
+            this.dex = dex;
+            this.bytes = bytes;
+            this.patchedMethods = patchedMethods;
+        }
+
+        Result(ImmutableDexFile dex, int patchedMethods) {
+            this(dex, null, patchedMethods);
+        }
+    }
+
+    /** Patch every class in {@code dex} and return the rewritten dex + count. */
+    @NonNull
+    static Result patchDex(@NonNull DexFile dex) {
+        List<ImmutableClassDef> outClasses = new ArrayList<>();
+        int patched = 0;
+        for (ClassDef classDef : dex.getClasses()) {
+            int[] count = {0};
+            ImmutableClassDef rewritten = patchClass(classDef, count);
+            if (rewritten != null) {
+                patched += count[0];
+                outClasses.add(rewritten);
+            } else {
+                outClasses.add(ImmutableClassDef.of(classDef));
+            }
+        }
+        return new Result(new ImmutableDexFile(dex.getOpcodes(), outClasses), patched);
+    }
+
+    /**
+     * @return a new ImmutableClassDef with matched methods replaced, or null
+     * if no selector matched (caller keeps the original via ImmutableClassDef.of).
+     */
+    private static ImmutableClassDef patchClass(@NonNull ClassDef classDef, int[] count) {
+        List<String> interfaces = new ArrayList<>();
+        for (String i : classDef.getInterfaces()) interfaces.add(i);
+
+        List<SmaliPatches.Selector> matched = matchedSelectors(classDef.getType(), interfaces);
+        if (matched.isEmpty()) return null;
+
+        List<ImmutableMethod> directMethods = new ArrayList<>();
+        List<ImmutableMethod> virtualMethods = new ArrayList<>();
+
+        for (Method m : classDef.getDirectMethods()) {
+            ImmutableMethod r = patchMethod(m, matched);
+            if (r != null) {
+                directMethods.add(r);
+                count[0]++;
+            } else {
+                directMethods.add(ImmutableMethod.of(m));
+            }
+        }
+        for (Method m : classDef.getVirtualMethods()) {
+            ImmutableMethod r = patchMethod(m, matched);
+            if (r != null) {
+                virtualMethods.add(r);
+                count[0]++;
+            } else {
+                virtualMethods.add(ImmutableMethod.of(m));
+            }
+        }
+
+        return new ImmutableClassDef(
+                classDef.getType(),
+                classDef.getAccessFlags(),
+                classDef.getSuperclass(),
+                interfaces,
+                classDef.getSourceFile(),
+                classDef.getAnnotations(),
+                classDef.getStaticFields(),
+                classDef.getInstanceFields(),
+                directMethods,
+                virtualMethods);
+    }
+
+    /** @return a replacement ImmutableMethod, or null if no patch matched. */
+    private static ImmutableMethod patchMethod(@NonNull Method m,
+                                               @NonNull List<SmaliPatches.Selector> selectors) {
+        MethodImplementation impl = m.getImplementation();
+        if (impl == null) return null; // abstract / native
+        for (SmaliPatches.Selector s : selectors) {
+            for (SmaliPatches.MethodPatch p : s.methods) {
+                if (matches(m, p)) {
+                    return replace(m, impl, p);
+                }
+            }
+        }
+        return null;
+    }
+
+    private static boolean matches(@NonNull Method m, @NonNull SmaliPatches.MethodPatch p) {
+        if (!m.getName().equals(p.name)) return false;
+        if (p.returnType != null && !m.getReturnType().equals(p.returnType)) return false;
+        if (p.paramTypes == null) return true; // wildcard
+        List<? extends MethodParameter> params = m.getParameters();
+        if (params.size() != p.paramTypes.size()) return false;
+        for (int i = 0; i < params.size(); i++) {
+            if (!params.get(i).getType().equals(p.paramTypes.get(i))) return false;
+        }
+        return true;
+    }
+
+    private static ImmutableMethod replace(@NonNull Method m,
+                                          @NonNull MethodImplementation impl,
+                                          @NonNull SmaliPatches.MethodPatch p) {
+        List<ImmutableInstruction> instrs = p.replacement.instructions(m.getReturnType());
+        int regs = p.replacement.registerCount(impl.getRegisterCount());
+        ImmutableMethodImplementation newImpl = new ImmutableMethodImplementation(
+                regs, instrs, Collections.emptyList(), Collections.emptyList());
+        return new ImmutableMethod(
+                m.getDefiningClass(),
+                m.getName(),
+                m.getParameters(),
+                m.getReturnType(),
+                m.getAccessFlags(),
+                m.getAnnotations(),
+                m.getHiddenApiRestrictions(),
+                newImpl);
+    }
+
+    private static List<SmaliPatches.Selector> matchedSelectors(
+            @NonNull String type, @NonNull List<String> interfaces) {
+        List<SmaliPatches.Selector> result = new ArrayList<>();
+        for (SmaliPatches.Selector s : SmaliPatches.all()) {
+            if (s.isInterface) {
+                if (interfaces.contains(s.type)) result.add(s);
+            } else if (s.type.equals(type)) {
+                result.add(s);
+            }
+        }
+        return result;
+    }
+
+    private DexPatcher() {
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/NoOpPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/NoOpPatcher.java
@@ -40,7 +40,7 @@ public final class NoOpPatcher implements ApkPatcher {
     public PatchResult patch(@NonNull Context ctx,
                              @NonNull String packageName,
                              @NonNull File inputApk,
-                             @NonNull File outputApk,
+                             @NonNull File outputDir,
                              @NonNull ProgressListener listener) {
         return PatchResult.failure("No patcher engine is available in this build.");
     }

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/NoOpPatcher.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/NoOpPatcher.java
@@ -1,0 +1,47 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+
+/**
+ * A no-op {@link ApkPatcher} used when no real engine is available (e.g. the
+ * build was stripped of the patcher dependency). Always reports unavailable
+ * and fails with an explanatory message, so callers can show "not supported
+ * in this build" rather than crashing.
+ */
+public final class NoOpPatcher implements ApkPatcher {
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
+
+    @NonNull
+    @Override
+    public PatchResult patch(@NonNull Context ctx,
+                             @NonNull String packageName,
+                             @NonNull File inputApk,
+                             @NonNull File outputApk,
+                             @NonNull ProgressListener listener) {
+        return PatchResult.failure("No patcher engine is available in this build.");
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/PatchResult.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/PatchResult.java
@@ -19,6 +19,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 /** Outcome of a patching run. */
 public final class PatchResult {
@@ -26,24 +28,35 @@ public final class PatchResult {
     public enum Status { SUCCESS, FAILED }
 
     public final Status status;
-    @Nullable public final File outputFile;
+    /**
+     * The signed APKs to install, base first followed by any re-signed config
+     * splits. On failure this is empty. Install the whole list together as a
+     * single split-install session.
+     */
+    @NonNull public final List<File> outputFiles;
     public final int patchedMethods;
     @Nullable public final String message;
 
-    private PatchResult(Status status, File outputFile, int patchedMethods, String message) {
+    private PatchResult(Status status, List<File> outputFiles, int patchedMethods, String message) {
         this.status = status;
-        this.outputFile = outputFile;
+        this.outputFiles = outputFiles;
         this.patchedMethods = patchedMethods;
         this.message = message;
     }
 
+    /** The patched base APK, or null on failure. */
+    @Nullable
+    public File baseApk() {
+        return outputFiles.isEmpty() ? null : outputFiles.get(0);
+    }
+
     @NonNull
-    static PatchResult success(@NonNull File output, int patchedMethods) {
-        return new PatchResult(Status.SUCCESS, output, patchedMethods, null);
+    static PatchResult success(@NonNull List<File> outputFiles, int patchedMethods) {
+        return new PatchResult(Status.SUCCESS, outputFiles, patchedMethods, null);
     }
 
     @NonNull
     static PatchResult failure(@NonNull String message) {
-        return new PatchResult(Status.FAILED, null, 0, message);
+        return new PatchResult(Status.FAILED, Collections.emptyList(), 0, message);
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/PatchResult.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/PatchResult.java
@@ -1,0 +1,49 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import java.io.File;
+
+/** Outcome of a patching run. */
+public final class PatchResult {
+
+    public enum Status { SUCCESS, FAILED }
+
+    public final Status status;
+    @Nullable public final File outputFile;
+    public final int patchedMethods;
+    @Nullable public final String message;
+
+    private PatchResult(Status status, File outputFile, int patchedMethods, String message) {
+        this.status = status;
+        this.outputFile = outputFile;
+        this.patchedMethods = patchedMethods;
+        this.message = message;
+    }
+
+    @NonNull
+    static PatchResult success(@NonNull File output, int patchedMethods) {
+        return new PatchResult(Status.SUCCESS, output, patchedMethods, null);
+    }
+
+    @NonNull
+    static PatchResult failure(@NonNull String message) {
+        return new PatchResult(Status.FAILED, null, 0, message);
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/PatcherFactory.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/PatcherFactory.java
@@ -1,0 +1,42 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Provides the {@link ApkPatcher} appropriate for this build flavor. The
+ * {@code play} flavor ships the no-op patcher (the real engine depends on
+ * apksig, which is only bundled for the {@code fdroid} / {@code github}
+ * flavors).
+ */
+public final class PatcherFactory {
+
+    @NonNull
+    public static ApkPatcher get() {
+        try {
+            Class<?> cls = Class.forName(
+                    "net.kollnig.missioncontrol.patch.Dexlib2Patcher");
+            return (ApkPatcher) cls.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            // Engine not compiled into this flavor (e.g. play).
+            return new NoOpPatcher();
+        }
+    }
+
+    private PatcherFactory() {
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/SmaliPatches.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/SmaliPatches.java
@@ -1,0 +1,218 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Smali patch definitions ported from apk-mitm
+ * (https://github.com/shroudedcode/apk-mitm) and the declarative subset of
+ * httptoolkit/frida-interception-and-unpinning. Both disable certificate
+ * pinning by replacing method bodies of X509TrustManager / HostnameVerifier /
+ * OkHttp CertificatePinner / common pinning libraries with no-op /
+ * always-accept stubs. Only classes that live in the target app's own dex
+ * files are patchable; framework classes (com.android.okhttp.*,
+ * com.android.org.conscrypt.*, javax.net.ssl.*) cannot be patched this way
+ * and rely on the network_security_config resource step + a trusted CA.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import androidx.annotation.NonNull;
+
+import org.jf.dexlib2.Opcode;
+import org.jf.dexlib2.iface.reference.Reference;
+import org.jf.dexlib2.iface.reference.TypeReference;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction10x;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction11n;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction11x;
+import org.jf.dexlib2.immutable.instruction.ImmutableInstruction22c;
+import org.jf.dexlib2.immutable.reference.ImmutableTypeReference;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Declarative method-body replacements, mirroring apk-mitm's {@code SmaliPatch}
+ * and the no-op/return-true subset of Frida's unpinning script. Selectors
+ * target either an interface (any implementor found in the app's dex) or a
+ * concrete class, and list methods whose bodies should be replaced with a
+ * fixed instruction sequence.
+ */
+final class SmaliPatches {
+
+    enum Replacement {
+        RETURN_VOID,
+        RETURN_TRUE,
+        RETURN_FALSE,
+        RETURN_NULL,
+        RETURN_EMPTY_CERT_ARRAY;
+
+        List<ImmutableInstruction> instructions(@NonNull String returnType) {
+            switch (this) {
+                case RETURN_VOID:
+                    return Collections.singletonList(
+                            new ImmutableInstruction10x(Opcode.RETURN_VOID));
+                case RETURN_TRUE:
+                    return Arrays.asList(
+                            new ImmutableInstruction11n(Opcode.CONST_4, 0, 1),
+                            new ImmutableInstruction11x(Opcode.RETURN, 0));
+                case RETURN_FALSE:
+                    return Arrays.asList(
+                            new ImmutableInstruction11n(Opcode.CONST_4, 0, 0),
+                            new ImmutableInstruction11x(Opcode.RETURN, 0));
+                case RETURN_NULL:
+                    return Arrays.asList(
+                            new ImmutableInstruction11n(Opcode.CONST_4, 0, 0),
+                            new ImmutableInstruction11x(Opcode.RETURN_OBJECT, 0));
+                case RETURN_EMPTY_CERT_ARRAY: {
+                    Reference arrayType = new ImmutableTypeReference(
+                            "[Ljava/security/cert/X509Certificate;");
+                    return Arrays.asList(
+                            new ImmutableInstruction11n(Opcode.CONST_4, 0, 0),
+                            new ImmutableInstruction22c(Opcode.NEW_ARRAY, 0, 0, arrayType),
+                            new ImmutableInstruction11x(Opcode.RETURN_OBJECT, 0));
+                }
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+
+        int registerCount(int original) {
+            switch (this) {
+                case RETURN_VOID:
+                    return Math.max(original, 0);
+                case RETURN_TRUE:
+                case RETURN_FALSE:
+                case RETURN_NULL:
+                case RETURN_EMPTY_CERT_ARRAY:
+                    return Math.max(original, 1);
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+    }
+
+    static final class MethodPatch {
+        final String name;
+        final List<String> paramTypes; // null = match any
+        final String returnType;       // null = match any
+        final Replacement replacement;
+
+        MethodPatch(String name, List<String> paramTypes,
+                    String returnType, Replacement replacement) {
+            this.name = name;
+            this.paramTypes = paramTypes;
+            this.returnType = returnType;
+            this.replacement = replacement;
+        }
+    }
+
+    static final class Selector {
+        final boolean isInterface;
+        final String type; // vm type, e.g. "Ljavax/net/ssl/X509TrustManager;"
+        final List<MethodPatch> methods;
+
+        Selector(boolean isInterface, String type, List<MethodPatch> methods) {
+            this.isInterface = isInterface;
+            this.type = type;
+            this.methods = methods;
+        }
+    }
+
+    @NonNull
+    static List<Selector> all() {
+        return Arrays.asList(
+                // --- X509TrustManager interface: any implementor
+                new Selector(true, "Ljavax/net/ssl/X509TrustManager;", Arrays.asList(
+                        new MethodPatch("checkClientTrusted",
+                                Arrays.asList("[Ljava/security/cert/X509Certificate;", "Ljava/lang/String;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("checkServerTrusted",
+                                Arrays.asList("[Ljava/security/cert/X509Certificate;", "Ljava/lang/String;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("getAcceptedIssuers",
+                                Collections.emptyList(),
+                                "[Ljava/security/cert/X509Certificate;",
+                                Replacement.RETURN_EMPTY_CERT_ARRAY))),
+                // --- HostnameVerifier interface: any implementor
+                new Selector(true, "Ljavax/net/ssl/HostnameVerifier;", Arrays.asList(
+                        new MethodPatch("verify",
+                                Arrays.asList("Ljava/lang/String;", "Ljavax/net/ssl/SSLSession;"),
+                                "Z", Replacement.RETURN_TRUE))),
+                // --- OkHttp 2.x (SquareUp, bundled in app dex)
+                new Selector(false, "Lcom/squareup/okhttp/CertificatePinner;", Arrays.asList(
+                        new MethodPatch("check",
+                                Arrays.asList("Ljava/lang/String;", "Ljava/util/List;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("check",
+                                Arrays.asList("Ljava/lang/String;", "Ljava/security/cert/Certificate;"),
+                                "V", Replacement.RETURN_VOID))),
+                // --- OkHttp 3.x / 4.x
+                new Selector(false, "Lokhttp3/CertificatePinner;", Arrays.asList(
+                        new MethodPatch("check",
+                                Arrays.asList("Ljava/lang/String;", "Ljava/util/List;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("check",
+                                Arrays.asList("Ljava/lang/String;", "Ljava/security/cert/Certificate;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("check",
+                                Arrays.asList("Ljava/lang/String;", "[Ljava/security/cert/Certificate;"),
+                                "V", Replacement.RETURN_VOID),
+                        new MethodPatch("check$okhttp",
+                                Arrays.asList("Ljava/lang/String;", "Lkotlin/jvm/functions/Function0;"),
+                                "V", Replacement.RETURN_VOID))),
+                // --- Trustkit
+                new Selector(false, "Lcom/datatheorem/android/trustkit/pinning/PinningTrustManager;", Arrays.asList(
+                        new MethodPatch("checkServerTrusted",
+                                Arrays.asList("[Ljava/security/cert/X509Certificate;", "Ljava/lang/String;"),
+                                "V", Replacement.RETURN_VOID))),
+                // --- Appcelerator
+                new Selector(false, "Lappcelerator/https/PinningTrustManager;", Arrays.asList(
+                        new MethodPatch("checkServerTrusted",
+                                Arrays.asList("[Ljava/security/cert/X509Certificate;", "Ljava/lang/String;"),
+                                "V", Replacement.RETURN_VOID))),
+                // --- IBM WorkLight
+                new Selector(false, "Lcom/worklight/wlclient/certificatepinning/HostNameVerifierWithCertificatePinning;", Arrays.asList(
+                        new MethodPatch("verify",
+                                null, "Z", Replacement.RETURN_TRUE))),
+                new Selector(false, "Lcom/worklight/androidgap/plugin/WLCertificatePinningPlugin;", Arrays.asList(
+                        new MethodPatch("execute",
+                                null, "Z", Replacement.RETURN_TRUE))),
+                // --- CWAC-Netsecurity
+                new Selector(false, "Lcom/commonsware/cwac/netsecurity/conscrypt/CertPinManager;", Arrays.asList(
+                        new MethodPatch("isChainValid",
+                                null, "Z", Replacement.RETURN_TRUE))),
+                // --- Netty
+                new Selector(false, "Lio/netty/handler/ssl/util/FingerprintTrustManagerFactory;", Arrays.asList(
+                        new MethodPatch("checkTrusted",
+                                null, "V", Replacement.RETURN_VOID))),
+                // --- PhoneGap sslCertificateChecker
+                new Selector(false, "Lnl/xservices/plugins/sslCertificateChecker;", Arrays.asList(
+                        new MethodPatch("execute",
+                                Arrays.asList("Ljava/lang/String;", "Lorg/json/JSONArray;",
+                                        "Lorg/apache/cordova/CallbackContext;"),
+                                "Z", Replacement.RETURN_TRUE))),
+                // --- Appmattus Cert Transparency
+                new Selector(false, "Lcom/appmattus/certificatetransparency/internal/verifier/CertificateTransparencyHostnameVerifier;", Arrays.asList(
+                        new MethodPatch("verify",
+                                null, "Z", Replacement.RETURN_TRUE))));
+    }
+
+    @NonNull
+    static TypeReference certArrayType() {
+        return new ImmutableTypeReference("[Ljava/security/cert/X509Certificate;");
+    }
+
+    private SmaliPatches() {
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/patch/SplitApkInstaller.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/patch/SplitApkInstaller.java
@@ -1,0 +1,103 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.pm.PackageInstaller;
+import android.os.Build;
+
+import androidx.annotation.NonNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+/**
+ * Installs a patched app as a split-install session: the re-signed base APK
+ * plus every re-signed config split are streamed into a single
+ * {@link PackageInstaller} session and committed atomically. Because the base
+ * and splits carry the same (patcher) signature, Android accepts them as one
+ * coherent package.
+ *
+ * <p>The commit result — including the {@code STATUS_PENDING_USER_ACTION}
+ * confirmation prompt — is delivered to {@link ApkInstallReceiver}.</p>
+ */
+public final class SplitApkInstaller {
+
+    private SplitApkInstaller() {
+    }
+
+    /**
+     * Create a session, write every APK in {@code apks} into it, and commit.
+     * Must be called off the main thread (it performs file I/O).
+     *
+     * @param apks the signed APKs to install (base first, then splits)
+     */
+    public static void install(@NonNull Context ctx, @NonNull String packageName,
+                               @NonNull List<File> apks) throws IOException {
+        if (apks.isEmpty()) throw new IOException("No APKs to install");
+
+        PackageInstaller installer = ctx.getPackageManager().getPackageInstaller();
+        PackageInstaller.SessionParams params = new PackageInstaller.SessionParams(
+                PackageInstaller.SessionParams.MODE_FULL_INSTALL);
+        params.setAppPackageName(packageName);
+
+        int sessionId = installer.createSession(params);
+        PackageInstaller.Session session = installer.openSession(sessionId);
+        try {
+            for (File apk : apks) {
+                writeApk(session, apk);
+            }
+            session.commit(statusSender(ctx, sessionId));
+        } catch (IOException | RuntimeException e) {
+            session.abandon();
+            throw e;
+        } finally {
+            session.close();
+        }
+    }
+
+    private static void writeApk(@NonNull PackageInstaller.Session session,
+                                 @NonNull File apk) throws IOException {
+        try (InputStream in = new FileInputStream(apk);
+             OutputStream out = session.openWrite(apk.getName(), 0, apk.length())) {
+            byte[] buf = new byte[65536];
+            int n;
+            while ((n = in.read(buf)) > 0) out.write(buf, 0, n);
+            session.fsync(out);
+        }
+    }
+
+    @NonNull
+    private static IntentSender statusSender(@NonNull Context ctx, int sessionId) {
+        Intent intent = new Intent(ctx, ApkInstallReceiver.class)
+                .setAction(ApkInstallReceiver.ACTION_INSTALL_STATUS);
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // The installer fills in EXTRA_STATUS / EXTRA_INTENT, so the
+            // PendingIntent must be mutable.
+            flags |= PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent pending = PendingIntent.getBroadcast(ctx, sessionId, intent, flags);
+        return pending.getIntentSender();
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
@@ -184,8 +184,9 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
 private const val TAG = "WgConnMonitor"
 
 /**
- * Continuous WireGuard liveness watchdog. Owns the 1s polling thread and the
- * Android clock, delegating the actual decision to [WgConnectivityChecker].
+ * Continuous WireGuard liveness watchdog. Owns the polling thread (1s while
+ * traffic moves, backing off to 5s once idle) and the Android clock,
+ * delegating the actual decision to [WgConnectivityChecker].
  *
  * Doze handling mirrors Mullvad's `SUSPEND_TIMEOUT` reset: if the loop notices
  * it was suspended longer than expected (the device dozed), the checker
@@ -199,11 +200,17 @@ internal class WgConnectivityMonitor(
     private val onBroken: () -> Unit
 ) {
     private companion object {
-        /** How often the loop samples the tunnel counters. */
+        /** How often the loop samples the tunnel counters while traffic moves. */
         const val LOOP_SLEEP_MS = 1_000L
 
-        /** A wall-clock gap larger than this means the device dozed. */
-        const val SUSPEND_TIMEOUT_MS = 6_000L
+        /** Sampling cadence once the tunnel has been idle for [IDLE_AFTER_MS]. */
+        const val IDLE_SLEEP_MS = 5_000L
+
+        /** Counters unchanged for this long — drop to the idle cadence. */
+        const val IDLE_AFTER_MS = 30_000L
+
+        /** Sleeping this much longer than requested means the device dozed. */
+        const val SUSPEND_SLACK_MS = 5_000L
     }
 
     private val checker = WgConnectivityChecker(prod)
@@ -230,10 +237,14 @@ internal class WgConnectivityMonitor(
         val seed = statsProvider() ?: return
         var lastCheck = SystemClock.elapsedRealtime()
         checker.seed(lastCheck, seed)
+        var lastRx = seed.rxBytes
+        var lastTx = seed.txBytes
+        var lastActivity = lastCheck
+        var sleepMs = LOOP_SLEEP_MS
 
         while (running && !Thread.currentThread().isInterrupted) {
             try {
-                Thread.sleep(LOOP_SLEEP_MS)
+                Thread.sleep(sleepMs)
             } catch (e: InterruptedException) {
                 break
             }
@@ -243,12 +254,23 @@ internal class WgConnectivityMonitor(
             lastCheck = now
 
             // The device dozed; the elapsed gap is not evidence of a stall.
-            if (slept >= SUSPEND_TIMEOUT_MS) {
+            if (slept >= sleepMs + SUSPEND_SLACK_MS) {
                 checker.onSuspended(now)
+                sleepMs = LOOP_SLEEP_MS
                 continue
             }
 
-            when (checker.tick(now, statsProvider())) {
+            // Battery: an idle tunnel doesn't need 1 Hz sampling. Any counter
+            // movement snaps back to the fast cadence on the next tick.
+            val stats = statsProvider()
+            if (stats != null && (stats.rxBytes != lastRx || stats.txBytes != lastTx)) {
+                lastRx = stats.rxBytes
+                lastTx = stats.txBytes
+                lastActivity = now
+            }
+            sleepMs = if (now - lastActivity >= IDLE_AFTER_MS) IDLE_SLEEP_MS else LOOP_SLEEP_MS
+
+            when (checker.tick(now, stats)) {
                 WgVerdict.HEALTHY, WgVerdict.WAITING -> {}
                 WgVerdict.BROKEN -> {
                     Log.w(TAG, "tunnel unresponsive after prod; reporting broken state")

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -31,6 +31,111 @@ extern _Atomic int wg_required;
 static atomic_long wg_drop_count = 0;
 static atomic_long wg_gap_drop_count = 0;
 
+// ---------------------------------------------------------------------------
+// WireGuard flow verdict cache.
+//
+// With the WireGuard hijack active, packets never reach the userspace TCP/UDP
+// state machines, so the session tables that normally amortise the allow
+// decision are never populated. Without this cache every UDP datagram (and,
+// with SNI inspection enabled, every outbound TCP/443 packet) would repeat
+// the uid lookup (a binder call on Android 10+), the JNI packet-object
+// creation and the Java allow decision — per packet, at line rate. It also
+// keeps blocked UDP flows blocked: the old block_udp() session would satisfy
+// has_udp_session() and let follow-up datagrams into the tunnel.
+//
+// A verdict sticks for the flow's lifetime, bounded by WG_FLOW_TTL so rule
+// and DNS-mapping changes are picked up within a minute (direct mode keeps
+// lingering sessions around for longer than that). jni_start and the WG
+// start/stop paths clear the cache so reloads apply new rules immediately.
+// ---------------------------------------------------------------------------
+
+#define WG_FLOW_CACHE_SIZE 512
+#define WG_FLOW_TTL 60 // seconds
+
+struct wg_flow {
+    time_t time;
+    uint8_t used;
+    uint8_t version;
+    uint8_t protocol;
+    uint8_t allowed;
+    uint16_t sport;
+    uint16_t dport;
+    uint8_t saddr[16];
+    uint8_t daddr[16];
+};
+
+static struct wg_flow wg_flow_cache[WG_FLOW_CACHE_SIZE];
+// handle_ip runs on the tunnel thread, but the cache is cleared from JNI
+// calls on other threads.
+static pthread_mutex_t wg_flow_lock = PTHREAD_MUTEX_INITIALIZER;
+
+void wg_flow_clear(void) {
+    pthread_mutex_lock(&wg_flow_lock);
+    memset(wg_flow_cache, 0, sizeof(wg_flow_cache));
+    pthread_mutex_unlock(&wg_flow_lock);
+}
+
+static struct wg_flow *wg_flow_slot(int version, int protocol,
+                                    const void *saddr, uint16_t sport,
+                                    const void *daddr, uint16_t dport) {
+    size_t alen = (version == 4 ? 4 : 16);
+    const uint8_t *s = saddr;
+    const uint8_t *d = daddr;
+    uint32_t h = (uint32_t) (version * 31 + protocol);
+    for (size_t i = 0; i < alen; i++)
+        h = h * 31 + s[i];
+    for (size_t i = 0; i < alen; i++)
+        h = h * 31 + d[i];
+    h = h * 31 + sport;
+    h = h * 31 + dport;
+    return &wg_flow_cache[h % WG_FLOW_CACHE_SIZE];
+}
+
+static int wg_flow_match(const struct wg_flow *f, int version, int protocol,
+                         const void *saddr, uint16_t sport,
+                         const void *daddr, uint16_t dport) {
+    size_t alen = (version == 4 ? 4 : 16);
+    return f->used && f->version == version && f->protocol == protocol &&
+           f->sport == sport && f->dport == dport &&
+           memcmp(f->saddr, saddr, alen) == 0 &&
+           memcmp(f->daddr, daddr, alen) == 0;
+}
+
+// Returns the cached verdict (0/1) or -1 on miss. Entries are not refreshed
+// on hit, so a busy flow re-validates against the Java rules every
+// WG_FLOW_TTL seconds.
+static int wg_flow_lookup(int version, int protocol,
+                          const void *saddr, uint16_t sport,
+                          const void *daddr, uint16_t dport) {
+    int verdict = -1;
+    pthread_mutex_lock(&wg_flow_lock);
+    struct wg_flow *f = wg_flow_slot(version, protocol, saddr, sport, daddr, dport);
+    if (wg_flow_match(f, version, protocol, saddr, sport, daddr, dport) &&
+        time(NULL) - f->time < WG_FLOW_TTL)
+        verdict = f->allowed;
+    pthread_mutex_unlock(&wg_flow_lock);
+    return verdict;
+}
+
+static void wg_flow_insert(int version, int protocol,
+                           const void *saddr, uint16_t sport,
+                           const void *daddr, uint16_t dport, int allowed) {
+    size_t alen = (version == 4 ? 4 : 16);
+    pthread_mutex_lock(&wg_flow_lock);
+    struct wg_flow *f = wg_flow_slot(version, protocol, saddr, sport, daddr, dport);
+    memset(f, 0, sizeof(*f)); // direct-mapped: a collision simply evicts
+    f->used = 1;
+    f->time = time(NULL);
+    f->version = (uint8_t) version;
+    f->protocol = (uint8_t) protocol;
+    f->allowed = (uint8_t) (allowed != 0);
+    f->sport = sport;
+    f->dport = dport;
+    memcpy(f->saddr, saddr, alen);
+    memcpy(f->daddr, daddr, alen);
+    pthread_mutex_unlock(&wg_flow_lock);
+}
+
 // Skip tunneling for addresses WireGuard cannot meaningfully forward
 // (multicast, link-local, loopback). Apps targeting these wouldn't gain
 // privacy from WG and the peer would likely drop them anyway.
@@ -306,6 +411,25 @@ void handle_ip(const struct arguments *args,
 
     flags[flen] = 0;
 
+    // WireGuard state, shared by the flow cache, the allow decision and the
+    // egress below. DNS is force-tunnelled even to local destinations (see
+    // the hijack comment further down).
+    int is_dns = (dport == 53 &&
+                  (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP));
+    int wg_is_enabled = atomic_load_explicit(&wg_enabled, memory_order_acquire);
+    int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
+    int wg_fd = atomic_load_explicit(&wg_outbound_fd, memory_order_acquire);
+    int wg_dest = !is_local_dest(version, daddr) || is_dns;
+    int wg_hijack = wg_is_enabled && wg_fd >= 0 && wg_dest;
+
+    // On the WG path the allow verdict is cached per flow (DNS is always
+    // tunnelled and skips the cache). A hit skips the uid lookup and the
+    // Java allow decision below.
+    int wg_cached = -1;
+    if (wg_hijack && !is_dns &&
+        (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP))
+        wg_cached = wg_flow_lookup(version, protocol, saddr, sport, daddr, dport);
+
     // Limit number of sessions
     if (sessions >= maxsessions) {
         if ((protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6) ||
@@ -318,11 +442,12 @@ void handle_ip(const struct arguments *args,
         }
     }
 
-    // Get uid
+    // Get uid (skipped on a WG flow-cache hit: the verdict is already known)
     jint uid = -1;
-    if (protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6 ||
+    if (wg_cached < 0 &&
+        (protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6 ||
         (protocol == IPPROTO_UDP && !has_udp_session(args, pkt, payload)) ||
-        (protocol == IPPROTO_TCP && syn && (dport != 443 || !is_play))) {
+        (protocol == IPPROTO_TCP && syn && (dport != 443 || !is_play)))) {
             if (args->ctx->sdk <= 28) // Android 9 Pie
                 uid = get_uid(version, protocol, saddr, sport, daddr, dport);
             else
@@ -336,8 +461,14 @@ void handle_ip(const struct arguments *args,
     // Check if allowed
     int allowed = 0;
     struct allowed *redirect = NULL;
-    if (protocol == IPPROTO_UDP && has_udp_session(args, pkt, payload))
+    if (wg_cached >= 0)
+        allowed = wg_cached;
+    // In WG mode UDP sessions are stale leftovers (handle_udp never runs);
+    // trusting them would let block_udp() entries pass into the tunnel.
+    else if (protocol == IPPROTO_UDP && !wg_hijack && has_udp_session(args, pkt, payload))
         allowed = 1; // could be a lingering/blocked session
+    else if (protocol == IPPROTO_UDP && wg_hijack && is_dns)
+        allowed = 1; // DNS always goes into the tunnel
     else if (protocol == IPPROTO_TCP && ((!syn && (dport != 443 || !is_play)) // assume existing session
                                          || (uid == 0 && dport == 53)         // assume existing session
                                          || (dport == 443 && syn && is_play))) // let SYN pass by until SNI can be extracted
@@ -359,7 +490,7 @@ void handle_ip(const struct arguments *args,
             const uint16_t datalen = (const uint16_t) (length - (data - pkt));
 
             // Search existing TCP session
-            struct ng_session *cur = args->ctx->ng_session;
+            cur = args->ctx->ng_session;
             while (cur != NULL &&
                    !(cur->protocol == IPPROTO_TCP &&
                      cur->tcp.version == version &&
@@ -401,6 +532,11 @@ void handle_ip(const struct arguments *args,
             if (cur != NULL)
                 cur->tcp.checkedHostname = 1;
         }
+
+        // Cache the verdict for the WG fast path.
+        if (wg_hijack && !is_dns &&
+            (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP))
+            wg_flow_insert(version, protocol, saddr, sport, daddr, dport, allowed);
     }
 
     // Handle allowed traffic
@@ -412,12 +548,6 @@ void handle_ip(const struct arguments *args,
         // intentionally protected by WG too: in WG mode the VPN builder uses
         // WG DNS or public fallback DNS, and unprotected DNS would leak the
         // user's physical network.
-        int is_dns = (dport == 53 &&
-                      (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP));
-        int wg_is_enabled = atomic_load_explicit(&wg_enabled, memory_order_acquire);
-        int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
-        int wg_fd = atomic_load_explicit(&wg_outbound_fd, memory_order_acquire);
-        int wg_dest = !is_local_dest(version, daddr) || is_dns;
 
         // Fail closed while WG is required but not (yet) running — e.g. the
         // brief window during a tunnel restart, or after a failed start.
@@ -437,7 +567,7 @@ void handle_ip(const struct arguments *args,
             return;
         }
 
-        if (wg_is_enabled && wg_fd >= 0 && wg_dest) {
+        if (wg_hijack) {
             ssize_t w = write(wg_fd, pkt, length);
             if (w != (ssize_t) length) {
                 if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
@@ -461,11 +591,15 @@ void handle_ip(const struct arguments *args,
         else if (protocol == IPPROTO_TCP)
             handle_tcp(args, pkt, length, payload, uid, allowed, redirect, epoll_fd);
     } else {
-        if (protocol == IPPROTO_UDP)
+        // On the WG path the blocked verdict lives in the flow cache; a
+        // block_udp() session there would be dead weight, and re-logging
+        // every datagram of a blocked flow would spam the log.
+        if (protocol == IPPROTO_UDP && !wg_hijack)
             block_udp(args, pkt, length, payload, uid);
 
-        log_android(ANDROID_LOG_WARN, "Address v%d p%d %s/%u syn %d not allowed",
-                    version, protocol, dest, dport, syn);
+        if (wg_cached < 0)
+            log_android(ANDROID_LOG_WARN, "Address v%d p%d %s/%u syn %d not allowed",
+                        version, protocol, dest, dport, syn);
     }
 }
 

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -177,6 +177,9 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1start(
     max_tun_msg = 0;
     ctx->stopping = 0;
 
+    // Rules may have changed across a reload; cached WG verdicts are stale.
+    wg_flow_clear();
+
     log_android(ANDROID_LOG_WARN, "Starting level %d", loglevel);
 
 }
@@ -388,6 +391,7 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1start(JNIEnv *env, job
     int flags = fcntl(sv[0], F_GETFL, 0);
     if (flags >= 0)
         fcntl(sv[0], F_SETFL, flags | O_NONBLOCK);
+    wg_flow_clear();
     atomic_store_explicit(&wg_outbound_fd, sv[0], memory_order_release);
     atomic_store_explicit(&wg_enabled, 1, memory_order_release);
     log_android(ANDROID_LOG_WARN, "WireGuard egress enabled tx=%d rx=%d", sv[0], sv[1]);
@@ -408,6 +412,7 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1stop(JNIEnv *env, jobj
         close(fd);
         log_android(ANDROID_LOG_WARN, "WireGuard egress disabled, closed tx=%d", fd);
     }
+    wg_flow_clear();
 }
 
 JNIEXPORT void JNICALL

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -406,6 +406,10 @@ void handle_ip(const struct arguments *args,
                const int epoll_fd,
                int sessions, int maxsessions);
 
+// Drops all cached WireGuard flow verdicts (ip.c); call whenever rules may
+// have changed or the WG tunnel starts/stops.
+void wg_flow_clear(void);
+
 jboolean handle_icmp(const struct arguments *args,
                      const uint8_t *pkt, size_t length,
                      const uint8_t *payload,

--- a/app/src/main/res/menu/menu_details.xml
+++ b/app/src/main/res/menu/menu_details.xml
@@ -16,4 +16,8 @@
         android:id="@+id/action_clear"
         android:title="@string/menu_clear"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_patch_inspection"
+        android:title="@string/menu_patch_inspection"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -769,4 +769,15 @@ Sincerely,\n\n]]></string>
     <string name="msg_invalid_url">Invalid URL</string>
     <string name="msg_apply_blocklists_failed">Failed to apply host files</string>
     <string name="msg_last_update">Last update: %s</string>
+
+    <!-- APK patcher for HTTPS content inspection -->
+    <string name="menu_patch_inspection">Patch for traffic inspection</string>
+    <string name="patch_title">Patch %1$s for inspection</string>
+    <string name="patch_progress">Patching…</string>
+    <string name="patch_success">Patched %1$d method(s). Opening installer.</string>
+    <string name="patch_failed">Patching failed: %1$s</string>
+    <string name="patch_failed_source_missing">source APK not found</string>
+    <string name="patch_unavailable">APK patching is not available in this build.</string>
+    <string name="patch_warning">This repackages the app to disable certificate pinning so its HTTPS traffic can be inspected. The patched APK is re-signed, so Android may require uninstalling the original app before installation. Only patch apps you trust to inspect. Continue?</string>
+    <string name="patch_install_prompt">Install the patched APK?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -774,6 +774,10 @@ Sincerely,\n\n]]></string>
     <string name="menu_patch_inspection">Patch for traffic inspection</string>
     <string name="patch_title">Patch %1$s for inspection</string>
     <string name="patch_progress">Patching…</string>
+    <string name="patch_started_background">Patching in the background. You\'ll be notified with progress.</string>
+    <string name="patch_installing">Installing…</string>
+    <string name="patch_install_success">App installed.</string>
+    <string name="patch_install_failed">Install failed: %1$s</string>
     <string name="patch_success">Patched %1$d method(s). Opening installer.</string>
     <string name="patch_failed">Patching failed: %1$s</string>
     <string name="patch_failed_source_missing">source APK not found</string>

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -5,4 +5,7 @@
     <cache-path
         name="share_images"
         path="share/" />
+    <cache-path
+        name="patched_apks"
+        path="apk-patcher/" />
 </paths>

--- a/app/src/patcher/java/net/kollnig/missioncontrol/patch/Dexlib2Patcher.java
+++ b/app/src/patcher/java/net/kollnig/missioncontrol/patch/Dexlib2Patcher.java
@@ -24,7 +24,6 @@ import androidx.annotation.Nullable;
 
 import com.android.apksig.ApkSigner;
 import com.reandroid.apk.ApkModule;
-import com.reandroid.apk.ApkSplitInfoCleaner;
 import com.reandroid.apk.DexFileInputSource;
 import com.reandroid.archive.InputSource;
 import com.reandroid.archive.ByteInputSource;
@@ -37,6 +36,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -57,6 +57,14 @@ import java.util.List;
  *   <li>Strip the original signature and re-sign with an AndroidKeyStore RSA
  *       key via apksig (v1 + v2 + v3).</li>
  * </ol>
+ *
+ * <p>Only the <em>base</em> APK is loaded and patched — all pinning-relevant
+ * content (dex, {@code resources.arsc}, manifest) lives there. Any config
+ * splits (ABI native libs, densities, languages) are left byte-for-byte
+ * unchanged and merely re-signed with the same key, then installed together
+ * with the base as a split-install session. This keeps only the base APK in
+ * memory, avoiding the {@code OutOfMemoryError} that whole-APK split merging
+ * caused on large apps.</p>
  *
  * <p>ARSCLib (Apache-2.0) handles binary resource read/write; dexlib2 (BSD-3)
  * handles dex; apksig (Apache-2.0) handles signing. No GPL dependency.</p>
@@ -85,59 +93,67 @@ public final class Dexlib2Patcher implements ApkPatcher {
     public PatchResult patch(@NonNull Context ctx,
                              @NonNull String packageName,
                              @NonNull File inputApk,
-                             @NonNull File outputApk,
+                             @NonNull File outputDir,
                              @NonNull ProgressListener listener) {
-        File workDir = new File(ctx.getCacheDir(), "apk-patcher");
-        workDir.mkdirs();
-        File unsigned = new File(workDir, "unsigned.apk");
+        outputDir.mkdirs();
+        File unsigned = new File(outputDir, "base-unsigned.apk");
         if (unsigned.exists()) unsigned.delete();
 
-        try (ApkModule apk = ApkModule.loadApkFile(inputApk)) {
-            // Merge any split APKs (App Bundle config splits) into the base
-            // module so the result is a single standalone installable APK.
-            mergeSplits(ctx, packageName, apk, listener);
-
-            // Strip the split manifest metadata (<split> / <isSplitRequired>)
-            // so Android treats the merged APK as a regular base APK.
-            ApkSplitInfoCleaner.cleanSplitInfo(apk);
-
-            int dexPatched = patchDexes(apk, listener);
-            ResourcePatcher.patchResources(apk, listener::onProgress);
-
-            listener.onProgress("Writing APK…");
-            apk.writeApk(unsigned);
-
-            listener.onProgress("Signing APK…");
+        try {
             SigningKeyManager.Signer signer = new SigningKeyManager().signer();
-            sign(unsigned, outputApk, signer);
+            List<File> outputs = new ArrayList<>();
+            int dexPatched;
 
+            // 1. Patch and sign the base APK. Only the base is loaded into
+            //    memory; splits never are.
+            File signedBase = new File(outputDir, "base.apk");
+            listener.onProgress("Reading base APK…");
+            try (ApkModule apk = ApkModule.loadApkFile(inputApk)) {
+                dexPatched = patchDexes(apk, listener);
+                ResourcePatcher.patchResources(apk, listener::onProgress);
+
+                listener.onProgress("Writing base APK…");
+                apk.writeApk(unsigned);
+            }
+            listener.onProgress("Signing base APK…");
+            sign(unsigned, signedBase, signer);
             if (!unsigned.delete()) unsigned.deleteOnExit();
+            outputs.add(signedBase);
+
+            // 2. Re-sign every config split unchanged with the same key so the
+            //    whole set installs together. apksig streams file-to-file, so
+            //    this stays cheap regardless of split size.
+            resignSplits(ctx, packageName, outputDir, signer, outputs, listener);
+
             listener.onProgress("Done. Patched " + dexPatched + " method(s).");
-            return PatchResult.success(outputApk, dexPatched);
+            return PatchResult.success(outputs, dexPatched);
         } catch (Throwable t) {
             return PatchResult.failure(firstLine(t));
         }
     }
 
     /**
-     * Discover the app's split APKs (e.g. {@code split_config.arm64_v8a.apk},
-     * {@code split_config.xxhdpi.apk}) via {@link PackageManager} and merge
-     * each into {@code base}. After this, {@code base} contains the union of
-     * all dex files, native libraries, resources and assets from every split.
+     * Re-sign each of the app's config splits (e.g.
+     * {@code split_config.arm64_v8a.apk}, {@code split_config.xxhdpi.apk}) with
+     * {@code signer} and add the results to {@code outputs}. The splits' bytes
+     * are otherwise untouched — only their signature is replaced so they match
+     * the re-signed base.
      */
-    private void mergeSplits(@NonNull Context ctx, @NonNull String packageName,
-                             @NonNull ApkModule base,
-                             @NonNull ProgressListener listener) throws IOException {
+    private void resignSplits(@NonNull Context ctx, @NonNull String packageName,
+                              @NonNull File outputDir,
+                              @NonNull SigningKeyManager.Signer signer,
+                              @NonNull List<File> outputs,
+                              @NonNull ProgressListener listener) throws Exception {
         String[] splitPaths = resolveSplitPaths(ctx, packageName);
         if (splitPaths == null || splitPaths.length == 0) return;
         for (String path : splitPaths) {
             File splitFile = new File(path);
             if (!splitFile.exists()) continue;
             String name = splitFile.getName();
-            listener.onProgress("Merging " + name + "…");
-            try (ApkModule split = ApkModule.loadApkFile(splitFile)) {
-                base.merge(split);
-            }
+            listener.onProgress("Signing " + name + "…");
+            File out = new File(outputDir, name);
+            sign(splitFile, out, signer);
+            outputs.add(out);
         }
     }
 
@@ -158,8 +174,12 @@ public final class Dexlib2Patcher implements ApkPatcher {
             throws Exception {
         int total = 0;
         List<DexFileInputSource> dexFiles = apk.listDexFiles();
+        int count = dexFiles.size();
+        int index = 0;
         for (DexFileInputSource src : dexFiles) {
+            index++;
             String name = src.getAlias();
+            listener.onProgress("Scanning " + name + " (" + index + "/" + count + ")…");
             byte[] original = readAll(src);
             DexPatcher.Result result = patchDex(original, name, listener);
             if (result != null) {

--- a/app/src/patcher/java/net/kollnig/missioncontrol/patch/Dexlib2Patcher.java
+++ b/app/src/patcher/java/net/kollnig/missioncontrol/patch/Dexlib2Patcher.java
@@ -1,0 +1,252 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.android.apksig.ApkSigner;
+import com.reandroid.apk.ApkModule;
+import com.reandroid.apk.ApkSplitInfoCleaner;
+import com.reandroid.apk.DexFileInputSource;
+import com.reandroid.archive.InputSource;
+import com.reandroid.archive.ByteInputSource;
+
+import org.jf.dexlib2.DexFileFactory;
+import org.jf.dexlib2.iface.DexFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The real {@link ApkPatcher} implementation. Repackages an installed
+ * application's base APK so its HTTPS traffic can be inspected by a local
+ * TLS-terminating proxy:
+ *
+ * <ol>
+ *   <li>Code-level pinning defeat — {@link DexPatcher} replaces the bodies of
+ *       {@code X509TrustManager}, {@code HostnameVerifier}, OkHttp
+ *       {@code CertificatePinner} and other common pinning methods with
+ *       no-op / always-accept stubs (see {@link SmaliPatches}).</li>
+ *   <li>Resource-level trust defeat — {@link ResourcePatcher} injects a
+ *       {@code network_security_config.xml} that trusts user-installed CAs
+ *       with {@code overridePins="true"} and marks the app debuggable, so the
+ *       platform's default {@code TrustManagerImpl} accepts the MITM CA.</li>
+ *   <li>Strip the original signature and re-sign with an AndroidKeyStore RSA
+ *       key via apksig (v1 + v2 + v3).</li>
+ * </ol>
+ *
+ * <p>ARSCLib (Apache-2.0) handles binary resource read/write; dexlib2 (BSD-3)
+ * handles dex; apksig (Apache-2.0) handles signing. No GPL dependency.</p>
+ *
+ * <p>Limitations:
+ * <ul>
+ *   <li>Apps that pin in code via classes not covered by {@link SmaliPatches}
+ *       will still reject the MITM CA and fall back to pass-through.</li>
+ * </ul></p>
+ */
+public final class Dexlib2Patcher implements ApkPatcher {
+
+    @Override
+    public boolean isAvailable() {
+        try {
+            Class.forName("com.android.apksig.ApkSigner");
+            Class.forName("com.reandroid.apk.ApkModule");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    @NonNull
+    @Override
+    public PatchResult patch(@NonNull Context ctx,
+                             @NonNull String packageName,
+                             @NonNull File inputApk,
+                             @NonNull File outputApk,
+                             @NonNull ProgressListener listener) {
+        File workDir = new File(ctx.getCacheDir(), "apk-patcher");
+        workDir.mkdirs();
+        File unsigned = new File(workDir, "unsigned.apk");
+        if (unsigned.exists()) unsigned.delete();
+
+        try (ApkModule apk = ApkModule.loadApkFile(inputApk)) {
+            // Merge any split APKs (App Bundle config splits) into the base
+            // module so the result is a single standalone installable APK.
+            mergeSplits(ctx, packageName, apk, listener);
+
+            // Strip the split manifest metadata (<split> / <isSplitRequired>)
+            // so Android treats the merged APK as a regular base APK.
+            ApkSplitInfoCleaner.cleanSplitInfo(apk);
+
+            int dexPatched = patchDexes(apk, listener);
+            ResourcePatcher.patchResources(apk, listener::onProgress);
+
+            listener.onProgress("Writing APK…");
+            apk.writeApk(unsigned);
+
+            listener.onProgress("Signing APK…");
+            SigningKeyManager.Signer signer = new SigningKeyManager().signer();
+            sign(unsigned, outputApk, signer);
+
+            if (!unsigned.delete()) unsigned.deleteOnExit();
+            listener.onProgress("Done. Patched " + dexPatched + " method(s).");
+            return PatchResult.success(outputApk, dexPatched);
+        } catch (Throwable t) {
+            return PatchResult.failure(firstLine(t));
+        }
+    }
+
+    /**
+     * Discover the app's split APKs (e.g. {@code split_config.arm64_v8a.apk},
+     * {@code split_config.xxhdpi.apk}) via {@link PackageManager} and merge
+     * each into {@code base}. After this, {@code base} contains the union of
+     * all dex files, native libraries, resources and assets from every split.
+     */
+    private void mergeSplits(@NonNull Context ctx, @NonNull String packageName,
+                             @NonNull ApkModule base,
+                             @NonNull ProgressListener listener) throws IOException {
+        String[] splitPaths = resolveSplitPaths(ctx, packageName);
+        if (splitPaths == null || splitPaths.length == 0) return;
+        for (String path : splitPaths) {
+            File splitFile = new File(path);
+            if (!splitFile.exists()) continue;
+            String name = splitFile.getName();
+            listener.onProgress("Merging " + name + "…");
+            try (ApkModule split = ApkModule.loadApkFile(splitFile)) {
+                base.merge(split);
+            }
+        }
+    }
+
+    @Nullable
+    private static String[] resolveSplitPaths(@NonNull Context ctx,
+                                              @NonNull String packageName) {
+        try {
+            ApplicationInfo ai = ctx.getPackageManager()
+                    .getApplicationInfo(packageName, 0);
+            return ai.splitSourceDirs;
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+    }
+
+    /** Patch every classes*.dex in {@code apk} in place. Returns total methods replaced. */
+    private int patchDexes(@NonNull ApkModule apk, @NonNull ProgressListener listener)
+            throws Exception {
+        int total = 0;
+        List<DexFileInputSource> dexFiles = apk.listDexFiles();
+        for (DexFileInputSource src : dexFiles) {
+            String name = src.getAlias();
+            byte[] original = readAll(src);
+            DexPatcher.Result result = patchDex(original, name, listener);
+            if (result != null) {
+                apk.add(new ByteInputSource(result.bytes, name));
+                total += result.patchedMethods;
+            }
+        }
+        return total;
+    }
+
+    private DexPatcher.Result patchDex(byte[] dexBytes, String name,
+                                       ProgressListener listener) throws Exception {
+        File in = File.createTempFile("in-" + sanitize(name), ".dex");
+        File out = File.createTempFile("out-" + sanitize(name), ".dex");
+        try {
+            try (FileOutputStream fos = new FileOutputStream(in)) {
+                fos.write(dexBytes);
+            }
+            DexFile dex = DexFileFactory.loadDexFile(in, null);
+            DexPatcher.Result result = DexPatcher.patchDex(dex);
+            if (result.patchedMethods == 0) return null;
+            DexFileFactory.writeDexFile(out.getAbsolutePath(), result.dex);
+            listener.onProgress(name + ": " + result.patchedMethods + " method(s)");
+            return new DexPatcher.Result(result.dex, readFile(out),
+                    result.patchedMethods);
+        } finally {
+            in.delete();
+            out.delete();
+        }
+    }
+
+    private void sign(@NonNull File unsigned, @NonNull File output,
+                      @NonNull SigningKeyManager.Signer signer) throws Exception {
+        ApkSigner.SignerConfig config = new ApkSigner.SignerConfig.Builder(
+                "tc-patcher",
+                signer.privateKey,
+                Collections.singletonList(signer.certificate))
+                .build();
+        ApkSigner apkSigner = new ApkSigner.Builder(Collections.singletonList(config))
+                .setInputApk(unsigned)
+                .setOutputApk(output)
+                .setV1SigningEnabled(true)
+                .setV2SigningEnabled(true)
+                .setV3SigningEnabled(true)
+                .setDebuggableApkPermitted(true)
+                .build();
+        apkSigner.sign();
+    }
+
+    private static byte[] readAll(@NonNull InputSource src) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (java.io.InputStream is = src.openStream()) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = is.read(buf)) > 0) baos.write(buf, 0, n);
+        }
+        return baos.toByteArray();
+    }
+
+    private static byte[] readFile(@NonNull File f) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (FileInputStream fis = new FileInputStream(f)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = fis.read(buf)) > 0) baos.write(buf, 0, n);
+        }
+        return baos.toByteArray();
+    }
+
+    private static String sanitize(@NonNull String name) {
+        return name.replace("/", "_").replace(".", "_");
+    }
+
+    private static String firstLine(@NonNull Throwable t) {
+        String msg = t.getMessage();
+        if (msg == null) msg = t.getClass().getSimpleName();
+        return msg.split("\n")[0];
+    }
+
+    /** Resolve the base APK path for a package, or null on failure. */
+    @SuppressWarnings("unused")
+    public static String sourceApkPath(@NonNull Context ctx, @NonNull String pkg) {
+        try {
+            ApplicationInfo ai = ctx.getPackageManager().getApplicationInfo(pkg, 0);
+            return ai.sourceDir;
+        } catch (PackageManager.NameNotFoundException e) {
+            return null;
+        }
+    }
+}

--- a/app/src/patcher/java/net/kollnig/missioncontrol/patch/ResourcePatcher.java
+++ b/app/src/patcher/java/net/kollnig/missioncontrol/patch/ResourcePatcher.java
@@ -1,0 +1,225 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import androidx.annotation.NonNull;
+
+import com.reandroid.apk.ApkModule;
+import com.reandroid.archive.ByteInputSource;
+import com.reandroid.arsc.chunk.PackageBlock;
+import com.reandroid.arsc.chunk.TableBlock;
+import com.reandroid.arsc.chunk.xml.AndroidManifestBlock;
+import com.reandroid.arsc.chunk.xml.ResXmlAttribute;
+import com.reandroid.arsc.chunk.xml.ResXmlDocument;
+import com.reandroid.arsc.chunk.xml.ResXmlElement;
+import com.reandroid.arsc.chunk.xml.ResXmlPullSerializer;
+import com.reandroid.arsc.value.Entry;
+import com.reandroid.arsc.value.ValueType;
+
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Edits an APK's binary Android resources so the platform's default
+ * {@code TrustManagerImpl} trusts user-installed certificate authorities (and
+ * overrides declared pin sets). This is the resource-level half of defeating
+ * certificate pinning — it complements {@link DexPatcher} (which handles
+ * code-level pinning) by injecting a {@code network_security_config.xml}
+ * that trusts user CAs with {@code overridePins="true"}, and makes the
+ * application debuggable so the debug trust-anchors apply.
+ *
+ * <p>This is the static (compile-time) equivalent of httptoolkit's Frida
+ * {@code TrustedCertificateIndex} injection script: instead of hooking
+ * Conscrypt at runtime, we patch the app's resource config once so the
+ * platform itself accepts the MITM CA on every subsequent launch.</p>
+ *
+ * <p>Uses ARSCLib (Apache-2.0), which replaces aapt/aapt2 and runs on-device.</p>
+ */
+final class ResourcePatcher {
+
+    /** Framework attribute resource id for {@code android:networkSecurityConfig}. */
+    private static final int ATTR_NETWORK_SECURITY_CONFIG = 0x01010271;
+
+    /** Path of the config file inside the APK. */
+    private static final String CONFIG_PATH = "res/xml/network_security_config.xml";
+
+    private static final String CONFIG_XML =
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+                    + "<network-security-config>\n"
+                    + "  <base-config cleartextTrafficPermitted=\"true\">\n"
+                    + "    <trust-anchors>\n"
+                    + "      <certificates src=\"system\" />\n"
+                    + "      <certificates src=\"user\" overridePins=\"true\" />\n"
+                    + "    </trust-anchors>\n"
+                    + "  </base-config>\n"
+                    + "  <debug-overrides>\n"
+                    + "    <trust-anchors>\n"
+                    + "      <certificates src=\"system\" />\n"
+                    + "      <certificates src=\"user\" overridePins=\"true\" />\n"
+                    + "    </trust-anchors>\n"
+                    + "  </debug-overrides>\n"
+                    + "</network-security-config>\n";
+
+    interface Progress {
+        void onMessage(@NonNull String message);
+    }
+
+    /**
+     * Add a user-CA-trusting {@code network_security_config.xml}, point the
+     * manifest at it, and mark the application debuggable. Returns true if any
+     * resource-level change was made.
+     */
+    static boolean patchResources(@NonNull ApkModule apk, @NonNull Progress progress)
+            throws IOException {
+        boolean changed = false;
+
+        TableBlock table = apk.getTableBlock(true);
+        if (table == null) {
+            progress.onMessage("No resources.arsc; skipping resource patch.");
+            return false;
+        }
+
+        PackageBlock pkg = firstAppPackage(table);
+        if (pkg == null) {
+            progress.onMessage("No app package in table; skipping resource patch.");
+            return false;
+        }
+
+        // 1. Create / fetch the res/xml entry and assign a resource id.
+        Entry entry = pkg.getOrCreate("", "xml", "network_security_config");
+        int resId = entry.getResourceId();
+
+        // 2. Compile the source XML to a binary Android XML resource.
+        byte[] binaryXml = compileBinaryXml(CONFIG_XML, pkg);
+        apk.add(new ByteInputSource(binaryXml, CONFIG_PATH));
+        progress.onMessage("Added " + CONFIG_PATH);
+        changed = true;
+
+        // 3. Point <application android:networkSecurityConfig="@xml/..."> at it.
+        AndroidManifestBlock manifest = apk.getAndroidManifestBlock();
+        if (manifest != null) {
+            ResXmlElement app = manifest.getOrCreateApplicationElement();
+            ResXmlAttribute attr = app.getOrCreateAndroidAttribute(
+                    "networkSecurityConfig", ATTR_NETWORK_SECURITY_CONFIG);
+            attr.setValueType(ValueType.REFERENCE);
+            attr.setData(resId);
+
+            manifest.setDebuggable(true);
+            progress.onMessage("Manifest: networkSecurityConfig=@xml/"
+                    + "network_security_config, debuggable=true");
+        }
+
+        apk.refreshTable();
+        apk.refreshManifest();
+        return changed;
+    }
+
+    private static byte[] compileBinaryXml(@NonNull String xml, @NonNull PackageBlock pkg)
+            throws IOException {
+        ResXmlPullSerializer serializer = new ResXmlPullSerializer();
+        serializer.setCurrentPackage(pkg);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        serializer.setOutput(out, "utf-8");
+        try {
+            XmlPullParser parser = XmlPullParserFactory.newInstance().newPullParser();
+            parser.setInput(new ByteArrayInputStream(
+                    xml.getBytes(StandardCharsets.UTF_8)), "utf-8");
+            copyXml(parser, serializer);
+        } catch (XmlPullParserException e) {
+            throw new IOException("Failed to parse network_security_config XML", e);
+        }
+        serializer.endDocument();
+        ResXmlDocument doc = serializer.getResultDocument();
+        // ResXmlDocument.writeBytes only writes to a File; round-trip via temp.
+        File tmp = File.createTempFile("nsc", ".xml");
+        try {
+            doc.writeBytes(tmp);
+            return readAll(tmp);
+        } finally {
+            tmp.delete();
+        }
+    }
+
+    private static byte[] readAll(@NonNull File f) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (java.io.InputStream is = new java.io.FileInputStream(f)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = is.read(buf)) > 0) baos.write(buf, 0, n);
+        }
+        return baos.toByteArray();
+    }
+
+    /** Stream a XmlPullParser into a XmlSerializer, preserving structure. */
+    private static void copyXml(@NonNull XmlPullParser parser,
+                                @NonNull org.xmlpull.v1.XmlSerializer serializer)
+            throws XmlPullParserException, IOException {
+        int event = parser.getEventType();
+        while (event != XmlPullParser.END_DOCUMENT) {
+            switch (event) {
+                case XmlPullParser.START_DOCUMENT:
+                    serializer.startDocument("utf-8", null);
+                    break;
+                case XmlPullParser.START_TAG: {
+                    // Resolve namespace/prefix; network-security-config uses no ns.
+                    String ns = parser.getNamespace();
+                    String name = parser.getName();
+                    serializer.startTag(ns, name);
+                    int n = parser.getAttributeCount();
+                    for (int i = 0; i < n; i++) {
+                        String ans = parser.getAttributeNamespace(i);
+                        String an = parser.getAttributeName(i);
+                        String av = parser.getAttributeValue(i);
+                        serializer.attribute(ans, an, av == null ? "" : av);
+                    }
+                    break;
+                }
+                case XmlPullParser.END_TAG:
+                    serializer.endTag(parser.getNamespace(), parser.getName());
+                    break;
+                case XmlPullParser.TEXT: {
+                    String t = parser.getText();
+                    if (t != null) serializer.text(t);
+                    break;
+                }
+                default:
+                    break;
+            }
+            event = parser.next();
+        }
+    }
+
+    private static PackageBlock firstAppPackage(@NonNull TableBlock table) {
+        // The app package is the non-framework (id 0x7f*) one.
+        for (PackageBlock pkg : table) {
+            int id = pkg.getId();
+            if (id != 0 && (id & 0xff000000) == 0x7f000000) return pkg;
+        }
+        // Fallback: first package overall.
+        for (PackageBlock pkg : table) return pkg;
+        return null;
+    }
+
+    private ResourcePatcher() {
+    }
+}

--- a/app/src/patcher/java/net/kollnig/missioncontrol/patch/SigningKeyManager.java
+++ b/app/src/patcher/java/net/kollnig/missioncontrol/patch/SigningKeyManager.java
@@ -1,0 +1,91 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol.patch;
+
+import android.content.Context;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+
+import androidx.annotation.NonNull;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+
+/**
+ * Owns the RSA signing key used to sign patched APKs. The key is generated and
+ * stored in the AndroidKeyStore (non-exportable, persistent across the app's
+ * lifetime), and a self-signed certificate is produced automatically. Using
+ * AndroidKeyStore avoids bundling an additional crypto provider.
+ */
+final class SigningKeyManager {
+
+    private static final String ALIAS = "tc-apk-patcher-signing-key";
+    private static final String KEYSTORE = "AndroidKeyStore";
+
+    private final KeyStore keyStore;
+
+    SigningKeyManager() throws Exception {
+        keyStore = KeyStore.getInstance(KEYSTORE);
+        keyStore.load(null);
+        if (!keyStore.containsAlias(ALIAS)) {
+            generate();
+        }
+    }
+
+    private void generate() throws Exception {
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
+                KeyProperties.KEY_ALGORITHM_RSA, KEYSTORE);
+        kpg.initialize(new KeyGenParameterSpec.Builder(ALIAS,
+                KeyProperties.PURPOSE_SIGN | KeyProperties.PURPOSE_VERIFY)
+                .setKeySize(2048)
+                .setDigests(KeyProperties.DIGEST_SHA256,
+                        KeyProperties.DIGEST_SHA512)
+                .setSignaturePaddings(KeyProperties.SIGNATURE_PADDING_RSA_PKCS1)
+                .setCertificateSubject(new javax.security.auth.x500.X500Principal(
+                        "CN=TrackerControl Patcher"))
+                .setCertificateNotBefore(new java.util.Date())
+                .setCertificateNotAfter(new java.util.Date(
+                        System.currentTimeMillis() + 100L * 365 * 24 * 3600 * 1000L))
+                .build());
+        kpg.generateKeyPair();
+    }
+
+    @NonNull
+    Signer signer() throws Exception {
+        PrivateKey priv = (PrivateKey) keyStore.getKey(ALIAS, null);
+        X509Certificate cert = (X509Certificate) keyStore.getCertificate(ALIAS);
+        return new Signer(priv, cert);
+    }
+
+    static final class Signer {
+        final PrivateKey privateKey;
+        final X509Certificate certificate;
+
+        Signer(PrivateKey privateKey, X509Certificate certificate) {
+            this.privateKey = privateKey;
+            this.certificate = certificate;
+        }
+    }
+
+    @SuppressWarnings("unused")
+    private void touch(Context ctx) {
+    }
+}

--- a/docs/apk-patcher.md
+++ b/docs/apk-patcher.md
@@ -1,0 +1,368 @@
+# On-Device APK Patching for HTTPS Content Inspection
+
+## Overview
+
+TrackerControl can now repackage installed apps on-device so their HTTPS
+traffic can be inspected by a local TLS-terminating proxy. This is the same
+circumvention offered by [apk-mitm](https://github.com/shroudedcode/apk-mitm)
+and ReVanced Manager's "Override certificate pinning" patch, but running
+entirely on the phone — no PC, no `adb`, no Node.js, no root required for the
+patching step itself.
+
+The feature is exposed as a **"Patch for traffic inspection"** action in the
+per-app details screen (`DetailsActivity`) and produces a signed, installable
+APK. Because the APK is re-signed with TrackerControl's local patching key,
+Android usually cannot install it over the original app; uninstall the original
+first if the package installer reports incompatible signatures.
+
+## Why this exists
+
+Android 7 (Nougat) stopped trusting user-installed CAs for app traffic by
+default, and many apps additionally pin certificates in code. A local MITM
+proxy therefore needs both:
+
+1. The app to **trust the proxy's CA** — requires a
+   `network_security_config.xml` that trusts user CAs with
+   `overridePins="true"`.
+2. The app to **not reject the proxy cert via code-level pinning** — requires
+   replacing `X509TrustManager` / `HostnameVerifier` / OkHttp
+   `CertificatePinner` (and similar) implementations with no-op / always-accept
+   stubs.
+
+Doing only one is insufficient. This patcher does both statically by repackaging
+the APK, so no runtime hook (Frida/Xposed) is needed and the change survives
+restarts.
+
+## Architecture
+
+```
+                DetailsActivity
+                      │
+                      ▼  (resolve sourceDir + splitSourceDirs via PackageManager)
+                PatcherFactory.get()
+                      │
+                      ▼  (reflection — play flavor → NoOpPatcher)
+                Dexlib2Patcher.patch()
+                      │
+            ┌─────────┼─────────────────────────┐
+            ▼         ▼                         ▼
+      mergeSplits  patchDexes            ResourcePatcher
+      (ARSCLib)    (dexlib2)             (ARSCLib)
+            │         │                         │
+            │         │  SmaliPatches            │  inject res/xml/
+            │         │  (declarative)           │  network_security_config.xml
+            │         │                         │  + manifest attribute
+            │         │                         │  + debuggable=true
+            └─────────┴─────────────────────────┘
+                      ▼
+                ApkModule.writeApk()  →  unsigned.apk
+                      ▼
+                apksig sign (v1+v2+v3, AndroidKeyStore RSA)
+                      ▼
+                patched.apk  →  FileProvider  →  install intent
+```
+
+### Two trust-defeat layers
+
+| Layer | What it defeats | Engine | License |
+|---|---|---|---|
+| **Code-level** (`DexPatcher` + `SmaliPatches`) | OkHttp `CertificatePinner`, custom `X509TrustManager`/`HostnameVerifier`, TrustKit, Appcelerator, IBM WorkLight, CWAC-Netsecurity, Netty, PhoneGap, Appmattus CT | dexlib2 (smali) | BSD-3 |
+| **Resource-level** (`ResourcePatcher`) | Default platform `TrustManagerImpl` rejecting user CAs; NSC-declared pin sets | ARSCLib (binary resource editor) | Apache-2.0 |
+
+The resource layer is the **static equivalent** of httptoolkit's Frida
+`TrustedCertificateIndex` injection script — instead of hooking Conscrypt at
+runtime, we patch the app's resource config once so the platform itself
+accepts the MITM CA on every subsequent launch.
+
+### Split APK handling
+
+Modern apps distributed via App Bundles install as a `base.apk` plus per-config
+splits (`split_config.arm64_v8a.apk`, `split_config.xxhdpi.apk`, language
+splits, …). `ApplicationInfo.sourceDir` only returns the base.
+
+The patcher:
+
+1. Resolves `ApplicationInfo.splitSourceDirs` (available since API 21; minSdk
+   is 23).
+2. Loads each split as an `ApkModule` and calls `base.merge(split)` (ARSCLib)
+   — unions all dex files, native libraries, resources, and assets into the
+   base.
+3. Calls `ApkSplitInfoCleaner.cleanSplitInfo(base)` to strip the `<split>` /
+   `<isSplitRequired>` manifest metadata so Android treats the merged APK as
+   a standalone base.
+
+The result is a single installable APK containing everything from all splits.
+
+## File layout
+
+```
+app/src/main/java/net/kollnig/missioncontrol/patch/
+├── ApkPatcher.java          # interface
+├── PatchResult.java         # result data class
+├── NoOpPatcher.java         # fallback for play flavor
+├── PatcherFactory.java      # reflection-based flavor dispatch
+├── DexPatcher.java          # dexlib2 method-body replacement engine
+└── SmaliPatches.java        # declarative patch definitions (apk-mitm + Frida ports)
+
+app/src/patcher/java/net/kollnig/missioncontrol/patch/   # fdroid/github only
+├── Dexlib2Patcher.java      # the real ApkPatcher impl (orchestrates everything)
+├── ResourcePatcher.java     # ARSCLib manifest + network_security_config
+└── SigningKeyManager.java   # AndroidKeyStore RSA key for re-signing
+```
+
+The `patcher` source set is only compiled into the `fdroid` and `github`
+product flavors (see `app/build.gradle` `sourceSets`). The `play` flavor
+excludes it entirely and `PatcherFactory` returns `NoOpPatcher` at runtime,
+because:
+
+- Play Store policy and the additional dependency weight (apksig + ARSCLib
+  ≈ 10 MB) make bundling the engine in the Play build undesirable.
+- The engine uses on-device APK repackaging, which sits awkwardly with Play
+  policy regardless.
+
+## Dependencies
+
+| Dependency | Version | License | Purpose |
+|---|---|---|---|
+| `org.smali:dexlib2` | 2.5.2 (existing) | BSD-3 | DEX read/write & method-body replacement |
+| `com.android.tools.build:apksig` | 9.0.1 | Apache-2.0 | Re-signing the patched APK (v1+v2+v3) |
+| `io.github.reandroid:ARSCLib` | 1.4.0 | Apache-2.0 | Binary resource editing (manifest + res/xml), split merging |
+
+All three are permissively licensed — no GPL dependency was added (ReVanced's
+GPL-3.0 patcher was deliberately avoided). The TrackerControl base is GPL-3.0,
+which remains compatible.
+
+The signing key is an RSA-2048 key generated and stored in the AndroidKeyStore
+(non-exportable), with a self-signed cert valid for 100 years. The patched APK
+is signed with v1 + v2 + v3 signature schemes for maximum install compatibility.
+This does not preserve the target app's original signing identity, so Android's
+normal update flow will reject installing it over the still-installed original.
+
+## What the patcher does to an APK
+
+1. **Merge splits** (if any) into a single base module.
+2. **Strip split manifest metadata** (`<split>`, `<isSplitRequired>`).
+3. **Patch every `classes*.dex`**: for each class implementing a known pinning
+   interface or extending a known pinning class, replace the matching methods'
+   bodies with stubs:
+   - `X509TrustManager.checkClientTrusted/checkServerTrusted` → `return-void`
+   - `X509TrustManager.getAcceptedIssuers` → `return new X509Certificate[0]`
+   - `HostnameVerifier.verify` → `return true`
+   - `OkHttp CertificatePinner.check`/`check$okhttp` → `return-void`
+   - TrustKit / Appcelerator / WorkLight / Netty / CWAC / PhoneGap / Appmattus
+     pinning methods → no-op or return-true/empty-array
+4. **Inject `res/xml/network_security_config.xml`** that trusts user CAs with
+   `overridePins="true"` and permits cleartext, plus debug-overrides trusting
+   user CAs.
+5. **Set `android:networkSecurityConfig`** on `<application>` to reference the
+   new XML resource, and set `android:debuggable="true"`.
+6. **Strip the original signature** (META-INF/*.SF, *.RSA, *.DSA, *.EC,
+   MANIFEST.MF) and **re-sign** with the AndroidKeyStore key via apksig.
+
+## Covered pinning libraries
+
+Ported from apk-mitm and the declarative subset of
+[httptoolkit/frida-interception-and-unpinning](https://github.com/httptoolkit/frida-interception-and-unpinning):
+
+- `javax.net.ssl.X509TrustManager` (any implementor)
+- `javax.net.ssl.HostnameVerifier` (any implementor)
+- `com.squareup.okhttp.CertificatePinner` (OkHttp 2.x)
+- `okhttp3.CertificatePinner` (OkHttp 3.x / 4.x, including `check$okhttp`)
+- `com.datatheorem.android.trustkit.pinning.PinningTrustManager`
+- `appcelerator.https.PinningTrustManager`
+- `com.worklight.wlclient.certificatepinning.HostNameVerifierWithCertificatePinning`
+- `com.worklight.androidgap.plugin.WLCertificatePinningPlugin`
+- `com.commonsware.cwac.netsecurity.conscrypt.CertPinManager`
+- `io.netty.handler.ssl.util.FingerprintTrustManagerFactory`
+- `nl.xservices.plugins.sslCertificateChecker` (PhoneGap)
+- `com.appmattus.certificatetransparency.internal.verifier.CertificateTransparencyHostnameVerifier`
+
+## Limitations
+
+- **Framework classes cannot be dex-patched.** `com.android.okhttp.*`,
+  `com.android.org.conscrypt.*`, and `javax.net.ssl.*` live in the framework,
+  not the app's dex. They are handled by the resource step (NSC trusting user
+  CAs + `overridePins="true"`) instead.
+- **Apps pinning via uncovered classes** will still reject the MITM CA. The
+  proxy must fall back to pass-through for those flows so connectivity is
+  never broken.
+- **No runtime hooks.** This is static repackaging — no Frida/Xposed. The
+  patch persists across restarts, but the app must be reinstalled and any
+  app updates will overwrite the patch.
+- **No split-APK output.** The output is always a single merged APK; if the
+  original was a large App Bundle, the patched APK will be larger than the
+  base alone because all splits are inlined.
+- **Non-rooted CA trust.** Even with `network_security_config` trusting user
+  CAs, the MITM CA must be installed as a user CA via Android's certificate
+  settings (or as a system CA on rooted devices) for the platform to actually
+  present it during TLS handshakes.
+
+---
+
+# Future Work: the MITM Engine
+
+The patcher makes an app **interceptable**; it does not yet intercept. The
+missing half is a TLS-terminating proxy that sits inside the VPN tunnel and
+decrypts HTTPS for display. This section documents the design for that follow-on
+work.
+
+## Goal
+
+When the user enables "Inspect HTTPS content" for a patched app, the VPN
+engine should:
+
+1. Detect TLS flows (TCP/443) from that app.
+2. Terminate TLS on the device using a locally-generated CA.
+3. Decrypt request/response bodies.
+4. Store them in a new `content` table for display in a "Content" tab.
+5. Re-encrypt toward the real upstream server.
+6. Fall back to **pass-through** on any handshake failure (never break
+   connectivity).
+
+## Architecture: Option B (Kotlin TLS relay) — recommended
+
+A userspace TLS-terminating proxy on the TUN side. Two implementation options
+were considered:
+
+- **Option A — Native (mbedTLS in C):** Highest performance, hardest to
+  write, duplicates a TLS stack already linked for WireGuard.
+- **Option B — Kotlin `javax.net.ssl` relay:** Reuses Android's TLS, easier to
+  maintain, handles modern TLS versions/ALPN/ cert validation correctly. Slower
+  but adequate for the per-flow counts a single device produces.
+
+Recommended: **Option B**.
+
+```
+app  ──TLS──►  [TC interceptor: terminate TLS w/ on-the-fly leaf cert]
+                     │
+                     ├── decrypted request bytes ──► capture ──► DB
+                     │
+                     └── open real TLS to upstream ──► decrypted response ──► capture ──► DB
+                                                                                       └─► re-encrypt → app
+```
+
+## Components to build
+
+### 1. Local CA + leaf cert generation (`net.kollnig.missioncontrol.intercept.ca`)
+
+- `LocalCaManager` — generates an RSA/EC root keypair on first run, stores in
+  AndroidKeyStore (or BouncyCastle-backed PEM in app-private storage).
+  `signLeaf(sni: String): X509Certificate` produces a per-host leaf signed by
+  the CA on the fly.
+- Settings screen to export the CA cert (`KeyChain.createInstallIntent`) and
+  check install status. **This is the step that requires the user to install
+  the CA in Android's certificate settings** (or as a system CA on rooted
+  devices) — the patched app's `network_security_config` will trust it once
+  installed.
+
+### 2. TLS interceptor (`net.kollnig.missioncontrol.intercept`)
+
+- `TlsInterceptor` — per-session state: `SSLSocket clientSide` (toward app,
+  presented with the leaf cert) and `SSLSocket serverSide` (toward upstream,
+  using the default trust manager). Two pump threads per session copying bytes
+  both directions, calling `capture(...)` on each chunk.
+- `InterceptorRegistry` — pool of active sessions keyed by
+  `(saddr,sport,daddr,dport)`. Bounded (e.g. 64 concurrent) with overflow
+  falling back to pass-through.
+- **Pass-through fallback** on any handshake failure (pinning not fully
+  defeated, protocol error) — the app keeps working, that flow is just not
+  decrypted.
+
+### 3. Native hook (`app/src/main/jni/netguard/`)
+
+The current TCP engine (`tcp.c:queue_tcp` line 977) reassembles segments and
+forwards bytes plaintext to the upstream socket. To intercept TLS:
+
+- Add `jni_intercept_tls(boolean)` mirroring `jni_sni` (`netguard.c:368`).
+- Add `is_intercept` global in `ip.c` mirroring `is_play` (line 259).
+- In `handle_tcp` (~`tcp.c:623`): if `args->intercept_tls && dest == 443` and
+  the rules layer returned `allowed && intercept` for this flow:
+  - Instead of opening the upstream socket in `connect_tcp`, post the TUN-side
+    socket fd + session metadata up to Java via a new JNI callback
+    `intercept_flow(Packet, int clientFd)`.
+  - Java (`ServiceSinkhole.interceptFlow`, modelled on `isAddressAllowed`
+    line 2118) hands the fd to `TlsInterceptor`.
+  - The native session's `write_data` path is then drained by Java owning the
+    socket; native stops forwarding upstream and only relays TUN ↔ client fd.
+- Persist the toggle as `intercept_tls_enabled` pref, default **off**, gated
+  to non-WG-active state (WG outbound packets bypass `tcp.c`/`udp.c` entirely
+  at `ip.c:571`; intercepting them needs a separate, more invasive Rust-side
+  hook — out of scope for v1).
+
+### 4. Capture pipeline + storage
+
+- New `content` table in `DatabaseHelper.java`:
+  ```sql
+  CREATE TABLE content (
+    id INTEGER PRIMARY KEY,
+    access_id INTEGER,            -- FK to access.rowid (uid,daddr,dport,...)
+    direction INTEGER,            -- 0=request, 1=response
+    seq INTEGER,
+    mime TEXT,
+    mime_utf8 INTEGER,            -- is it printable
+    body BLOB,                    -- capped, e.g. 16 KB per chunk
+    time INTEGER,
+    redacted INTEGER
+  );
+  ```
+- `ContentCaptureStore` (Kotlin) — writers from `TlsInterceptor.capture(...)`:
+  - Redaction regexes for `Authorization`, `Cookie`, `Set-Cookie`, `token=`,
+    `password=` etc. (configurable list).
+  - Size cap per flow (e.g. 64 KB total) to bound DB growth.
+  - Binary detection — only store printable/UTF-8; otherwise store mime +
+    length only.
+
+### 5. UI
+
+- New `ActivityContent` / `AdapterContent` mirroring `ActivityLog` — list of
+  captured flows with uid, host, time, size.
+- Detail view: per-flow request/response viewer (hex + utf-8 panes), redacted
+  sections marked.
+- Entry point from `DetailsActivity` (per-app) and a top-level "Content" tab.
+
+### 6. Privacy & UX guards
+
+- Toggle default off, with a clear warning dialog (mirrors the existing SNI
+  research-mode warning flow).
+- Per-app allowlist for interception (extend `Rule.java`) — defaults to empty;
+  user explicitly opts apps in. Avoids intercepting system apps.
+- A "panic" clear-all button on the Content activity that drops the table.
+- Crash safety: if `TlsInterceptor` fails a handshake, fall back to
+  **pass-through** so the app keeps working — never break connectivity.
+
+### 7. WireGuard path
+
+- `wgbridge-rs/src/transport/ip_send.rs:38` writes decrypted inbound packets
+  to the TUN fd; outbound encrypted packets bypass `tcp.c`/`udp.c` (go
+  straight to `wg_fd` at `ip.c:571`).
+- For TLS interception on the WG path you'd need to also intercept the
+  **outbound** encrypted WG packets before encryption, which is more invasive
+  (you'd hook the Rust tunnel's outbound send). **Out of scope for v1** —
+  restrict the toggle to disabled-when-WG-active, mirroring how `is_play` is
+  gated. Document this in the toggle's settings summary.
+
+## Suggested implementation order
+
+1. `LocalCaManager` + settings entry + CA install flow. Verify a test app
+   with `network_security_config` trusting user CAs accepts a signed leaf.
+2. `content` table + `ContentCaptureStore` + stub UI list.
+3. `TlsInterceptor` in pure Kotlin against a unit-tested in-process TLS pair
+   (no native integration yet) — prove the MITM logic.
+4. Native hook: `jni_intercept_tls` + `intercept_flow` callback + plumb the
+   client fd to `TlsInterceptor`. Pass-through fallback on any error.
+5. UI detail view + redaction.
+6. Per-app allowlist + WG-disable guard.
+7. Lint/typecheck, tests, manual end-to-end.
+
+## Open design questions
+
+1. **HTTP/2 and WebSocket:** `javax.net.ssl` exposes plaintext bytes after
+   TLS, but HTTP/2 framing and WebSocket need parsing to be readable. Ship a
+   basic HTTP/1.x parser only for v1, or include h2 via OkHttp's `Http2`
+   codec?
+2. **Certificate install UX:** Should the app guide the user through the
+   Android CA-install flow with a wizard, or just present the cert and let
+   them install it manually?
+3. **Per-flow vs per-app toggle:** Granular per-flow control (intercept some
+   hosts but not others) adds complexity; per-app is simpler and probably
+   sufficient for v1.


### PR DESCRIPTION
## Summary

Adds an on-device APK patcher for traffic inspection builds. The patcher wires a per-app details action through a flavor-gated patching engine that can merge split APKs, patch common certificate pinning implementations, inject a user-CA-trusting network security config, re-sign the result, and hand it to Android's installer.

Also includes supporting documentation and WireGuard flow/cache adjustments that keep inspection-related traffic handling efficient while the WireGuard hijack path is active.

## User Impact

Users of fdroid/github builds get a new "Patch for traffic inspection" action in app details. Play builds keep a no-op fallback and do not include the patcher dependencies. The UI now warns that patched APKs are re-signed and may require uninstalling the original app before installation.

## Validation

- `./gradlew :app:compileFdroidDebugJavaWithJavac :app:compilePlayDebugJavaWithJavac`
- `git diff --check`

I also started `./gradlew :app:assembleFdroidDebug`, but stopped it after it sat silent during packaging; no failure was reported before interruption.