### PR TITLE
Add optional TCP MSS clamp for tethering PMTUD failures (#478)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -720,6 +720,10 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             ServiceSinkhole.reload("changed " + name, this, false);
         }
 
+        else if ("tcp_mss_clamp".equals(name)) {
+            ServiceSinkhole.reload("changed " + name, this, false);
+        }
+
         else if ("manage_system".equals(name)) {
             boolean manage = prefs.getBoolean(name, false);
             if (!manage)

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -244,7 +244,7 @@ public class ServiceSinkhole extends VpnService {
 
     private native long jni_init(int sdk);
 
-    private native void jni_start(long context, int loglevel);
+    private native void jni_start(long context, int loglevel, boolean tcpMssClamp);
 
     private native void jni_run(long context, int tun, boolean fwd53, int rcode);
 
@@ -1675,7 +1675,9 @@ public class ServiceSinkhole extends VpnService {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
         boolean log = prefs.getBoolean("log", false);
         boolean log_app = prefs.getBoolean("log_app", true);
-        Log.i(TAG, "Start native log=" + log + "/" + log_app + " filter=true");
+        boolean tcpMssClamp = prefs.getBoolean("tcp_mss_clamp", false);
+        Log.i(TAG, "Start native log=" + log + "/" + log_app +
+                " filter=true tcp_mss_clamp=" + tcpMssClamp);
 
         // Prepare rules
         prepareUidAllowed(listAllowed, listRule);
@@ -1725,7 +1727,7 @@ public class ServiceSinkhole extends VpnService {
 
         if (tunnelThread == null) {
             Log.i(TAG, "Starting tunnel thread context=" + jni_context);
-            jni_start(jni_context, prio);
+            jni_start(jni_context, prio, tcpMssClamp);
 
             tunnelThread = new Thread(new Runnable() {
                 @Override

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -170,14 +170,16 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
 
 JNIEXPORT void JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1start(
-        JNIEnv *env, jobject instance, jlong context, jint loglevel_) {
+        JNIEnv *env, jobject instance, jlong context, jint loglevel_, jboolean tcp_mss_clamp) {
     struct context *ctx = (struct context *) context;
 
     loglevel = loglevel_;
     max_tun_msg = 0;
     ctx->stopping = 0;
+    ctx->tcp_mss_clamp = tcp_mss_clamp;
 
-    log_android(ANDROID_LOG_WARN, "Starting level %d", loglevel);
+    log_android(ANDROID_LOG_WARN, "Starting level %d tcp mss clamp %d",
+                loglevel, tcp_mss_clamp);
 
 }
 

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -49,15 +49,16 @@
 #define UDP4_MAXMSG (IP_MAXPACKET - 20 - 8) // bytes (socket)
 #define UDP6_MAXMSG (IPV6_MAXPACKET - 40 - 8) // bytes (socket)
 
-// TCP MSS clamp for the SYN/SYN-ACK we inject into the tun. The tun advertises
+// Optional TCP MSS clamp for the SYN/SYN-ACK we inject into the tun. The tun advertises
 // an oversized MTU (get_mtu() == 10000), so the derived MSS (~9960) would let a
 // peer emit segments far larger than any real upstream path (cellular/WireGuard
 // are typically <= 1500). Because handle_icmp() drops the ICMPv4 "fragmentation
 // needed" / ICMPv6 "packet too big" messages that Path-MTU-Discovery relies on,
 // such oversized segments can black-hole - notably for tethered clients (#478).
 // Clamping to a conservative value keeps every segment small enough to traverse
-// typical constrained paths without depending on PMTUD. Heuristic; verify on
-// device before relying on the exact value.
+// typical constrained paths without depending on PMTUD. This is enabled only
+// by the tethering compatibility setting. Heuristic; verify on device before
+// relying on the exact value.
 #define TCP_MSS_CLAMP 1360 // bytes
 
 #define ICMP_TIMEOUT 5 // seconds
@@ -91,6 +92,7 @@ struct context {
     int pipefds[2];
     int stopping;
     int sdk;
+    jboolean tcp_mss_clamp;
     struct ng_session *ng_session;
 };
 

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -49,6 +49,17 @@
 #define UDP4_MAXMSG (IP_MAXPACKET - 20 - 8) // bytes (socket)
 #define UDP6_MAXMSG (IPV6_MAXPACKET - 40 - 8) // bytes (socket)
 
+// TCP MSS clamp for the SYN/SYN-ACK we inject into the tun. The tun advertises
+// an oversized MTU (get_mtu() == 10000), so the derived MSS (~9960) would let a
+// peer emit segments far larger than any real upstream path (cellular/WireGuard
+// are typically <= 1500). Because handle_icmp() drops the ICMPv4 "fragmentation
+// needed" / ICMPv6 "packet too big" messages that Path-MTU-Discovery relies on,
+// such oversized segments can black-hole - notably for tethered clients (#478).
+// Clamping to a conservative value keeps every segment small enough to traverse
+// typical constrained paths without depending on PMTUD. Heuristic; verify on
+// device before relying on the exact value.
+#define TCP_MSS_CLAMP 1360 // bytes
+
 #define ICMP_TIMEOUT 5 // seconds
 
 #define UDP_TIMEOUT_53 15 // seconds

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -719,13 +719,12 @@ jboolean handle_tcp(const struct arguments *args,
                 }
             }
 
-            // Clamp the MSS we use for downstream segmentation into the tun.
+            // In tethering compatibility mode, clamp the MSS we use for
+            // downstream segmentation into the tun.
             // This bounds the size of the segments we emit toward the peer so
-            // they fit constrained upstream paths even though PMTUD ICMP is
-            // dropped (#478). Applied to both the default (oversized-tun) MSS
-            // and any smaller value advertised by the peer, so smaller paths
-            // still work.
-            if (mss > TCP_MSS_CLAMP)
+            // they fit constrained paths even though PMTUD ICMP is dropped
+            // (#478). Smaller values advertised by the peer remain unchanged.
+            if (args->ctx->tcp_mss_clamp && mss > TCP_MSS_CLAMP)
                 mss = TCP_MSS_CLAMP;
 
             log_android(ANDROID_LOG_WARN, "%s new session mss %u ws %u window %u",
@@ -1274,14 +1273,15 @@ ssize_t write_tcp(const struct arguments *args, const struct tcp_session *cur,
 
     // TCP options
     if (syn) {
-        // Advertise a clamped MSS to the peer so it sizes its segments to fit
-        // constrained upstream paths without relying on PMTUD ICMP (#478).
+        // In tethering compatibility mode, advertise a clamped MSS to the peer
+        // so it sizes its segments to fit constrained upstream paths without
+        // relying on PMTUD ICMP (#478).
         // The MSS option value goes on the wire in network byte order (the
         // parser reads it with ntohs, see handle SYN above); htons is required
         // here for the clamp to take effect - the value must not be written in
         // host order.
         uint16_t mss = get_default_mss(cur->version);
-        if (mss > TCP_MSS_CLAMP)
+        if (args->ctx->tcp_mss_clamp && mss > TCP_MSS_CLAMP)
             mss = TCP_MSS_CLAMP;
 
         *(options) = 2; // MSS

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -719,6 +719,15 @@ jboolean handle_tcp(const struct arguments *args,
                 }
             }
 
+            // Clamp the MSS we use for downstream segmentation into the tun.
+            // This bounds the size of the segments we emit toward the peer so
+            // they fit constrained upstream paths even though PMTUD ICMP is
+            // dropped (#478). Applied to both the default (oversized-tun) MSS
+            // and any smaller value advertised by the peer, so smaller paths
+            // still work.
+            if (mss > TCP_MSS_CLAMP)
+                mss = TCP_MSS_CLAMP;
+
             log_android(ANDROID_LOG_WARN, "%s new session mss %u ws %u window %u",
                         packet, mss, ws, ntohs(tcphdr->window) << ws);
 
@@ -1265,9 +1274,19 @@ ssize_t write_tcp(const struct arguments *args, const struct tcp_session *cur,
 
     // TCP options
     if (syn) {
+        // Advertise a clamped MSS to the peer so it sizes its segments to fit
+        // constrained upstream paths without relying on PMTUD ICMP (#478).
+        // The MSS option value goes on the wire in network byte order (the
+        // parser reads it with ntohs, see handle SYN above); htons is required
+        // here for the clamp to take effect - the value must not be written in
+        // host order.
+        uint16_t mss = get_default_mss(cur->version);
+        if (mss > TCP_MSS_CLAMP)
+            mss = TCP_MSS_CLAMP;
+
         *(options) = 2; // MSS
         *(options + 1) = 4; // total option length
-        *((uint16_t *) (options + 2)) = get_default_mss(cur->version);
+        *((uint16_t *) (options + 2)) = htons(mss);
 
         *(options + 4) = 3; // window scale
         *(options + 5) = 3; // total option length

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -113,6 +113,8 @@
     <string name="setting_ip6">Enable IPv6 traffic</string>
     <string name="setting_call">Disable on call</string>
     <string name="setting_reload_onconnectivity">Reload on every connectivity change</string>
+    <string name="setting_tcp_mss_clamp">Tethering compatibility mode</string>
+    <string name="summary_tcp_mss_clamp">Limit TCP segment size to avoid stalled connections on some tethered networks. May reduce performance.</string>
 
     <string name="setting_advanced_options">Advanced options (for experts)</string>
     <string name="setting_system">Show system apps</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -57,6 +57,11 @@
                 android:title="@string/setting_reload_onconnectivity" />
             <eu.faircode.netguard.SwitchPreference
                 android:defaultValue="false"
+                android:key="tcp_mss_clamp"
+                android:summary="@string/summary_tcp_mss_clamp"
+                android:title="@string/setting_tcp_mss_clamp" />
+            <eu.faircode.netguard.SwitchPreference
+                android:defaultValue="false"
                 android:key="doh_enabled"
                 android:summary="@string/summary_doh_enabled"
                 android:title="@string/setting_doh_enabled" />


### PR DESCRIPTION
Provides an opt-in workaround for the tethering stalls reported in #478.

## Problem

TrackerControl's TUN uses an MTU of 10000, and the native TCP proxy can therefore use an MSS near 9960. When oversized packets are written back through the TUN toward a tethered client, the smaller downstream path may return ICMP "fragmentation needed" / "packet too big" messages. The native ICMP handler does not currently process those PMTUD messages.

A fixed global clamp would reduce TUN aggregation for every TCP connection, increasing native reads, allocations, checksums, and writes even for users who do not encounter the tethering problem.

## Change

Adds an advanced, default-off **Tethering compatibility mode** setting.

When enabled:

- the MSS stored for a new TCP session is capped at 1360 bytes;
- injected SYN/SYN-ACK packets advertise an MSS no larger than 1360 bytes.

The preference is read once when the VPN starts and stored in the native context. Native code checks it only during TCP SYN/session setup; there is no preference lookup or additional branch for established data packets.

The existing MSS option write is also corrected to use network byte order with `htons()`. That correctness fix applies regardless of whether compatibility mode is enabled.

The global TUN MTU remains unchanged.

## Tradeoffs

1360 is a conservative heuristic, not a complete PMTUD implementation. Compatibility mode may reduce throughput and increase CPU/battery use because it produces more native socket reads and TUN writes. Keeping it opt-in limits that cost to affected users and enables direct A/B testing.

## Validation

- `:app:externalNativeBuildGithubDebug -x :app:wgbridgeBuild`: **BUILD SUCCESSFUL** for arm64-v8a, armeabi-v7a, x86, and x86_64.
- XML validation and `git diff --check`: passed.
- Full `:app:assembleGithubDebug` reached and compiled the changed native code, but the repository currently fails resource linking on unrelated Ukrainian blocking-mode string references.

## Required device testing

1. Reproduce #478 with a tethered client and confirm large TLS/download flows complete with compatibility mode enabled.
2. Confirm the same reproduction still occurs with the setting disabled.
3. Check normal phone traffic, IPv4/IPv6, and WireGuard on/off.
4. Compare throughput and battery/CPU behavior before considering enabling the workaround by default.
