### PR TITLE
Strip build-time metadata from native libs for reproducible builds

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -32,4 +32,15 @@ target_link_libraries( netguard
 target_link_options(netguard PRIVATE
     "-Wl,-z,max-page-size=16384"
     "-Wl,-z,common-page-size=16384"
-    "-Wl,--build-id=sha1")
+    "-Wl,--build-id=none")
+
+# The clang version string embedded in .comment (which varies with the NDK's
+# use of BOLT-optimized toolchains, "+bolt"/"-bolt") and any residual
+# .note.gnu.build-id both harm reproducibility. Strip them post-link.
+# See https://izzyondroid.org/docs/reproducibleBuilds/DebugFailedRBs/#clang
+add_custom_command(TARGET netguard
+    POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} --remove-section .comment
+            --remove-section .note.gnu.build-id
+            $<TARGET_FILE:netguard>
+    VERBATIM)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,9 +81,16 @@ tasks.register('wgbridgeBuild') {
         env['PATH'] = "${cargoDir}${File.pathSeparator}${System.getProperty('user.home')}/.cargo/bin${File.pathSeparator}${env['PATH'] ?: ''}"
         env['ANDROID_NDK_HOME'] = findNdkDirectory().absolutePath
         // Android 15+ requires 16KB-aligned ELF LOAD segments.
+        // --remap-path-prefix strips the checkout- and machine-specific
+        // absolute paths (cargo registry cache, wgbridge-rs checkout dir)
+        // that rustc otherwise bakes into panic/track_caller strings, so
+        // libwgbridge.so is reproducible across build machines.
         env['RUSTFLAGS'] = ((env['RUSTFLAGS'] ?: '') +
                 ' -C link-arg=-Wl,-z,max-page-size=16384' +
-                ' -C link-arg=-Wl,-z,common-page-size=16384').trim()
+                ' -C link-arg=-Wl,-z,common-page-size=16384' +
+                ' -C link-arg=-Wl,--build-id=none' +
+                " --remap-path-prefix=${System.getProperty('user.home')}/.cargo=/cargo" +
+                " --remap-path-prefix=${wgbridgeSrcDir.absolutePath}=/wgbridge-rs").trim()
 
         // cargo-ndk drives the per-ABI cross-compilation and linker setup.
         def cargoNdk = "${System.getProperty('user.home')}/.cargo/bin/cargo-ndk"
@@ -111,6 +118,28 @@ tasks.register('wgbridgeBuild') {
         // gotatun statically; drop the stray artifacts.
         wgbridgeAbis.each { abi ->
             fileTree(dir: "$wgbridgeOutDir/$abi", include: 'libgotatun*.so').each { it.delete() }
+        }
+
+        // The NDK's clang linker still embeds a .comment section (compiler
+        // version string, incl. "+bolt"/"-bolt" markers that vary by NDK
+        // build) even with --build-id=none. Strip it for reproducibility,
+        // matching the equivalent objcopy step for the CMake-built netguard
+        // library. See https://izzyondroid.org/docs/reproducibleBuilds/DebugFailedRBs/#clang
+        def hostTag = { ->
+            def os = System.getProperty('os.name').toLowerCase()
+            if (os.contains('mac')) return 'darwin-x86_64'
+            if (os.contains('win')) return 'windows-x86_64'
+            return 'linux-x86_64'
+        }()
+        def objcopy = "${findNdkDirectory().absolutePath}/toolchains/llvm/prebuilt/${hostTag}/bin/llvm-objcopy"
+        wgbridgeAbis.each { abi ->
+            def lib = file("$wgbridgeOutDir/$abi/libwgbridge.so")
+            if (lib.exists()) {
+                providers.exec {
+                    commandLine objcopy, '--remove-section', '.comment',
+                            '--remove-section', '.note.gnu.build-id', lib.absolutePath
+                }.result.get().assertNormalExitValue()
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Strips the `.comment` section (embeds clang's version string, including the "+bolt"/"-bolt" markers that kept showing up in @IzzySoft's diffoscope diffs) and `.note.gnu.build-id` from `libnetguard.so` post-link, per [IzzyOnDroid's RB debugging guide](https://izzyondroid.org/docs/reproducibleBuilds/DebugFailedRBs/#clang).
- Applies the same treatment to `libwgbridge.so` (the Rust WireGuard bridge, added after this thread started), plus `--remap-path-prefix` for the cargo registry/checkout paths and `-Wl,--build-id=none`, mirroring the existing `-ffile-prefix-map` fix for the C sources.

## Verification
Built the app twice from a clean state and diffed the resulting APKs:
```
differing entries: 0
```
Also confirmed with `llvm-objdump`/`strings` on the packaged `.so`s in both APKs: no `.comment`, no `.note.gnu.build-id`, no leaked absolute build paths.

Closes #440 — would appreciate @IzzySoft re-testing RB against this branch when convenient.

## Test plan
- [x] `./gradlew assembleGithubRelease` succeeds
- [x] Two independent clean builds produce byte-identical APKs (0 CRC differences across all zip entries)
- [x] `llvm-objdump -h` confirms `.comment`/`.note.gnu.build-id` absent from both native libs in the packaged APK

🤖 Generated with [Claude Code](https://claude.com/claude-code)