### PR TITLE
Make filtered-but-hidden apps reachable via search (#420, #483)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -64,6 +64,7 @@ import net.kollnig.missioncontrol.data.InternetBlocklist;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> implements Filterable {
@@ -421,7 +422,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
             @Override
             protected FilterResults performFiltering(CharSequence query) {
                 List<Rule> listResult = new ArrayList<>();
-                String queryStr = query == null ? "" : query.toString().toLowerCase().trim();
+                String queryStr = query == null ? "" : query.toString().toLowerCase(Locale.ROOT).trim();
                 if (queryStr.isEmpty())
                     listResult.addAll(listAll);
                 else {
@@ -435,8 +436,8 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                     // but filtered apps stay reachable (#420, #483).
                     for (Rule rule : getSearchPool())
                         if (rule.uid == uid ||
-                                rule.packageName.toLowerCase().contains(queryStr) ||
-                                (rule.name != null && rule.name.toLowerCase().contains(queryStr)))
+                                rule.packageName.toLowerCase(Locale.ROOT).contains(queryStr) ||
+                                (rule.name != null && rule.name.toLowerCase(Locale.ROOT).contains(queryStr)))
                             listResult.add(rule);
                 }
 

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -62,7 +62,9 @@ import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> implements Filterable {
     private static final String TAG = "TrackerControl.Adapter";
@@ -78,8 +80,13 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
     private boolean wifiActive = true;
     private boolean otherActive = true;
     private boolean live = true;
+    private final Context appContext;
     private List<Rule> listAll = new ArrayList<>();
     private List<Rule> listFiltered = new ArrayList<>();
+    // Full installed-app set used only for search, so apps hidden from the visible
+    // list by the display filters remain reachable (#420, #483). Built lazily and
+    // invalidated whenever the visible list is replaced.
+    private List<Rule> searchPool = null;
     private int iconSize;
     private final RequestOptions glideOptions;
     private String cachedSort;
@@ -106,6 +113,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
     public AdapterRule(Context context, View anchor) {
         this.anchor = anchor;
+        this.appContext = context.getApplicationContext();
         this.inflater = LayoutInflater.from(context);
         this.glideOptions = new RequestOptions().format(DecodeFormat.PREFER_RGB_565);
 
@@ -147,6 +155,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
     public void set(List<Rule> listRule) {
         listAll = listRule;
+        searchPool = null; // rebuilt lazily on next search
         List<Rule> oldList = listFiltered;
         listFiltered = new ArrayList<>(listRule);
         DiffUtil.DiffResult result = DiffUtil.calculateDiff(new RuleDiffCallback(oldList, listFiltered));
@@ -379,23 +388,52 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         }
     }
 
+    /**
+     * The set searched by the search box. It is the visible list plus every other installed
+     * app, so apps hidden by the display filters (system / frozen / no-internet) but still
+     * routed and filtered by TC can be found and configured (#420, #483). Visible apps keep
+     * their fully-populated rules (with tracker counts); hidden apps are added as lightweight
+     * stubs. Built once per visible-list update and cached.
+     */
+    private synchronized List<Rule> getSearchPool() {
+        if (searchPool != null)
+            return searchPool;
+
+        List<Rule> pool = new ArrayList<>(listAll);
+        Set<String> present = new HashSet<>();
+        for (Rule rule : listAll)
+            present.add(rule.packageName);
+        try {
+            for (Rule stub : Rule.getSearchStubs(appContext))
+                if (!present.contains(stub.packageName))
+                    pool.add(stub);
+        } catch (Throwable ex) {
+            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+        }
+
+        searchPool = pool;
+        return pool;
+    }
+
     @Override
     public Filter getFilter() {
         return new Filter() {
             @Override
             protected FilterResults performFiltering(CharSequence query) {
                 List<Rule> listResult = new ArrayList<>();
-                if (query == null)
+                String queryStr = query == null ? "" : query.toString().toLowerCase().trim();
+                if (queryStr.isEmpty())
                     listResult.addAll(listAll);
                 else {
-                    String queryStr = query.toString().toLowerCase().trim();
                     int uid;
                     try {
                         uid = Integer.parseInt(queryStr);
                     } catch (NumberFormatException ignore) {
                         uid = -1;
                     }
-                    for (Rule rule : listAll)
+                    // Search the full installed-app set, not just the visible list, so hidden
+                    // but filtered apps stay reachable (#420, #483).
+                    for (Rule rule : getSearchPool())
                         if (rule.uid == uid ||
                                 rule.packageName.toLowerCase().contains(queryStr) ||
                                 (rule.name != null && rule.name.toLowerCase().contains(queryStr)))

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -513,6 +513,52 @@ public class Rule {
         }
     }
 
+    /**
+     * Build a lightweight list of rules for ALL installed applications, for search only.
+     *
+     * The visible list built by {@link #getRules} applies the show_system / show_frozen /
+     * show_nointernet display filters. An app hidden by those filters (e.g. an OEM-preinstalled
+     * app that TC routes because "include system apps" is on, a frozen package, or a shared-UID
+     * sibling) can still be routed through the tun and filtered/blocked by UID, yet be absent
+     * from the list and therefore unreachable — the user cannot open it to add an exception or
+     * exclude it. That is the "blocked but not listed" breakage reported in issues #420
+     * (Instagram) and #483 (Feeder), whose only workaround is disabling TC entirely.
+     *
+     * Search therefore must reach every installed app, not just the currently-visible subset.
+     * This intentionally skips the expensive / side-effecting work in getRules (tracker counts,
+     * default seeding, sorting, snackbars): stubs only need enough to be matched by the search
+     * filter and to open the per-app details screen (name, package, uid, internet).
+     */
+    public static List<Rule> getSearchStubs(Context context) {
+        synchronized (context.getApplicationContext()) {
+            List<Rule> listStub = new ArrayList<>();
+
+            SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
+            SharedPreferences tracker_protect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+            SharedPreferences notify = context.getSharedPreferences("notify", Context.MODE_PRIVATE);
+
+            DatabaseHelper dh = DatabaseHelper.getInstance(context);
+            for (PackageInfo info : getPackages(context))
+                try {
+                    // Skip self
+                    if (info.applicationInfo.uid == Process.myUid())
+                        continue;
+
+                    Rule rule = new Rule(dh, info, context);
+                    rule.apply = apply.getBoolean(info.packageName, true);
+                    rule.tracker_protect = BlockingMode.isTrackerProtectionEnabled(
+                            context, tracker_protect, info.packageName);
+                    rule.notify = notify.getBoolean(info.packageName, true);
+                    rule.updateChanged();
+                    listStub.add(rule);
+                } catch (Throwable ex) {
+                    Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                }
+
+            return listStub;
+        }
+    }
+
     private static List<String> getHandlingPackages(PackageManager pm, Intent intent) {
         List<String> packagesList = new ArrayList<>();
 


### PR DESCRIPTION
## Problem

Some installed apps are **filtered/blocked by TC but never appear in TC's app list**, so the user cannot open them to add a per-tracker exception or exclude the app. The only workaround is disabling TC entirely — the worst kind of (unescapable) breakage.

- **#420** — Instagram is blocked (DMs won't send) but is missing from the list; searching "Instagram" finds nothing.
- **#483** — Feeder (RSS reader, F-Droid) is installed but absent from the list.
- Related: **#229** "Android groups applications on UID".

## Root cause

Blocking is keyed on **UID** in the packet path (`ServiceSinkhole.isAddressAllowed` / `blockKnownTracker` / `shouldTrackApp`), and VPN routing is decided from `Rule.getRules(true, ...)` (the full app set, gated only by `!apply || (!includeSystem && system)`).

The **visible** list, however, is built by `Rule.getRules(false, ...)`, which applies the `show_system` / `show_frozen` / `show_nointernet` **display filters**. So an app hidden by one of those filters — e.g. an OEM-preinstalled package that TC routes because *"include system apps in VPN"* is enabled, a frozen package, or a shared-UID sibling (#229) — is **still routed and blocked by UID while being absent from the list**.

`AdapterRule`'s search only iterated the already-filtered visible subset (`listAll`), so the hidden-but-filtered app could not be found by search either. That matches #420's exact repro (search "Instagram" → missing).

## Fix (search-only; default view unchanged)

- `Rule.getSearchStubs(context)` — a lightweight, side-effect-free list of rules for **every installed app** (skips tracker-count queries, default seeding, sorting, snackbars). Enough to be matched by search and to open the per-app details screen.
- `AdapterRule` — search now runs over the visible list **plus every other installed app** (pool built lazily, cached, invalidated on `set()`). A hidden-but-filtered app can now be found and opened to configure an exception or exclude it. Visible apps keep their fully-populated rules (tracker counts intact). An **empty query still shows exactly the visible list**, so there is no clutter regression in the default view.

This keeps the recovery path (search → open → configure/exclude) working for any app TC can filter, without adding user-facing toggles (per the project's simplicity-over-configurability philosophy).

## Deferred (documented, not fixed here)

The underlying display-filter behaviour and shared-UID runtime attribution (#229 — the packet path resolves a UID to `getPackagesForUid(uid)[0]`, so per-package settings on a non-representative sibling may not take effect at runtime) are left intact. This change guarantees **reachability/recoverability**, which is the user-facing breakage; a fuller shared-UID attribution redesign is out of scope here.

## Testing

- `./gradlew :app:compileGithubDebugJavaWithJavac` — **BUILD SUCCESSFUL** (Rust `wgbridgeBuild` via preBuild ran; `cargo` present).
- Not verified on-device: I cannot install Instagram/Feeder to reproduce the exact hidden-app state. The change is behaviour-preserving for the default (empty-query) view and only widens the search pool. On-device confirmation that searching a hidden app now surfaces it, and that opening it lets the user exclude/except it, is still recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)