### PR TITLE
Fix bottom nav bar overlap on edge-to-edge displays

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -384,6 +384,19 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         vpnContainer = findViewById(R.id.vpnContainer);
         bottomNav = findViewById(R.id.bottomNav);
 
+        // Pad the bottom navigation by the system bar insets so it isn't
+        // obscured by the gesture/navigation bar on API 35+ edge-to-edge
+        final int bottomNavInitialLeft = bottomNav.getPaddingLeft();
+        final int bottomNavInitialTop = bottomNav.getPaddingTop();
+        final int bottomNavInitialRight = bottomNav.getPaddingRight();
+        final int bottomNavInitialBottom = bottomNav.getPaddingBottom();
+        ViewCompat.setOnApplyWindowInsetsListener(bottomNav, (v, insets) -> {
+            Insets sysBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(bottomNavInitialLeft + sysBars.left, bottomNavInitialTop,
+                    bottomNavInitialRight + sysBars.right, bottomNavInitialBottom + sysBars.bottom);
+            return insets;
+        });
+
         if (savedInstanceState == null) {
             getSupportFragmentManager()
                     .beginTransaction()


### PR DESCRIPTION
## Summary

Fixes the main screen's `BottomNavigationView` being obscured by the system gesture/navigation bar on API 35+ (edge-to-edge, which Android 15 enforces).

The existing per-activity pattern already pads the toolbar (`appbar`) for the **top** status-bar inset. What was missing on the main screen was **bottom** inset handling — the `BottomNavigationView` at the bottom of `main.xml` had no padding for the nav bar. This adds one narrowly-scoped `OnApplyWindowInsetsListener` on `bottomNav` that pads it by the systemBars left/right/bottom insets (preserving any initial padding) and returns `insets` so nested consumers still receive them.

## Relationship to #585

**Supersedes and closes #585.** That PR (thanks @NYBACHOK for surfacing the issue) added a *second*, root-level listener on `android.R.id.content` returning `WindowInsetsCompat.CONSUMED`. That competes with the existing `appbar` listener and swallows insets before they reach the views that need them — the exact double-inset failure mode this project already fixed once in `cd9887a` ("Fix doubled top inset gap on Insights toolbar"). This version instead follows the codebase's established single-responsibility, non-consuming inset pattern.

## Notes
- Only `ActivityMain.java` changed (+13 lines); no layout edits.
- IME insets deliberately omitted — the only text input is the top-of-screen toolbar SearchView, which the keyboard never covers.

## Test plan
- [ ] On an API 35+ device/emulator with gesture nav, verify the bottom navigation sits fully above the nav bar (not underneath it).
- [ ] Verify the toolbar top inset is unchanged (no doubled gap).
- [ ] Verify landscape / three-button nav still lays out correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)