### PR TITLE
Transparency: label blocked/allowed in traffic log; whitelist Cloudflare CDN (WI-6: #554, #561, #358)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -159,6 +159,7 @@ public class AdapterLog extends CursorAdapter {
         final TextView tvDaddr = view.findViewById(R.id.tvDAddr);
         TextView tvDPort = view.findViewById(R.id.tvDPort);
         final TextView tvOrganization = view.findViewById(R.id.tvOrganization);
+        TextView tvStatus = view.findViewById(R.id.tvStatus);
         final ImageView ivIcon = view.findViewById(R.id.ivIcon);
         TextView tvUid = view.findViewById(R.id.tvUid);
         TextView tvData = view.findViewById(R.id.tvData);
@@ -167,6 +168,17 @@ public class AdapterLog extends CursorAdapter {
 
         // Show time
         tvTime.setText(new SimpleDateFormat("HH:mm:ss").format(time));
+
+        // Show blocked/allowed status as a clear text label (not just the tinted icon)
+        if (allowed < 0)
+            tvStatus.setVisibility(View.GONE);
+        else {
+            tvStatus.setVisibility(View.VISIBLE);
+            tvStatus.setText(allowed > 0 ? R.string.allowed : R.string.blocked);
+            tvStatus.setTextColor(context.getColor(allowed > 0
+                    ? R.color.timeline_allowed
+                    : R.color.timeline_blocked));
+        }
 
         // Show connection type
         if (connection <= 0)

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -58,9 +58,17 @@ import eu.faircode.netguard.ServiceSinkhole;
  */
 public class TrackerList {
     private static final String TAG = TrackerList.class.getSimpleName();
+    // Shared CDN registrable domains that host legitimate content for many
+    // sites and therefore cause false positives when a tracker shares the same
+    // infrastructure. Matched exactly against the domains listed in the
+    // blocklists. Note: Cloudflare's own analytics beacon
+    // (cloudflareinsights.com) is deliberately NOT ignored here so it stays
+    // blockable — only the general Cloudflare CDN domain (which fronts e.g.
+    // cdnjs.cloudflare.com) is whitelisted.
     private static final Set<String> ignoreDomains = new HashSet<>(Arrays.asList(
             "cloudfront.net",
-            "fastly.net"));
+            "fastly.net",
+            "cloudflare.com"));
     private static final Map<String, Tracker> hostnameToTracker = new ConcurrentHashMap<>();
     public static String TRACKER_HOSTLIST = "TRACKER_HOSTLIST";
     private static final Tracker hostlistTracker = new Tracker(TRACKER_HOSTLIST, UNCATEGORISED);

--- a/app/src/main/res/layout/log.xml
+++ b/app/src/main/res/layout/log.xml
@@ -81,6 +81,15 @@
             android:layout_weight="1"
             android:orientation="vertical">
 
+            <TextView
+                android:id="@+id/tvStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextSmall"
+                android:textSize="12sp"
+                android:textStyle="bold"
+                tools:text="BLOCKED" />
+
             <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
## WI-6 — Transparency: blocked connections invisible / unlabelled

Fixes the *visibility* half of WI-6. References #554, #561, #358.

### Problem
- **#561:** In the raw traffic log (`AdapterLog`), blocked-vs-allowed was encoded **only** via a small tinted connection icon (`AdapterLog.java` ~173/181-182) — no text. The newer tracker Timeline (`TimelineAdapter` ~176-188) already labels this clearly.
- **#554 (partial):** Legitimate Cloudflare-fronted content was over-blocked as a shared-IP tracker. The shared-CDN false-positive whitelist `TrackerList.ignoreDomains` (~61-63) covered `cloudfront.net`/`fastly.net` but not Cloudflare.
- **#554 / #358:** A blocked connection with no recognised-tracker mapping has no row in the per-app list, so "no way to unblock" (see *Out of scope*).

### What changed
**1. Traffic log now labels blocked/allowed (#561)** — `AdapterLog.java` + `res/layout/log.xml`
- Added a per-row coloured text label (`BLOCKED` red / `ALLOWED` green), mirroring the `TimelineAdapter` idiom. Reuses existing resources `R.string.blocked` / `R.string.allowed` and `R.color.timeline_blocked` / `R.color.timeline_allowed`. Label is hidden when the allowed state is unknown (`allowed < 0`).

**2. Whitelist Cloudflare's shared CDN (#554 partial)** — `TrackerList.java`
- Added `cloudflare.com` to `ignoreDomains`. Verified the mechanism first: `isIgnoredDomain()` does an **exact** registrable-domain match against the domains listed in the blocklists. In the Disconnect list Cloudflare appears as `cloudflare.com` (the shared CDN fronting e.g. `cdnjs.cloudflare.com`), `cloudflareinsights.com` (its Web Analytics beacon), and `cloudflarestream.com`. `cloudflare.com` is the correct analogue of `cloudfront.net`/`fastly.net`; the analytics beacon `cloudflareinsights.com` is **deliberately left blockable** (exact match won't touch it).

### Root cause (attribution half — see *Out of scope*)
`updateAccess`, which feeds the per-app tracker list, runs only when `isTracker` is true (`ServiceSinkhole.java` ~978), while the raw log is written whenever logging is on (~974). In addition, `TrackerList.getAppTrackers()` (~337-339) *skips* any access row where `findTracker(host) == null`. So a blocked-but-unrecognised connection has no toggleable per-app row.

### Deliberately out of scope
- **Surfacing blocked-but-unattributed connections as toggleable per-app rows (#554/#358 "no way to unblock").** A correct fix would require (a) changing the access-table population policy to write **non-tracker** rows — flooding a per-app table with every host each app contacts (battery/DB/philosophy regression), (b) redesigning `getAppTrackers()` to emit an "unknown" category, and (c) a new per-app/per-host block mechanism that does not exist. Crucially it would still be **dishonest**: the block decision is IP-based off the **UID-global** `dns` table (no `uid` column) — the deliberately-deferred attribution limitation documented in `TODO.md` and triage §C-3. Left for a dedicated attribution redesign rather than papered over here.
- **Merge-friction note:** kept edits away from the `ServiceSinkhole.getDns` region (~1330-1450) and the `TrackerList.loadTrackers`/JSON-parse region (~178/524) that concurrent PRs touch.

### Testing
- `./gradlew :app:compileGithubDebugJavaWithJavac` compiled cleanly (Java + resources) on first run. Only Java/resources were touched; no packet-path change.
- **I could not capture screenshots.** A maintainer should visually confirm the new `BLOCKED`/`ALLOWED` labels in the traffic log render correctly in light and dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
