### PR TITLE
Fix Fragment view leak and edge-to-edge/contrast UI polish issues

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
@@ -21,6 +21,9 @@ import android.widget.TextView;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.viewpager2.widget.ViewPager2;
@@ -51,6 +54,22 @@ public class ActivityOnboarding extends AppCompatActivity {
     private OnboardingAdapter adapter;
     private boolean slidesInitialized = false;
 
+    /**
+     * Adds the bottom system-bar (navigation bar) inset to a view's existing
+     * bottom margin, so it isn't clipped on edge-to-edge displays.
+     */
+    private void addBottomInsetMargin(View v) {
+        ViewGroup.MarginLayoutParams initialParams = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+        final int initialBottomMargin = initialParams.bottomMargin;
+        ViewCompat.setOnApplyWindowInsetsListener(v, (view, insets) -> {
+            Insets sysBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            ViewGroup.MarginLayoutParams params = (ViewGroup.MarginLayoutParams) view.getLayoutParams();
+            params.bottomMargin = initialBottomMargin + sysBars.bottom;
+            view.setLayoutParams(params);
+            return insets;
+        });
+    }
+
     private boolean isLockdownEnabled() {
         try {
             int lockdown = Settings.Secure.getInt(getContentResolver(), "always_on_vpn_lockdown", 0);
@@ -68,6 +87,12 @@ public class ActivityOnboarding extends AppCompatActivity {
         viewPager = findViewById(R.id.viewPager);
         btnNext = findViewById(R.id.btnNext);
         btnPrevious = findViewById(R.id.btnPrevious);
+
+        // Consume the bottom system-bar inset as extra margin so the Next/
+        // Previous buttons aren't clipped by the gesture/navigation bar on
+        // edge-to-edge displays.
+        addBottomInsetMargin(btnNext);
+        addBottomInsetMargin(btnPrevious);
 
         BlockingMode.enforcePlayStoreMode(this);
         setupSlides();

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
@@ -211,6 +211,14 @@ public class TrackersFragment extends Fragment {
     }
 
     @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        // Avoid leaking the SwipeRefreshLayout (and its Activity context) beyond
+        // the view's lifecycle when the Fragment instance is retained.
+        swipeRefresh = null;
+    }
+
+    @Override
     public void onDestroy() {
         super.onDestroy();
         running = false;

--- a/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
@@ -26,6 +26,9 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -108,6 +111,16 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
         list.setLayoutManager(new LinearLayoutManager(requireContext()));
         adapter = new VpnAdapter();
         list.setAdapter(adapter);
+
+        // Pad the list by the bottom system bar inset so the last row isn't
+        // obscured by the gesture/navigation bar on edge-to-edge displays.
+        final int listInitialBottom = list.getPaddingBottom();
+        ViewCompat.setOnApplyWindowInsetsListener(list, (v, insets) -> {
+            Insets sysBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+            v.setPadding(v.getPaddingLeft(), v.getPaddingTop(), v.getPaddingRight(),
+                    listInitialBottom + sysBars.bottom);
+            return insets;
+        });
 
         refreshUi();
         if (!isFirstTimeVpnSetup() && !isWireGuardMode())

--- a/app/src/main/res/layout/item_vpn_footer.xml
+++ b/app/src/main/res/layout/item_vpn_footer.xml
@@ -6,4 +6,5 @@
     android:padding="16dp"
     android:text="@string/vpn_manage_wireguard_profiles"
     android:textAppearance="@style/TextSmall"
-    android:textColor="?attr/colorAccent" />
+    android:textColor="@color/colorFooterLink"
+    android:textStyle="bold" />

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -3,4 +3,9 @@
     <color name="colorPrimary">#fb8c00</color>
     <color name="colorPrimaryDark">#c25e00</color>
     <color name="colorAccent">#4db6ac</color>
+
+    <!-- Brighter than colorAccent for low-contrast text links on the dark
+         (near-black) surface, e.g. the "Manage WireGuard profiles" footer
+         link. See issue #560. -->
+    <color name="colorFooterLink">#80cbc4</color>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -17,6 +17,11 @@
     <color name="switchTrackActive">@color/colorAccent</color>
     <color name="switchTrackNormal">#888</color>
 
+    <!-- Link/action color for footer-style text links (e.g. "Manage WireGuard
+         profiles"). Same as colorAccent in light mode; overridden with a
+         brighter tone in values-night for contrast against a dark surface. -->
+    <color name="colorFooterLink">@color/colorAccent</color>
+
     <color name="colorSend">#FF0000</color>
     <color name="colorReceive">#0000FF</color>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -91,6 +91,13 @@
 
     <style name="RocketSwitch.NoIcon">
         <item name="thumbIcon">@null</item>
+        <!-- Restore the standard Material3 track outline (suppressed via
+             transparent trackDecorationTint in RocketSwitch) so the inactive
+             track reads as a switch rather than a bare thumb. Scoped to
+             .NoIcon only (used by the traffic log toggle), leaving the
+             rocket-icon RocketSwitch (main enable switch) untouched.
+             See issue #559. -->
+        <item name="trackDecorationTint">?attr/colorOutline</item>
     </style>
 
     <!-- ActionBar with colorPrimary background and white icons/text -->


### PR DESCRIPTION
Five small, independent UI-polish fixes, batched into one PR per the triage in `OPEN_ISSUES_TRIAGE.md` (WI-7, WI-8). Draft PR for maintainer review.

## Checklist

- [x] Fixes #586 — `TrackersFragment` held its `SwipeRefreshLayout` in a field with no `onDestroyView()`, leaking the View (and Activity context) on every details-screen recreation. Added `onDestroyView()` that nulls the field.
- [x] Fixes #575 — The WireGuard/VPN screen's RecyclerView had no bottom window-inset handling, so the last row was hidden under the gesture/navigation bar. Added a per-view `WindowInsetsCompat` listener in `VpnFragment` (mirrors the pattern already used in `ActivityLog`/`ActivitySettings`/`DetailsActivity`/`ActivityMain`); did not touch `ActivityMain.java`.
- [x] Fixes #551 — The onboarding Next/Previous buttons used a flat 16dp bottom margin, so they could be clipped by the nav bar on edge-to-edge displays. Added a bottom-inset-consuming margin listener in `ActivityOnboarding`.
- [x] Fixes #560 — The "Manage WireGuard profiles" footer link used `?attr/colorAccent`, which in night mode (`#4db6ac`) reads as muted/low-contrast against the dark surface. Added a brighter dedicated `colorFooterLink` for night mode and made the text bold so it clearly reads as a link.
- [x] Fixes #559 — The traffic-log toggle's `RocketSwitch.NoIcon` style zeroed out `trackDecorationTint`, removing the Material3 track outline and leaving the inactive track looking like a bare thumb rather than a switch. Restored the outline for that style variant only, leaving the rocket-icon main power switch (`RocketSwitch`, used by `ActivityMain`) untouched.

## Notes

- Branch is based on current `origin/master` (includes PR #597 inset fixes and PR #539 code-review fixes), so the diff here is limited to these five changes.
- Did not touch `ActivityMain.java`, `CountriesFragment.java`, or `OPEN_ISSUES_TRIAGE.md`, per scope.
- **#559 (switch styling) could not be visually verified/screenshotted in this environment — a maintainer should confirm the traffic-log toggle now reads clearly as a switch in both light and dark mode before merging.**
- #560's color choice is also worth a maintainer's eyeball pass in night mode.

## Test plan

- [x] `./gradlew :app:compileGithubDebugJavaWithJavac` — BUILD SUCCESSFUL (includes the Rust `wgbridgeBuild` step via `preBuild`; `cargo` was available in this environment).
- [ ] Manual visual check of #559 (traffic-log switch) and #560 (footer link) in light/dark mode on a device or emulator.
- [ ] Manual check of #575 (VPN screen last row) and #551 (onboarding Next/Previous buttons) on an edge-to-edge (gesture nav) device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)