### PR TITLE
Batch access/usage DB writes, debounce network reloads, back off WG restarts

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -39,6 +39,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -50,6 +51,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     public static final int ACCESS_UNCERTAIN_MULTIPLE_TRACKERS = 3;
 
     public Cursor getHosts(int uid) {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -63,6 +66,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public Cursor getHosts() {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -102,6 +107,56 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final long LOG_BATCH_FLUSH_MS = 5000;
     private final List<ContentValues> logBatch = new ArrayList<>();
     private long lastLogFlush = System.currentTimeMillis();
+
+    // Access/usage batching: coalesces repeated updates to the same
+    // (uid, version, protocol, daddr, dport) row into a single write instead
+    // of one transaction per tracker flow.
+    private static final int ACCESS_BATCH_SIZE = 50;
+    private static final long ACCESS_BATCH_FLUSH_MS = 2000;
+    private final Map<AccessKey, PendingAccess> accessBatch = new LinkedHashMap<>();
+    private long lastAccessFlush = System.currentTimeMillis();
+
+    private static final int USAGE_BATCH_SIZE = 50;
+    private static final long USAGE_BATCH_FLUSH_MS = 2000;
+    private final Map<AccessKey, long[]> usageBatch = new LinkedHashMap<>();
+    private long lastUsageFlush = System.currentTimeMillis();
+
+    private static final class AccessKey {
+        final int uid, version, protocol, dport;
+        final String daddr;
+
+        AccessKey(int uid, int version, int protocol, String daddr, int dport) {
+            this.uid = uid;
+            this.version = version;
+            this.protocol = protocol;
+            this.daddr = daddr;
+            this.dport = dport;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof AccessKey))
+                return false;
+            AccessKey k = (AccessKey) o;
+            return uid == k.uid && version == k.version && protocol == k.protocol &&
+                    dport == k.dport && daddr.equals(k.daddr);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(uid, version, protocol, daddr, dport);
+        }
+    }
+
+    // Last-write-wins per key: only the latest state of a rapidly repeated
+    // access update needs to reach the row.
+    private static final class PendingAccess {
+        long time;
+        boolean allowed;
+        int uncertain;
+        boolean blockSpecified;
+        int block;
+    }
 
     static {
         hthread = new HandlerThread("DatabaseHelper");
@@ -572,43 +627,75 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
     // Access
 
-    public boolean updateAccess(Packet packet, String dname, int block, int uncertain) {
-        int rows;
+    public void updateAccess(Packet packet, String dname, int block, int uncertain) {
+        String daddr = (dname == null ? packet.daddr : dname);
+        AccessKey key = new AccessKey(packet.uid, packet.version, packet.protocol, daddr, packet.dport);
+
+        PendingAccess p = new PendingAccess();
+        p.time = packet.time;
+        p.allowed = packet.allowed;
+        p.uncertain = uncertain;
+        p.blockSpecified = (block >= 0);
+        p.block = block;
+
+        synchronized (accessBatch) {
+            accessBatch.put(key, p);
+            long now = System.currentTimeMillis();
+            if (accessBatch.size() >= ACCESS_BATCH_SIZE || now - lastAccessFlush >= ACCESS_BATCH_FLUSH_MS)
+                flushAccessBatch();
+        }
+    }
+
+    public void flushAccessBatch() {
+        Map<AccessKey, PendingAccess> batch;
+        synchronized (accessBatch) {
+            if (accessBatch.isEmpty())
+                return;
+            batch = new LinkedHashMap<>(accessBatch);
+            accessBatch.clear();
+            lastAccessFlush = System.currentTimeMillis();
+        }
 
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
             db.beginTransactionNonExclusive();
             try {
-                ContentValues cv = new ContentValues();
-                cv.put("time", packet.time);
-                cv.put("allowed", packet.allowed ? 1 : 0);
-                cv.put("uncertain", uncertain);
-                if (block >= 0)
-                    cv.put("block", block);
+                for (Map.Entry<AccessKey, PendingAccess> entry : batch.entrySet()) {
+                    AccessKey key = entry.getKey();
+                    PendingAccess p = entry.getValue();
 
-                // There is a segmented index on uid, version, protocol, daddr and dport
-                rows = db.update("access", cv, "uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?",
-                        new String[] {
-                                Integer.toString(packet.uid),
-                                Integer.toString(packet.version),
-                                Integer.toString(packet.protocol),
-                                dname == null ? packet.daddr : dname,
-                                Integer.toString(packet.dport) });
+                    ContentValues cv = new ContentValues();
+                    cv.put("time", p.time);
+                    cv.put("allowed", p.allowed ? 1 : 0);
+                    cv.put("uncertain", p.uncertain);
+                    if (p.blockSpecified)
+                        cv.put("block", p.block);
 
-                if (rows == 0) {
-                    cv.put("uid", packet.uid);
-                    cv.put("version", packet.version);
-                    cv.put("protocol", packet.protocol);
-                    cv.put("daddr", dname == null ? packet.daddr : dname);
-                    cv.put("dport", packet.dport);
-                    if (block < 0)
-                        cv.put("block", block);
+                    // There is a segmented index on uid, version, protocol, daddr and dport
+                    int rows = db.update("access", cv,
+                            "uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?",
+                            new String[] {
+                                    Integer.toString(key.uid),
+                                    Integer.toString(key.version),
+                                    Integer.toString(key.protocol),
+                                    key.daddr,
+                                    Integer.toString(key.dport) });
 
-                    if (db.insert("access", null, cv) == -1)
-                        Log.e(TAG, "Insert access failed");
-                } else if (rows != 1)
-                    Log.e(TAG, "Update access failed rows=" + rows);
+                    if (rows == 0) {
+                        cv.put("uid", key.uid);
+                        cv.put("version", key.version);
+                        cv.put("protocol", key.protocol);
+                        cv.put("daddr", key.daddr);
+                        cv.put("dport", key.dport);
+                        if (!p.blockSpecified)
+                            cv.put("block", -1);
+
+                        if (db.insert("access", null, cv) == -1)
+                            Log.e(TAG, "Insert access failed");
+                    } else if (rows != 1)
+                        Log.e(TAG, "Update access failed rows=" + rows);
+                }
 
                 db.setTransactionSuccessful();
             } finally {
@@ -619,47 +706,59 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
 
         notifyAccessChanged();
-        return (rows == 0);
     }
 
     public void updateUsage(Usage usage, String dname) {
+        String daddr = (dname == null ? usage.DAddr : dname);
+        AccessKey key = new AccessKey(usage.Uid, usage.Version, usage.Protocol, daddr, usage.DPort);
+
+        synchronized (usageBatch) {
+            long[] acc = usageBatch.get(key);
+            if (acc == null) {
+                acc = new long[3];
+                usageBatch.put(key, acc);
+            }
+            acc[0] += usage.Sent;
+            acc[1] += usage.Received;
+            acc[2] += 1;
+
+            long now = System.currentTimeMillis();
+            if (usageBatch.size() >= USAGE_BATCH_SIZE || now - lastUsageFlush >= USAGE_BATCH_FLUSH_MS)
+                flushUsageBatch();
+        }
+    }
+
+    public void flushUsageBatch() {
+        Map<AccessKey, long[]> batch;
+        synchronized (usageBatch) {
+            if (usageBatch.isEmpty())
+                return;
+            batch = new LinkedHashMap<>(usageBatch);
+            usageBatch.clear();
+            lastUsageFlush = System.currentTimeMillis();
+        }
+
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
             db.beginTransactionNonExclusive();
             try {
-                // There is a segmented index on uid, version, protocol, daddr and dport
-                String selection = "uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?";
-                String[] selectionArgs = new String[] {
-                        Integer.toString(usage.Uid),
-                        Integer.toString(usage.Version),
-                        Integer.toString(usage.Protocol),
-                        dname == null ? usage.DAddr : dname,
-                        Integer.toString(usage.DPort)
-                };
+                for (Map.Entry<AccessKey, long[]> entry : batch.entrySet()) {
+                    AccessKey key = entry.getKey();
+                    long[] delta = entry.getValue();
 
-                try (Cursor cursor = db.query("access", new String[] { "sent", "received", "connections" }, selection,
-                        selectionArgs, null, null, null)) {
-                    long sent = 0;
-                    long received = 0;
-                    int connections = 0;
-                    int colSent = cursor.getColumnIndex("sent");
-                    int colReceived = cursor.getColumnIndex("received");
-                    int colConnections = cursor.getColumnIndex("connections");
-                    if (cursor.moveToNext()) {
-                        sent = cursor.isNull(colSent) ? 0 : cursor.getLong(colSent);
-                        received = cursor.isNull(colReceived) ? 0 : cursor.getLong(colReceived);
-                        connections = cursor.isNull(colConnections) ? 0 : cursor.getInt(colConnections);
-                    }
-
-                    ContentValues cv = new ContentValues();
-                    cv.put("sent", sent + usage.Sent);
-                    cv.put("received", received + usage.Received);
-                    cv.put("connections", connections + 1);
-
-                    int rows = db.update("access", cv, selection, selectionArgs);
-                    if (rows != 1)
-                        Log.e(TAG, "Update usage failed rows=" + rows);
+                    // Collapses the previous SELECT-then-UPDATE round trip into a
+                    // single UPDATE; COALESCE guards against NULL (never-accounted) columns.
+                    db.execSQL(
+                            "UPDATE access SET " +
+                                    "sent = COALESCE(sent, 0) + ?, " +
+                                    "received = COALESCE(received, 0) + ?, " +
+                                    "connections = COALESCE(connections, 0) + ? " +
+                                    "WHERE uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?",
+                            new Object[] {
+                                    delta[0], delta[1], delta[2],
+                                    key.uid, key.version, key.protocol, key.daddr, key.dport
+                            });
                 }
 
                 db.setTransactionSuccessful();
@@ -674,6 +773,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void setAccess(long id, int block) {
+        flushAccessBatch();
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
@@ -698,6 +798,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void clearAccess() {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
@@ -717,6 +819,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void clearAccess(int uid, boolean keeprules) {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
@@ -741,6 +845,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void resetUsage(int uid) {
+        flushUsageBatch();
         lock.writeLock().lock();
         try {
             // There is a segmented index on uid
@@ -767,6 +872,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public Cursor getAccess(int uid) {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -785,6 +892,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public Cursor getAccess() {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -797,6 +906,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public Cursor getAccessUnset(int uid, int limit, long since) {
+        flushAccessBatch();
+        flushUsageBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -847,6 +958,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
      * @return Cursor with columns: uid, daddr, allowed, time, uncertain
      */
     public Cursor getInsightsData7Days() {
+        flushAccessBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
@@ -864,6 +976,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public Cursor getRecentTrackerActivity() {
+        flushAccessBatch();
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -27,6 +27,7 @@ import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDoneException;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteStatement;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Message;
@@ -729,6 +730,12 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     public void flushUsageBatch() {
+        // A usage delta's access row may still be sitting unflushed in
+        // accessBatch (independent batch/flush timers); flush it first so the
+        // UPDATE below always has a row to land on instead of silently
+        // matching zero rows and losing the delta.
+        flushAccessBatch();
+
         Map<AccessKey, long[]> batch;
         synchronized (usageBatch) {
             if (usageBatch.isEmpty())
@@ -743,22 +750,35 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             SQLiteDatabase db = this.getWritableDatabase();
             db.beginTransactionNonExclusive();
             try {
-                for (Map.Entry<AccessKey, long[]> entry : batch.entrySet()) {
-                    AccessKey key = entry.getKey();
-                    long[] delta = entry.getValue();
+                // Collapses the previous SELECT-then-UPDATE round trip into a
+                // single UPDATE; COALESCE guards against NULL (never-accounted) columns.
+                SQLiteStatement stmt = db.compileStatement(
+                        "UPDATE access SET " +
+                                "sent = COALESCE(sent, 0) + ?, " +
+                                "received = COALESCE(received, 0) + ?, " +
+                                "connections = COALESCE(connections, 0) + ? " +
+                                "WHERE uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?");
+                try {
+                    for (Map.Entry<AccessKey, long[]> entry : batch.entrySet()) {
+                        AccessKey key = entry.getKey();
+                        long[] delta = entry.getValue();
 
-                    // Collapses the previous SELECT-then-UPDATE round trip into a
-                    // single UPDATE; COALESCE guards against NULL (never-accounted) columns.
-                    db.execSQL(
-                            "UPDATE access SET " +
-                                    "sent = COALESCE(sent, 0) + ?, " +
-                                    "received = COALESCE(received, 0) + ?, " +
-                                    "connections = COALESCE(connections, 0) + ? " +
-                                    "WHERE uid = ? AND version = ? AND protocol = ? AND daddr = ? AND dport = ?",
-                            new Object[] {
-                                    delta[0], delta[1], delta[2],
-                                    key.uid, key.version, key.protocol, key.daddr, key.dport
-                            });
+                        stmt.clearBindings();
+                        stmt.bindLong(1, delta[0]);
+                        stmt.bindLong(2, delta[1]);
+                        stmt.bindLong(3, delta[2]);
+                        stmt.bindLong(4, key.uid);
+                        stmt.bindLong(5, key.version);
+                        stmt.bindLong(6, key.protocol);
+                        stmt.bindString(7, key.daddr);
+                        stmt.bindLong(8, key.dport);
+
+                        int rows = stmt.executeUpdateDelete();
+                        if (rows != 1)
+                            Log.e(TAG, "Update usage failed rows=" + rows);
+                    }
+                } finally {
+                    stmt.close();
                 }
 
                 db.setTransactionSuccessful();

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -116,6 +116,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final long ACCESS_BATCH_FLUSH_MS = 2000;
     private final Map<AccessKey, PendingAccess> accessBatch = new LinkedHashMap<>();
     private long lastAccessFlush = System.currentTimeMillis();
+    // Bounds how long the tail of a burst can sit unflushed: a size/next-write
+    // flush may never come if traffic goes quiet, so the first entry of an
+    // otherwise-idle batch schedules a time-based flush on the DB handler
+    // thread. Without this, a lone late access update stays invisible to
+    // listeners (no notifyAccessChanged) until the next reader or shutdown.
+    private final Runnable accessFlushRunnable = this::flushAccessBatch;
+    private final Runnable usageFlushRunnable = this::flushUsageBatch;
 
     private static final int USAGE_BATCH_SIZE = 50;
     private static final long USAGE_BATCH_FLUSH_MS = 2000;
@@ -640,11 +647,29 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         p.block = block;
 
         synchronized (accessBatch) {
+            boolean wasEmpty = accessBatch.isEmpty();
+            // Coalescing is last-write-wins, but block is only carried on the
+            // updates that specify it (block >= 0). If the newer update leaves
+            // block unspecified, preserve the pending specified value instead
+            // of dropping it — an unbatched sequence would have left the row's
+            // block untouched by the later (block < 0) write.
+            PendingAccess prev = accessBatch.get(key);
+            if (prev != null && prev.blockSpecified && !p.blockSpecified) {
+                p.blockSpecified = true;
+                p.block = prev.block;
+            }
             accessBatch.put(key, p);
             long now = System.currentTimeMillis();
             if (accessBatch.size() >= ACCESS_BATCH_SIZE || now - lastAccessFlush >= ACCESS_BATCH_FLUSH_MS)
                 flushAccessBatch();
+            else if (wasEmpty)
+                scheduleAccessFlush();
         }
+    }
+
+    private void scheduleAccessFlush() {
+        handler.removeCallbacks(accessFlushRunnable);
+        handler.postDelayed(accessFlushRunnable, ACCESS_BATCH_FLUSH_MS);
     }
 
     public void flushAccessBatch() {
@@ -652,6 +677,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         synchronized (accessBatch) {
             if (accessBatch.isEmpty())
                 return;
+            handler.removeCallbacks(accessFlushRunnable);
             batch = new LinkedHashMap<>(accessBatch);
             accessBatch.clear();
             lastAccessFlush = System.currentTimeMillis();
@@ -714,6 +740,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         AccessKey key = new AccessKey(usage.Uid, usage.Version, usage.Protocol, daddr, usage.DPort);
 
         synchronized (usageBatch) {
+            boolean wasEmpty = usageBatch.isEmpty();
             long[] acc = usageBatch.get(key);
             if (acc == null) {
                 acc = new long[3];
@@ -726,7 +753,14 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             long now = System.currentTimeMillis();
             if (usageBatch.size() >= USAGE_BATCH_SIZE || now - lastUsageFlush >= USAGE_BATCH_FLUSH_MS)
                 flushUsageBatch();
+            else if (wasEmpty)
+                scheduleUsageFlush();
         }
+    }
+
+    private void scheduleUsageFlush() {
+        handler.removeCallbacks(usageFlushRunnable);
+        handler.postDelayed(usageFlushRunnable, USAGE_BATCH_FLUSH_MS);
     }
 
     public void flushUsageBatch() {
@@ -740,6 +774,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         synchronized (usageBatch) {
             if (usageBatch.isEmpty())
                 return;
+            handler.removeCallbacks(usageFlushRunnable);
             batch = new LinkedHashMap<>(usageBatch);
             usageBatch.clear();
             lastUsageFlush = System.currentTimeMillis();

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -126,6 +126,14 @@ import javax.net.ssl.HttpsURLConnection;
 public class ServiceSinkhole extends VpnService {
     private static final String TAG = "TrackerControl.VPN";
 
+    // Safety net for the per-command wakelock: a command that hangs or throws
+    // before reaching the release in CommandHandler's finally block (or a
+    // future code path that forgets to release) auto-releases instead of
+    // holding the CPU awake indefinitely. Generously covers the slowest
+    // legitimate case (WG config parse + bounded DNS resolve + handshake +
+    // the 3s handover-retry sleep) with margin.
+    private static final long WAKELOCK_TIMEOUT_MS = 30_000L;
+
     private boolean registeredUser = false;
     private boolean registeredIdleState = false;
     private boolean registeredApState = false;
@@ -2938,10 +2946,27 @@ public class ServiceSinkhole extends VpnService {
         networkCallback = nc;
     }
 
-    private void reloadAfterNetworkChange(String reason) {
-        if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
-            net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged();
-        reload(reason, ServiceSinkhole.this, false);
+    // Network flapping (Wi-Fi<->cellular handoffs, DHCP renewals) fires several
+    // ConnectivityManager callbacks within milliseconds of each other. Each
+    // reload is a foreground-service update + wakelock + native VPN restart +
+    // WireGuard rebind, so bursts are coalesced into a single reload using the
+    // last reason once the burst settles. Every reason string currently in use
+    // maps to the same shouldRestartWireGuard()==true branch, so collapsing to
+    // the latest reason changes no behaviour beyond the log line.
+    private static final long NETWORK_RELOAD_DEBOUNCE_MS = 1500L;
+    private static final Object NETWORK_RELOAD_TOKEN = new Object();
+    private final Handler networkReloadDebounceHandler = new Handler(Looper.getMainLooper());
+
+    private void reloadAfterNetworkChange(final String reason) {
+        networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
+        networkReloadDebounceHandler.postAtTime(new Runnable() {
+            @Override
+            public void run() {
+                if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
+                    net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged();
+                reload(reason, ServiceSinkhole.this, false);
+            }
+        }, NETWORK_RELOAD_TOKEN, SystemClock.uptimeMillis() + NETWORK_RELOAD_DEBOUNCE_MS);
     }
 
     private void listenConnectivityChanges() {
@@ -3021,8 +3046,8 @@ public class ServiceSinkhole extends VpnService {
             return START_STICKY;
         }
 
-        // Keep awake
-        getLock(this).acquire();
+        // Keep awake (bounded: see WAKELOCK_TIMEOUT_MS)
+        getLock(this).acquire(WAKELOCK_TIMEOUT_MS);
 
         // Get state
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -3096,10 +3121,16 @@ public class ServiceSinkhole extends VpnService {
         synchronized (this) {
             Log.i(TAG, "Destroy");
 
-            // Flush any pending log entries before shutdown
+            // Flush any pending batched writes before shutdown
             DatabaseHelper dh = DatabaseHelper.getInstance(ServiceSinkhole.this);
-            if (dh != null)
+            if (dh != null) {
                 dh.flushLogBatch();
+                dh.flushAccessBatch();
+                dh.flushUsageBatch();
+            }
+
+            // Cancel any debounced network-change reload so it doesn't fire post-teardown
+            networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
 
             commandLooper.quit();
             logLooper.quit();

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -530,9 +530,6 @@ public class ServiceSinkhole extends VpnService {
                         !prefs.getBoolean("enabled", false) &&
                         !prefs.getBoolean("show_stats", false))
                     stopForeground(true);
-
-                // Request garbage collection
-                System.gc();
             } catch (Throwable ex) {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
 

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -61,6 +61,15 @@ object WgEgress {
     @Volatile private var lastCheapRecoveryMs: Long = 0
     @Volatile private var recoveryNotificationGeneration: Long = 0
     @Volatile private var restartAttempts: Int = 0
+    // Tracks whether a delayed (backed-off) restart is currently posted, so
+    // clearRecoveryState() can cancel it without forcing verifyHandler's lazy
+    // init on paths that never scheduled anything (e.g. plain-JUnit-tested
+    // no-tunnel callers that never touch the main-thread Looper).
+    @Volatile private var restartScheduled: Boolean = false
+    private val pendingRestartRunnable = Runnable {
+        restartScheduled = false
+        requestReloadCb?.run()
+    }
 
     // Single-thread executor for network-change rebinds: bounds the thread
     // count on a flapping network (instead of one raw Thread per event) and
@@ -272,10 +281,13 @@ object WgEgress {
         clearEndpointCache()
         forceRestartPending = true
         if (notify) scheduleRecoveryNotificationCheck()
+        verifyHandler.removeCallbacks(pendingRestartRunnable)
         if (delay <= 0L) {
+            restartScheduled = false
             requestReloadCb?.run()
         } else {
-            verifyHandler.postDelayed({ requestReloadCb?.run() }, delay)
+            restartScheduled = true
+            verifyHandler.postDelayed(pendingRestartRunnable, delay)
         }
     }
 
@@ -495,6 +507,13 @@ object WgEgress {
         recoveryNotificationGeneration++
         forceRestartPending = false
         restartAttempts = 0
+        // restartScheduled guards the lazy init: this runs on every no-tunnel
+        // /disable path, most of which never scheduled a delayed restart and
+        // so never touched verifyHandler in the first place.
+        if (restartScheduled) {
+            restartScheduled = false
+            verifyHandler.removeCallbacks(pendingRestartRunnable)
+        }
     }
 
     private fun scheduleFreshHandshakeNotificationCheck() {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -36,6 +36,12 @@ object WgEgress {
     // rebind + re-resolve, the cheap path clearly didn't help — escalate to
     // a full restart.
     private const val CHEAP_RECOVERY_ESCALATION_MS = 90_000L
+    // Exponential backoff for repeated full-restart cycles (captive portal,
+    // blocked UDP path): first restart is immediate, subsequent ones back off
+    // instead of looping every ~20s (BYTES_RX_TIMEOUT_MS + PING_TIMEOUT_MS)
+    // indefinitely, each doing DNS + handshake + monitor polling under a wakelock.
+    private const val RESTART_BACKOFF_BASE_MS = 20_000L
+    private const val RESTART_BACKOFF_MAX_MS = 5 * 60_000L
 
     @Volatile private var tunnel: WgTunnel? = null
     @Volatile private var lastError: String? = null
@@ -54,6 +60,16 @@ object WgEgress {
     @Volatile private var forceRestartPending: Boolean = false
     @Volatile private var lastCheapRecoveryMs: Long = 0
     @Volatile private var recoveryNotificationGeneration: Long = 0
+    @Volatile private var restartAttempts: Int = 0
+
+    // Single-thread executor for network-change rebinds: bounds the thread
+    // count on a flapping network (instead of one raw Thread per event) and
+    // rebindQueued dedups bursts so only one rebind is in flight/queued at a time.
+    private val rebindExecutor = java.util.concurrent.Executors.newSingleThreadExecutor {
+        Thread(it, "wg-rebind").apply { isDaemon = true }
+    }
+    private val rebindLock = Any()
+    @Volatile private var rebindQueued: Boolean = false
 
     @Volatile private var requestReloadCb: Runnable? = null
     @Volatile private var notifyBrokenCb: Runnable? = null
@@ -249,11 +265,18 @@ object WgEgress {
     }
 
     private fun requestFullRestart(reason: String, notify: Boolean) {
-        Log.w(TAG, "$reason; forcing restart")
+        val attempt = restartAttempts++
+        val delay = if (attempt == 0) 0L
+        else minOf(RESTART_BACKOFF_MAX_MS, RESTART_BACKOFF_BASE_MS shl (attempt - 1).coerceAtMost(10))
+        Log.w(TAG, "$reason; forcing restart (attempt=${attempt + 1}, delay=${delay}ms)")
         clearEndpointCache()
         forceRestartPending = true
         if (notify) scheduleRecoveryNotificationCheck()
-        requestReloadCb?.run()
+        if (delay <= 0L) {
+            requestReloadCb?.run()
+        } else {
+            verifyHandler.postDelayed({ requestReloadCb?.run() }, delay)
+        }
     }
 
     private fun scheduleRecoveryNotificationCheck() {
@@ -264,6 +287,7 @@ object WgEgress {
             val latest = latestHandshakeMillisOrNull() ?: 0L
             if (latest > 0 && now() - latest < HANDSHAKE_DEAD_AFTER_MS) {
                 lastError = null
+                restartAttempts = 0
                 notifyStateChanged()
                 return@postDelayed
             }
@@ -365,14 +389,26 @@ object WgEgress {
         // roaming (Wi-Fi <-> cellular, crossing borders) without a
         // re-handshake. Runs off-thread because endpoint re-resolution does
         // blocking DNS. Falls back to a full restart if the rebind fails.
-        Log.i(TAG, "underlying network changed; rebinding WG sockets")
-        Thread({
-            if (tryCheapRecovery()) {
-                lastCheapRecoveryMs = now()
-            } else if (tunnel != null && !forceRestartPending) {
-                requestFullRestart("WG rebind failed after network change", notify = false)
+        synchronized(rebindLock) {
+            if (rebindQueued) {
+                Log.i(TAG, "underlying network changed; rebind already queued, skipping duplicate")
+                return
             }
-        }, "wg-rebind").start()
+            rebindQueued = true
+        }
+
+        Log.i(TAG, "underlying network changed; rebinding WG sockets")
+        rebindExecutor.execute {
+            try {
+                if (tryCheapRecovery()) {
+                    lastCheapRecoveryMs = now()
+                } else if (tunnel != null && !forceRestartPending) {
+                    requestFullRestart("WG rebind failed after network change", notify = false)
+                }
+            } finally {
+                synchronized(rebindLock) { rebindQueued = false }
+            }
+        }
     }
 
     /**
@@ -458,6 +494,7 @@ object WgEgress {
         verificationGeneration++
         recoveryNotificationGeneration++
         forceRestartPending = false
+        restartAttempts = 0
     }
 
     private fun scheduleFreshHandshakeNotificationCheck() {
@@ -468,6 +505,7 @@ object WgEgress {
             if (latest > 0 && now() - latest < HANDSHAKE_DEAD_AFTER_MS) {
                 lastError = null
                 recoveryNotificationGeneration++
+                restartAttempts = 0
                 notifyStateChanged()
             }
         }, POST_WAKE_VERIFY_DELAY_MS)

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -68,17 +68,25 @@ object WgEgress {
     @Volatile private var restartScheduled: Boolean = false
     private val pendingRestartRunnable = Runnable {
         restartScheduled = false
-        requestReloadCb?.run()
+        // If forceRestartPending was cleared while this was queued, the tunnel
+        // was already (re)started by another path (e.g. a network-change
+        // reload consumed the pending restart in startOrUpdate) — firing now
+        // would kick a redundant restart of an already-healthy tunnel.
+        if (forceRestartPending) requestReloadCb?.run()
     }
 
     // Single-thread executor for network-change rebinds: bounds the thread
-    // count on a flapping network (instead of one raw Thread per event) and
-    // rebindQueued dedups bursts so only one rebind is in flight/queued at a time.
+    // count on a flapping network (instead of one raw Thread per event).
+    // rebindInFlight means a rebind task is running; a network change arriving
+    // during that window sets rebindDirty so the task re-runs once with the
+    // latest network instead of being dropped — otherwise the sockets could
+    // stay bound to a network that has already gone away.
     private val rebindExecutor = java.util.concurrent.Executors.newSingleThreadExecutor {
         Thread(it, "wg-rebind").apply { isDaemon = true }
     }
     private val rebindLock = Any()
-    @Volatile private var rebindQueued: Boolean = false
+    private var rebindInFlight: Boolean = false
+    private var rebindDirty: Boolean = false
 
     @Volatile private var requestReloadCb: Runnable? = null
     @Volatile private var notifyBrokenCb: Runnable? = null
@@ -402,23 +410,42 @@ object WgEgress {
         // re-handshake. Runs off-thread because endpoint re-resolution does
         // blocking DNS. Falls back to a full restart if the rebind fails.
         synchronized(rebindLock) {
-            if (rebindQueued) {
-                Log.i(TAG, "underlying network changed; rebind already queued, skipping duplicate")
+            if (rebindInFlight) {
+                // A rebind is already running; the network changed again, so
+                // mark it for a re-run rather than dropping this event.
+                rebindDirty = true
+                Log.i(TAG, "underlying network changed; rebind in flight, scheduling re-run")
                 return
             }
-            rebindQueued = true
+            rebindInFlight = true
+            rebindDirty = false
         }
 
         Log.i(TAG, "underlying network changed; rebinding WG sockets")
         rebindExecutor.execute {
             try {
-                if (tryCheapRecovery()) {
-                    lastCheapRecoveryMs = now()
-                } else if (tunnel != null && !forceRestartPending) {
-                    requestFullRestart("WG rebind failed after network change", notify = false)
+                while (true) {
+                    if (tryCheapRecovery()) {
+                        lastCheapRecoveryMs = now()
+                    } else if (tunnel != null && !forceRestartPending) {
+                        requestFullRestart("WG rebind failed after network change", notify = false)
+                    }
+                    synchronized(rebindLock) {
+                        if (!rebindDirty) {
+                            rebindInFlight = false
+                            return@execute
+                        }
+                        // Another network change landed mid-rebind; loop once
+                        // more with the now-current default network.
+                        rebindDirty = false
+                    }
                 }
-            } finally {
-                synchronized(rebindLock) { rebindQueued = false }
+            } catch (e: Throwable) {
+                Log.w(TAG, "WG rebind task failed", e)
+                synchronized(rebindLock) {
+                    rebindInFlight = false
+                    rebindDirty = false
+                }
             }
         }
     }
@@ -519,12 +546,18 @@ object WgEgress {
     private fun scheduleFreshHandshakeNotificationCheck() {
         val gen = verificationGeneration
         verifyHandler.postDelayed({
-            if (gen != verificationGeneration) return@postDelayed
             val latest = latestHandshakeMillisOrNull() ?: 0L
-            if (latest > 0 && now() - latest < HANDSHAKE_DEAD_AFTER_MS) {
+            val fresh = latest > 0 && now() - latest < HANDSHAKE_DEAD_AFTER_MS
+            // A confirmed-fresh handshake means the path is healthy right now,
+            // so clear the restart backoff even if a concurrent network-change
+            // event bumped verificationGeneration and invalidated the check
+            // below — otherwise a later transient breakage would needlessly
+            // wait out a stale (up to 5 min) backoff before recovering.
+            if (fresh) restartAttempts = 0
+            if (gen != verificationGeneration) return@postDelayed
+            if (fresh) {
                 lastError = null
                 recoveryNotificationGeneration++
-                restartAttempts = 0
                 notifyStateChanged()
             }
         }, POST_WAKE_VERIFY_DELAY_MS)

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
@@ -90,6 +90,29 @@ public class DatabaseHelperAccessBatchTest {
     }
 
     @Test
+    public void specifiedBlockSurvivesLaterUnspecifiedUpdateInSameBatch() {
+        // A block-setting update (block >= 0) followed by an ordinary
+        // (block < 0) update for the same key within one batch window must not
+        // drop the block: an unbatched sequence would leave the row's block
+        // untouched by the second write, so last-write-wins has to carry it.
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearAccess();
+
+        int uid = 13579;
+        dh.updateAccess(packet(uid, "tracker.example.com", 443, 1_000L, true), null,
+                1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.updateAccess(packet(uid, "tracker.example.com", 443, 2_000L, false), null,
+                -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.flushAccessBatch();
+
+        try (Cursor c = dh.getAccess(uid)) {
+            assertTrue(c.moveToFirst());
+            assertEquals("specified block must not be lost when a later update omits it",
+                    1, c.getInt(c.getColumnIndexOrThrow("block")));
+        }
+    }
+
+    @Test
     public void differentKeysInSameBatchProduceSeparateRows() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
         dh.clearAccess();

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
@@ -65,6 +65,31 @@ public class DatabaseHelperAccessBatchTest {
     }
 
     @Test
+    public void usageFlushBeforeAccessFlushStillAccumulates() {
+        // Regression: flushUsageBatch used to run independently of
+        // accessBatch, so a usage delta whose access row was still pending
+        // (not yet flushed) matched zero rows and was silently dropped.
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearAccess();
+
+        int uid = 24680;
+        Packet seed = packet(uid, "tracker.example.com", 443, 1_000L, true);
+        dh.updateAccess(seed, null, -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        // Note: no flushAccessBatch() here — the access row is still pending.
+
+        Usage u = usage(uid, "tracker.example.com", 443, 100, 200);
+        dh.updateUsage(u, null);
+        dh.flushUsageBatch();
+
+        try (Cursor c = dh.getAccess(uid)) {
+            assertTrue(c.moveToFirst());
+            assertEquals(100L, c.getLong(c.getColumnIndexOrThrow("sent")));
+            assertEquals(200L, c.getLong(c.getColumnIndexOrThrow("received")));
+            assertEquals(1, c.getInt(c.getColumnIndexOrThrow("connections")));
+        }
+    }
+
+    @Test
     public void differentKeysInSameBatchProduceSeparateRows() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
         dh.clearAccess();

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
@@ -1,0 +1,111 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.database.Cursor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Covers the access/usage batching added to collapse per-flow SQLite writes
+ * into a single transaction (see updateAccess/updateUsage in DatabaseHelper).
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseHelperAccessBatchTest {
+
+    @Test
+    public void repeatedUpdateAccessForSameKeyCoalescesIntoOneRow() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearAccess();
+
+        int uid = 12345;
+        Packet p1 = packet(uid, "tracker.example.com", 443, 1_000L, true);
+        Packet p2 = packet(uid, "tracker.example.com", 443, 2_000L, false);
+
+        dh.updateAccess(p1, null, -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.updateAccess(p2, null, -1, DatabaseHelper.ACCESS_UNCERTAIN_SHARED_IP);
+        dh.flushAccessBatch();
+
+        try (Cursor c = dh.getAccess(uid)) {
+            assertEquals("two updates to the same key must coalesce into one row", 1, c.getCount());
+            assertTrue(c.moveToFirst());
+            assertEquals(2000L, c.getLong(c.getColumnIndexOrThrow("time")));
+            assertEquals("last write should win", 0, c.getInt(c.getColumnIndexOrThrow("allowed")));
+            assertEquals(DatabaseHelper.ACCESS_UNCERTAIN_SHARED_IP,
+                    c.getInt(c.getColumnIndexOrThrow("uncertain")));
+        }
+    }
+
+    @Test
+    public void repeatedUpdateUsageForSameKeyAccumulatesInsteadOfOverwriting() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearAccess();
+
+        int uid = 54321;
+        Packet seed = packet(uid, "tracker.example.com", 443, 1_000L, true);
+        dh.updateAccess(seed, null, -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.flushAccessBatch();
+
+        Usage u1 = usage(uid, "tracker.example.com", 443, 100, 200);
+        Usage u2 = usage(uid, "tracker.example.com", 443, 300, 400);
+        dh.updateUsage(u1, null);
+        dh.updateUsage(u2, null);
+        dh.flushUsageBatch();
+
+        try (Cursor c = dh.getAccess(uid)) {
+            assertTrue(c.moveToFirst());
+            assertEquals(400L, c.getLong(c.getColumnIndexOrThrow("sent")));
+            assertEquals(600L, c.getLong(c.getColumnIndexOrThrow("received")));
+            assertEquals(2, c.getInt(c.getColumnIndexOrThrow("connections")));
+        }
+    }
+
+    @Test
+    public void differentKeysInSameBatchProduceSeparateRows() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearAccess();
+
+        int uid = 99999;
+        dh.updateAccess(packet(uid, "a.example.com", 443, 1_000L, true), null,
+                -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.updateAccess(packet(uid, "b.example.com", 443, 1_000L, true), null,
+                -1, DatabaseHelper.ACCESS_UNCERTAIN_NONE);
+        dh.flushAccessBatch();
+
+        try (Cursor c = dh.getAccess(uid)) {
+            assertEquals(2, c.getCount());
+        }
+    }
+
+    private static Packet packet(int uid, String daddr, int dport, long time, boolean allowed) {
+        Packet p = new Packet();
+        p.time = time;
+        p.version = 4;
+        p.protocol = 6;
+        p.uid = uid;
+        p.daddr = daddr;
+        p.dport = dport;
+        p.allowed = allowed;
+        p.flags = "";
+        p.saddr = "10.0.0.2";
+        p.sport = 12345;
+        return p;
+    }
+
+    private static Usage usage(int uid, String daddr, int dport, long sent, long received) {
+        Usage u = new Usage();
+        u.Uid = uid;
+        u.Version = 4;
+        u.Protocol = 6;
+        u.DAddr = daddr;
+        u.DPort = dport;
+        u.Sent = sent;
+        u.Received = received;
+        u.Time = System.currentTimeMillis();
+        return u;
+    }
+}


### PR DESCRIPTION
## Summary
Implements the four highest-ROI fixes from a battery review of the VPN service, WireGuard egress, and database layer:

- **Batch `updateAccess`/`updateUsage`** (`DatabaseHelper.java`): mirrors the existing `insertLog` batching — repeated writes to the same access row within a 2s/50-entry window coalesce into one transaction (last-write-wins for state, summed deltas for usage), and `updateUsage`'s old SELECT-then-UPDATE collapses into a single `UPDATE ... SET sent = COALESCE(sent,0) + ?`. Access-table readers/writers flush pending batches first for read-your-writes consistency; `onDestroy` flushes on shutdown so nothing is lost.
  - Scoped down from the original review: `insertDns` is intentionally left unbatched, since its return value synchronously gates `prepareUidIPFilters` (firewall rule enforcement for newly resolved trackers) — batching it would introduce a correctness-relevant delay.
- **Serialize + back off WireGuard recovery** (`WgEgress.kt`): network-change rebinds now run through a single-thread executor with dedup instead of spawning an unbounded raw `Thread` per event. The broken→full-restart loop now backs off exponentially (20s → 40s → 80s → ... capped at 5 min) instead of retrying every ~20s forever on a captive portal or blocked UDP path. Backoff resets on any confirmed fresh handshake.
- **Debounce network reloads** (`ServiceSinkhole.java`): bursts of `ConnectivityManager` callbacks (common during Wi-Fi↔cellular handoffs) now coalesce into a single reload 1.5s after the burst settles, instead of restarting the VPN/WireGuard per callback. Cancelled cleanly on service destroy.
- **Bounded wakelock**: `onStartCommand`'s wakelock now has a 30s timeout as a safety net against a hung or throwing command path holding it indefinitely.

## Test plan
- [x] `./gradlew compileFdroidDebugJavaWithJavac` and `compileFdroidDebugKotlin` — clean
- [x] `./gradlew testFdroidDebugUnitTest` — full suite passes
- [x] Added `DatabaseHelperAccessBatchTest` covering coalescing (last-write-wins), usage accumulation, and distinct-key isolation within a batch
- [ ] Not yet exercised on a real device — recommend a manual pass (network flapping, WireGuard recovery on a blocked/captive network, and traffic-heavy app usage) before merging, especially given the timing-sensitive WireGuard recovery changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)