### PR TITLE
Don't self-disable on OS-initiated VPN revoke (fix #526, #331)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3147,11 +3147,37 @@ public class ServiceSinkhole extends VpnService {
     public void onRevoke() {
         Log.i(TAG, "Revoke");
 
-        // Disable firewall (will result in stop command)
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        prefs.edit().putBoolean("enabled", false).apply();
+        // Android does not tell us *why* onRevoke() fired. The system calls it
+        // identically for (a) a deliberate user disable from the system VPN
+        // settings, (b) another VPN app taking the single VPN slot (#331), and
+        // (c) an OS-initiated teardown/re-auth of the always-on slot — Doze,
+        // memory pressure, an OS update — which is the "always-on VPN turns
+        // itself off after 3-5 days" report (#526).
+        //
+        // We deliberately do NOT persist enabled=false here. Every genuine
+        // in-app disable path (the main toggle in ActivityMain, the quick-
+        // settings tile in ServiceTileMain, and the widget in WidgetAdmin)
+        // already sets enabled=false *itself* before stopping the service, and
+        // tearing down our own tunnel does not trigger onRevoke(). So a revoke
+        // reaching this method is always externally initiated. Clearing
+        // "enabled" here used to turn every such external teardown into a
+        // permanent self-disable with no recovery: the service is START_STICKY
+        // and onStartCommand() keys off "enabled", so once it is false every
+        // subsequent (re)start immediately stops again.
+        //
+        // Leaving "enabled" untouched lets the existing recovery mechanisms
+        // re-establish the tunnel once TC reacquires the VPN slot: the OS
+        // restarting the always-on service, ReceiverAutostart on boot, the
+        // watchdog alarm, and reopening ActivityMain (which calls start() when
+        // enabled). We do not add any retry loop here, so a second VPN that
+        // legitimately holds the slot is not thrashed — recovery is driven only
+        // by those OS-paced triggers. The remaining tradeoff is that a user who
+        // disables TC via the *system* VPN settings (rather than the in-app
+        // toggle) will see it come back on the next such trigger; the in-app
+        // toggle remains the supported way to turn TC off.
 
-        // Feedback
+        // Feedback: the tunnel really did drop, so inform the user (mirrors
+        // Android's own "VPN disconnected" notice). This does not disable TC.
         showDisabledNotification();
         WidgetMain.updateWidgets(this);
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,7 +302,7 @@
     <string name="msg_started">Looking for trackers...</string>
     <string name="msg_waiting">Waiting for event</string>
     <string name="msg_disabled">Use the switch above to enable TrackerControl.</string>
-    <string name="msg_revoked">TrackerControl has been disabled, likely by using another VPN based app</string>
+    <string name="msg_revoked">TrackerControl was disconnected, likely by another VPN app or the system. It will reconnect automatically when possible.</string>
     <string name="msg_installed">Problems with %1$s?</string>
     <string name="msg_installed_description">Allow app to contact companies</string>
     <string name="msg_installed_tracker_libraries_found">Contains %d tracker libraries</string>


### PR DESCRIPTION
Fixes #526. Likely also fixes #331.

This is work item **WI-5** from `OPEN_ISSUES_TRIAGE.md`. Draft for maintainer review — this is a reliability change that cannot be fully validated without multi-day, on-device always-on testing.

## Symptom
- **#526** — an always-on VPN "turns itself off after 3–5 days"; the user gets Android's "VPN disconnected" notification and must manually re-enable TC.
- **#331** — enabling another VPN permanently disables TC with no recovery.

## Root cause
`ServiceSinkhole.onRevoke()` unconditionally did `prefs.edit().putBoolean("enabled", false)`. The service is `START_STICKY` and `onStartCommand()` keys off the `enabled` pref, so once it is `false` every subsequent (re)start immediately stops again.

Android does **not** tell us *why* `onRevoke()` fired — it is called identically for:
- (a) a deliberate user disable from the **system** VPN settings,
- (b) another VPN app taking the single VPN slot (#331), and
- (c) an **OS-initiated** teardown / re-auth of the always-on slot (Doze, memory pressure, OS update) — the 3–5-day self-disable (#526).

So an OS-initiated teardown was treated identically to a deliberate user disable, with no self-recovery.

## The fix
Stop persisting `enabled=false` in `onRevoke()`. Leaving `enabled` untouched lets the **existing** recovery mechanisms re-establish the tunnel once TC reacquires the VPN slot:
- the OS restarting the always-on service,
- `ReceiverAutostart` on boot,
- the watchdog alarm (if enabled), and
- reopening `ActivityMain` (which calls `start()` when `enabled`).

The revoke notification string is reworded to reflect auto-recovery rather than a permanent disable.

## Why this is safe for genuine user disables
Every genuine **in-app** disable path already sets `enabled=false` *itself* before stopping the service, and tearing down our own tunnel does **not** trigger `onRevoke()`:
- main toggle — `ActivityMain.java:285` sets `enabled=false`, then `:359` calls `ServiceSinkhole.stop(...)`;
- quick-settings tile — `ServiceTileMain.java:85-90`;
- widget — `WidgetAdmin.java:75-80`.

Therefore a revoke reaching `onRevoke()` is always *externally* initiated, so it is safe to stop treating it as a user disable.

## Design tradeoff / residual risk
- **System-settings disable ambiguity.** A user who disables TC via the **system** VPN settings (rather than the in-app toggle) will now see it come back on the next recovery trigger (app reopen / boot / always-on restart). The in-app toggle remains the supported, honest way to turn TC off. This is the deliberate ambiguity WI-5 calls out: Android cannot distinguish this case from an OS teardown.
- **No restart storm (#331).** No retry loop is added in `onRevoke()`; after `super.onRevoke()` (which `stopSelf()`s) nothing aggressively retries. Recovery is driven only by OS-paced triggers, so a second VPN that legitimately holds the slot is not thrashed. The existing start/reload error path (`ServiceSinkhole.java:546-553`) still backs off — it declines to retry (and does not disable on a `StartFailedException`) when `VpnService.prepare() != null` — so it continues to act as the anti-thrash guard when TC is not the authorized VPN.
- **State/UI inconsistency window.** Between an external revoke and the next recovery trigger, the app toggle reads "on" while the tunnel is down. This is a deliberate trade for always-on reliability (the previous behaviour showed "off" honestly but never recovered).

## Testing
- ✅ Compiles: `./gradlew :app:compileGithubDebugJavaWithJavac` (BUILD SUCCESSFUL; also builds the Rust `wgbridge` via `preBuild`).
- ✅ Traced all genuine user-disable paths (UI toggle / tile / widget) to confirm they set `enabled=false` independently of `onRevoke()`.
- ✅ Traced the start/reload error path to confirm the anti-thrash back-off remains intact.
- ⚠️ **Not** validated on-device: the 3–5-day always-on teardown recovery (#526) and the another-VPN-then-recovery flow (#331) need real always-on / multi-day device testing. Please verify: (1) genuine in-app disable still stops TC and keeps it off; (2) after an external revoke, TC recovers on app reopen / boot / always-on restart; (3) no wakeup/notification storm when another VPN holds the slot for an extended period.

🤖 Generated with [Claude Code](https://claude.com/claude-code)