### PR TITLE
Fix DNS failure on IPv6-only mobile data (accept IPv6 resolvers)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1330,38 +1330,26 @@ public class ServiceSinkhole extends VpnService {
         String vpnDns2 = prefs.getString("dns2", null);
         Log.i(TAG, "DNS system=" + TextUtils.join(",", sysDns) + " config=" + vpnDns1 + "," + vpnDns2);
 
-        if (vpnDns1 != null)
-            try {
-                InetAddress dns = InetAddress.getByName(vpnDns1);
-                if (!(dns.isLoopbackAddress() || dns.isAnyLocalAddress()) &&
-                        (dns instanceof Inet4Address))
-                    listDns.add(dns);
-            } catch (Throwable ignored) {
-            }
+        // First pass: IPv4 resolvers only. This reproduces the historical
+        // behaviour and is preserved exactly for IPv4 and dual-stack networks —
+        // wherever a working IPv4 resolver exists, the tun keeps advertising only
+        // IPv4 DNS, so nothing changes for the working majority.
+        collectDns(listDns, vpnDns1, vpnDns2, sysDns, false);
 
-        if (vpnDns2 != null)
-            try {
-                InetAddress dns = InetAddress.getByName(vpnDns2);
-                if (!(dns.isLoopbackAddress() || dns.isAnyLocalAddress()) &&
-                        (dns instanceof Inet4Address))
-                    listDns.add(dns);
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-            }
-
-        if (listDns.size() == 2)
-            return listDns;
-
-        for (String def_dns : sysDns)
-            try {
-                InetAddress ddns = InetAddress.getByName(def_dns);
-                if (!listDns.contains(ddns) &&
-                        !(ddns.isLoopbackAddress() || ddns.isAnyLocalAddress()) &&
-                        (ddns instanceof Inet4Address))
-                    listDns.add(ddns);
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-            }
+        // Second pass: on IPv6-only networks (increasingly common on modern
+        // cellular / Android 13+ IPv6-only mobile data) the carrier hands out only
+        // IPv6 resolvers, so the IPv4-only pass above finds nothing. Previously we
+        // then fell through to hardcoded IPv4 public DNS (getDefaultDns), which is
+        // unreachable without a working CLAT/NAT64 path — so all resolution failed
+        // on mobile data. Accept the carrier's IPv6 resolvers instead. Gated on the
+        // "ip6" preference because the builder only routes/advertises IPv6 when it
+        // is enabled (see getConfig: the "ip6 || Inet4Address" DNS filter and the
+        // 2000::/3 route). The native tunnel already intercepts and blocks DNS over
+        // IPv6 (udp.c/dns.c are IP-version-agnostic). Issue #339 (part of #449).
+        if (listDns.isEmpty() && ip6) {
+            Log.i(TAG, "No IPv4 resolver available; accepting IPv6 resolvers (IPv6-only network)");
+            collectDns(listDns, vpnDns1, vpnDns2, sysDns, true);
+        }
 
         // Fallback DNS servers if none found
         if (listDns.isEmpty())
@@ -1370,6 +1358,52 @@ public class ServiceSinkhole extends VpnService {
         Log.i(TAG, "Get DNS=" + TextUtils.join(",", listDns));
 
         return listDns;
+    }
+
+    // Collect usable resolvers — custom (dns/dns2) first, then the system
+    // resolvers — into listDns, mirroring the historical selection order and the
+    // "stop once two custom entries are set" short-circuit. allowIp6=false keeps
+    // the original IPv4-only filtering; allowIp6=true additionally accepts IPv6
+    // resolvers (used as an IPv6-only-network fallback, see getDns).
+    private static void collectDns(List<InetAddress> listDns, String vpnDns1,
+                                   String vpnDns2, List<String> sysDns, boolean allowIp6) {
+        if (vpnDns1 != null)
+            try {
+                InetAddress dns = InetAddress.getByName(vpnDns1);
+                if (isUsableDns(dns, allowIp6) && !listDns.contains(dns))
+                    listDns.add(dns);
+            } catch (Throwable ignored) {
+            }
+
+        if (vpnDns2 != null)
+            try {
+                InetAddress dns = InetAddress.getByName(vpnDns2);
+                if (isUsableDns(dns, allowIp6) && !listDns.contains(dns))
+                    listDns.add(dns);
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
+
+        if (listDns.size() == 2)
+            return;
+
+        for (String def_dns : sysDns)
+            try {
+                InetAddress ddns = InetAddress.getByName(def_dns);
+                if (isUsableDns(ddns, allowIp6) && !listDns.contains(ddns))
+                    listDns.add(ddns);
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
+    }
+
+    // A resolver is usable if it is a real remote address (not loopback / any-local)
+    // and of a family the tun will actually carry: IPv4 always, IPv6 only when
+    // allowed (i.e. IPv6 routing is enabled and no IPv4 resolver was available).
+    private static boolean isUsableDns(InetAddress dns, boolean allowIp6) {
+        if (dns.isLoopbackAddress() || dns.isAnyLocalAddress())
+            return false;
+        return (dns instanceof Inet4Address) || (allowIp6 && dns instanceof Inet6Address);
     }
 
     private static List<InetAddress> getWireGuardDns(net.kollnig.missioncontrol.wg.WgConfig config) {


### PR DESCRIPTION
Fixes #339. Likely also fixes the **mobile-data half of #449** (`#449` bundles a Wi-Fi symptom and a cellular symptom; this addresses the cellular one). Work item **WI-4** in the open-issue triage.

## Symptom
All DNS resolution fails on mobile data (apps can't load anything), while dual-stack Wi-Fi works fine. Common on modern IPv6-only cellular networks (Android 13+ mobile data).

## Root cause
`ServiceSinkhole.getDns()` rejected **every** non-IPv4 resolver via three `dns instanceof Inet4Address` gates (custom `dns`, custom `dns2`, and each system resolver). On an IPv6-only cellular network the carrier hands out only IPv6 DNS servers, so all of them were discarded and the method fell through to hardcoded IPv4 public DNS (`getDefaultDns`). Those IPv4 addresses are unreachable from the tun without a working CLAT/NAT64 path, so name resolution failed entirely on mobile data.

## Fix
Accept IPv6 resolvers, but conservatively:

- **First pass — IPv4 only** (`collectDns(..., allowIp6=false)`): reproduces the historical selection exactly (custom `dns`/`dns2` first, then system resolvers, with the same "stop once two custom entries are set" short-circuit). Wherever a working IPv4 resolver exists, the tun keeps advertising **only** IPv4 DNS — so IPv4 and dual-stack networks are unchanged.
- **Second pass — IPv6 fallback** (`allowIp6=true`): runs **only** when the IPv4 pass found nothing **and** the `ip6` preference is enabled. This is exactly the IPv6-only-cellular case. The carrier's IPv6 resolvers are then used instead of the unreachable hardcoded IPv4 fallback.

The change is confined to the `getDns` region (~lines 1322-1406); two small private helpers (`collectDns`, `isUsableDns`) were extracted to avoid duplicating the selection logic across the two passes.

### Why the downstream path already supports this
I traced every consumer of `getDns()` before widening the filter:

- **VPN builder** (`getConfig`, ~line 1543): already gates each server on `if (ip6 || dns instanceof Inet4Address)` and already routes `2000::/3` into the tun when `ip6` is enabled (~line 1624). It was ready to receive IPv6 DNS; only `getDns()` was withholding them.
- **Native tunnel** (`jni/netguard/udp.c`, `dns.c`): IPv6 UDP sessions are fully parsed, and `parse_dns_response` is invoked for **any** session whose destination port is 53 regardless of IP version. The block decision (`is_domain_blocked(qname)`) and the in-place response rewrite are domain-string based and IP-version-agnostic, so tracker detection/blocking works identically over IPv6 DNS.
- **DoH fallback** (`DnsProxyServer.resolveViaStandardDns`): uses a `DatagramSocket` (works for IPv6) and runs inside TC's own process, which is excluded from the VPN, so its IPv6 upstream traffic goes over the physical network. This path is *improved* by the fix.
- **`AdapterLog`**: display-only highlighting of the first two DNS servers; IPv6-safe.

No native/C changes were required.

## Testing / Risk — needs on-device validation ⚠️
I could **not** validate this on real hardware — I have no IPv6-only cellular device/SIM or NAT64/CLAT test network in this environment. What was verified:

- ✅ Compiles: `./gradlew :app:compileGithubDebugJavaWithJavac` (BUILD SUCCESSFUL) against the PR base.
- ✅ Static trace of the full DNS consumption path (builder, native tunnel, DoH proxy, log adapter) confirms IPv6 DNS is carried, intercepted, and blocked correctly.
- ✅ Logic review confirms IPv4/dual-stack output is byte-for-byte the historical behaviour (the IPv6 pass cannot run when any IPv4 resolver is found).

**Please validate on real networks before merging:**
1. **IPv6-only cellular** (the target fix): confirm apps resolve/load and that tracker blocking still works. New logcat line `No IPv4 resolver available; accepting IPv6 resolvers (IPv6-only network)` should appear, and `Get DNS=` should list the carrier's IPv6 addresses.
2. **464XLAT / NAT64 carriers**: confirm no regression where CLAT was previously masking the bug.
3. **Dual-stack Wi-Fi and IPv4-only**: confirm DNS and tracker detection are unchanged (expect only IPv4 in `Get DNS=`).
4. **`ip6` preference disabled** on an IPv6-only network: behaviour intentionally unchanged (IPv6 not routed, so IPv6 DNS is not advertised) — verify no crash.
5. **Custom DNS** (`dns`/`dns2`) set to IPv6 addresses on an IPv6-enabled network: confirm they are honoured.

### Risk
Low and well-scoped: no packet-path/native changes, no new background/network work (battery-neutral), and the working IPv4/dual-stack majority is provably unaffected because the IPv6 pass is a strict no-IPv4-found fallback.

Fixes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)