### PR TITLE
Fix: stale pause alarm re-fires after manual resume from UI

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -21,6 +21,8 @@
 package eu.faircode.netguard;
 
 import android.Manifest;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -634,6 +636,14 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
             prefs.edit().putBoolean("enabled", resultCode == RESULT_OK).apply();
             if (resultCode == RESULT_OK) {
+                // Cancel any pending pause auto-resume alarm, so a stale one
+                // does not re-fire after TC was resumed manually (#327)
+                AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+                Intent alarmIntent = new Intent(WidgetAdmin.INTENT_ON);
+                alarmIntent.setPackage(getPackageName());
+                PendingIntent pi = PendingIntentCompat.getBroadcast(this, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                am.cancel(pi);
+
                 ServiceSinkhole.start("prepared", this);
             } else if (resultCode == RESULT_CANCELED)
                 Toast.makeText(this, R.string.msg_vpn_cancelled, Toast.LENGTH_LONG).show();


### PR DESCRIPTION
Fixes #327

## Root cause

When TC is paused N minutes from the notification, `WidgetAdmin.onReceive()` schedules a broadcast alarm for `WidgetAdmin.INTENT_ON` (`app/src/main/java/eu/faircode/netguard/WidgetAdmin.java:82-90`) that will re-enable TC after the pause duration.

That alarm is only cancelled inside `WidgetAdmin.onReceive()` itself, for its own `INTENT_ON` / `INTENT_OFF` / `INTENT_PAUSE` broadcasts (`WidgetAdmin.java:53-61`).

If the user instead resumes TC manually from the main app UI (the on/off switch), the flow goes through `ActivityMain`'s VPN-prepare/`onActivityResult(REQUEST_VPN, ...)` path (`app/src/main/java/eu/faircode/netguard/ActivityMain.java`, `onActivityResult`), which sets `enabled=true` in prefs and calls `ServiceSinkhole.start("prepared", this)` directly — it never touches `AlarmManager`. The original pause alarm is therefore orphaned and still fires later: TC vibrates, re-initializes the foreground/VPN mid-session, and drops in-flight connections.

I confirmed `ServiceTileMain` (the Quick Settings tile) already cancels this same alarm correctly on click (`ServiceTileMain.java:76-81`) — only the main-UI resume path was missing it.

## Fix

In `ActivityMain.onActivityResult()`, when the VPN prepare result confirms `enabled` (`resultCode == RESULT_OK`, right before `ServiceSinkhole.start("prepared", this)`), cancel the same `INTENT_ON` `PendingIntent` that `WidgetAdmin` schedules. The `Intent`/`PendingIntent` construction (action `WidgetAdmin.INTENT_ON`, request code `0`, `FLAG_UPDATE_CURRENT` via `PendingIntentCompat.getBroadcast`) is built identically to `WidgetAdmin.java:55-57` so `AlarmManager.cancel()` matches the originally-scheduled alarm (`PendingIntent` equality is based on component/action/request code, not on the intent extras).

This covers the switch-toggle resume path, since toggling the switch on always routes through `onActivityResult(REQUEST_VPN, ...)` (either immediately, when the VPN is already prepared, or after the system VPN-consent dialog).

Diff is a single, minimal change to `ActivityMain.java` (2 new imports + 8 lines in `onActivityResult`); no other files touched.

## Testing

Verified:
- Traced the exact `PendingIntent` construction in `WidgetAdmin.java` and `ServiceTileMain.java` to confirm the cancel in `ActivityMain` matches (same action string, request code, flags), so `am.cancel(pi)` targets the correct alarm.
- `./gradlew :app:compileGithubDebugJavaWithJavac` (also builds `libwgbridge.so` via `preBuild`/`wgbridgeBuild`) — BUILD SUCCESSFUL.

Not verified (needs a maintainer / on-device pass):
- Manual on-device repro: pause from notification, resume from the app UI before the timer elapses, confirm no vibration/VPN restart occurs once the original timer would have fired.
- No unit/instrumentation test added for this alarm-scheduling behavior — the existing test suite doesn't appear to cover `WidgetAdmin`/`ActivityMain` alarm interactions, and Robolectric coverage of `AlarmManager` scheduling would be a larger addition than this minimal fix warrants.