### PR TITLE
Fix dead toggle for ambiguous shared-IP trackers in tracker list

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -279,6 +279,31 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     return tv;
                 }
 
+                @Override
+                public boolean areAllItemsEnabled() {
+                    return false;
+                }
+
+                @Override
+                public boolean isEnabled(int pos) {
+                    Tracker t = getItem(pos);
+                    return t == null || !isAmbiguousDeadToggle(t);
+                }
+
+                /**
+                 * Ambiguous shared-IP trackers are always allowed at runtime outside
+                 * Strict mode (see BlockingModeLogic#blocksAmbiguousTrackerIp), no
+                 * matter their configured blocked state. Tapping such a row would
+                 * silently toggle hidden state with no runtime effect, so it must be
+                 * treated as non-interactive rather than shown as a dead toggle.
+                 */
+                private boolean isAmbiguousDeadToggle(Tracker t) {
+                    return trackerProtectionEnabled
+                            && !BlockingMode.isMinimalMode(getContext())
+                            && !BlockingMode.isStrictMode(getContext())
+                            && t.isAllowedInStandardMode();
+                }
+
                 private void updateText(TextView tv, Tracker t) {
                     String name = t.getName();
                     if (name.equals(TRACKER_HOSTLIST))
@@ -291,6 +316,8 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     List<String> sortedHosts = new ArrayList<>(t.getHosts());
                     Collections.sort(sortedHosts);
                     String hosts = TextUtils.join("\n• ", sortedHosts);
+
+                    boolean uncertainAllowed = isAmbiguousDeadToggle(t);
 
                     Spannable spannable;
                     boolean showStatus;
@@ -321,7 +348,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         String text = String.format("%s\n• %s", title, hosts);
                         spannable = new SpannableString(text);
                     } else {
-                        String status = getContext().getString(companyBlocked ? R.string.blocked : R.string.allowed);
+                        String status = getContext().getString(uncertainAllowed
+                                ? R.string.allowed_shared_ip
+                                : (companyBlocked ? R.string.blocked : R.string.allowed));
                         int color = ContextCompat.getColor(getContext(),
                                 companyBlocked ? R.color.colorPrimary : R.color.colorAccent);
 
@@ -341,6 +370,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
                     tv.setText(spannable, TextView.BufferType.SPANNABLE);
+                    // Grey out ambiguous shared-IP rows: they are non-interactive
+                    // (see isEnabled above), so the toggle isn't a dead click.
+                    tv.setEnabled(!uncertainAllowed);
                 }
             };
             holder.mCompaniesList.setAdapter(trackersAdapter);
@@ -381,6 +413,15 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                         Tracker t = trackersAdapter.getItem(i);
                         if (t == null)
                             return;
+
+                        // Ambiguous shared-IP trackers are always allowed at runtime
+                        // outside Strict mode. The row is marked non-interactive via
+                        // the adapter's isEnabled(), but guard here too in case a
+                        // click still reaches us, instead of silently doing nothing.
+                        if (!BlockingMode.isStrictMode(mContext) && t.isAllowedInStandardMode()) {
+                            Toast.makeText(mContext, R.string.allowed_shared_ip, Toast.LENGTH_SHORT).show();
+                            return;
+                        }
 
                         final boolean blockedTrackerCategory = b.blocked(mAppUid, t.category);
                         if (!blockedTrackerCategory) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -658,6 +658,7 @@ Sincerely,\n\n]]></string>
     <string name="analysis_queued">Analysis queued…</string>
     <string name="blocked">BLOCKED</string>
     <string name="allowed">ALLOWED</string>
+    <string name="allowed_shared_ip">Allowed — shared IP; enable Strict mode to block</string>
 
     <string name="setting_domain_based_blocked">Domain-based Blocking</string>
     <string name="summary_domain_based_blocking">Allows more granular blocking. Still in development.</string>


### PR DESCRIPTION
Fixes #576

## Root cause

In `net.kollnig.missioncontrol.details.TrackersListAdapter` (`onBindViewHolder`'s anonymous `ArrayAdapter<Tracker>`), the per-row status is recomputed on every bind. For trackers where `Tracker#isAllowedInStandardMode()` is true (ambiguous shared-IP hosts — `ACCESS_UNCERTAIN_MIXED_TRACKER_AND_NON_TRACKER`, see `TrackerList.java`), the display is force-pinned back to `ALLOWED` in non-Strict mode:

```java
if (companyBlocked
        && !BlockingMode.isStrictMode(getContext())
        && t.isAllowedInStandardMode()) {
    companyBlocked = false; // display forced to ALLOWED
}
```

This is correct — the runtime genuinely only blocks such ambiguous shared-IP hosts in Strict mode (`BlockingModeLogic#blocksAmbiguousTrackerIp`, `ServiceSinkhole.java`). The bug is that the row's click handler (`holder.mCompaniesList.setOnItemClickListener`) still called `b.block()`/`b.unblock()` and `notifyDataSetChanged()` unconditionally. Since the very next bind always re-pins the label back to `ALLOWED`, the row behaved as a **dead toggle**: it looked active (an enabled row with a switch-adjacent list item), but tapping it had no visible or runtime effect. Reporters saw this on domains such as an Amazon ad domain under the `gasbuddy` app.

## Fix (UI-only — no runtime/blocking semantics changed)

- Added `Tracker`-aware `isEnabled(int)` / `areAllItemsEnabled()` overrides on the row `ArrayAdapter` so ambiguous shared-IP rows are non-interactive at the `ListView` level (mirrors the existing pattern used for read-only rows in Minimal mode, `TrackersListAdapter.java` ~348-355).
- Added a defensive guard inside the shared `OnItemClickListener` so that even if a click somehow still reaches the handler, it shows an informative `Toast` instead of silently toggling hidden state.
- Replaced the misleading `ALLOWED` label on these specific rows with a new string resource, `allowed_shared_ip`: *"Allowed — shared IP; enable Strict mode to block"*.
- Grey out (`setEnabled(false)`) the row's `TextView` for these entries for visual/accessibility consistency, and reset `setEnabled(true)` on other rows to account for `ListView` view recycling.

Runtime blocking logic (`BlockingModeLogic`, `ServiceSinkhole`) is untouched — this only fixes the UI to stop presenting a functional-looking control that has no effect outside Strict mode.

## Screenshots

Not available in this environment (no emulator/device attached to this session). **A maintainer should visually confirm the new row state** (greyed text, updated label, no response to tap) before merging, ideally on a device/app with an ambiguous shared-IP tracker (e.g. an Amazon-ad-domain case like the original report).

## Testing

- [x] `./gradlew :app:compileGithubDebugJavaWithJavac` — passes (also exercised the Rust `wgbridgeBuild` preBuild step successfully)
- [ ] Manual on-device verification of the new row state (not done — no device available in this session)
- [ ] Confirm normal (non-ambiguous) tracker rows still toggle correctly in Standard mode (no regression expected, but not manually re-verified on-device)

🤖 Generated with [Claude Code](https://claude.com/claude-code)