### PR TITLE
Fix cursor leaks and restore Chrome Timeline tracking

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityDns.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityDns.java
@@ -250,6 +250,8 @@ public class ActivityDns extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         running = false;
+        if (adapter != null)
+            adapter.close();
         adapter = null;
         super.onDestroy();
     }

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
@@ -22,6 +22,7 @@ package eu.faircode.netguard;
 
 
 import android.app.Activity;
+import android.os.Build;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
@@ -41,8 +42,9 @@ public class ActivityForwardApproval extends Activity {
     static {
         try {
             System.loadLibrary("netguard");
-        } catch (UnsatisfiedLinkError ignored) {
-            System.exit(1);
+        } catch (UnsatisfiedLinkError error) {
+            if (!"robolectric".equals(Build.FINGERPRINT))
+                throw error;
         }
     }
 

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -103,9 +103,7 @@ public class ActivityForwarding extends AppCompatActivity {
                         if (menuItem.getItemId() == R.id.menu_delete) {
                             DatabaseHelper.getInstance(ActivityForwarding.this).deleteForward(protocol, dport);
                             ServiceSinkhole.reload("forwarding", ActivityForwarding.this, false);
-                            adapter = new AdapterForwarding(ActivityForwarding.this,
-                                    DatabaseHelper.getInstance(ActivityForwarding.this).getForwarding());
-                            lvForwarding.setAdapter(adapter);
+                            adapter.changeCursor(DatabaseHelper.getInstance(ActivityForwarding.this).getForwarding());
                         }
                         return false;
                     }
@@ -133,6 +131,8 @@ public class ActivityForwarding extends AppCompatActivity {
     @Override
     protected void onDestroy() {
         running = false;
+        if (adapter != null)
+            adapter.close();
         adapter = null;
         if (dialog != null) {
             dialog.dismiss();
@@ -220,9 +220,7 @@ public class ActivityForwarding extends AppCompatActivity {
                                             if (running)
                                                 if (ex == null) {
                                                     ServiceSinkhole.reload("forwarding", ActivityForwarding.this, false);
-                                                    adapter = new AdapterForwarding(ActivityForwarding.this,
-                                                            DatabaseHelper.getInstance(ActivityForwarding.this).getForwarding());
-                                                    lvForwarding.setAdapter(adapter);
+                                                    adapter.changeCursor(DatabaseHelper.getInstance(ActivityForwarding.this).getForwarding());
                                                 } else
                                                     Toast.makeText(ActivityForwarding.this, ex.toString(), Toast.LENGTH_LONG).show();
                                         }

--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -277,6 +277,8 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
     @Override
     protected void onDestroy() {
         running = false;
+        if (adapter != null)
+            adapter.close();
         adapter = null;
         PreferenceManager.getDefaultSharedPreferences(this).unregisterOnSharedPreferenceChangeListener(this);
         super.onDestroy();

--- a/app/src/main/java/eu/faircode/netguard/AdapterDns.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterDns.java
@@ -59,6 +59,10 @@ public class AdapterDns extends CursorAdapter {
         colTTL = cursor.getColumnIndex("ttl");
     }
 
+    void close() {
+        changeCursor(null);
+    }
+
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
         return LayoutInflater.from(context).inflate(R.layout.dns, parent, false);

--- a/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
@@ -47,6 +47,10 @@ public class AdapterForwarding extends CursorAdapter {
         colRUid = cursor.getColumnIndex("ruid");
     }
 
+    void close() {
+        changeCursor(null);
+    }
+
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
         return LayoutInflater.from(context).inflate(R.layout.forward, parent, false);

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -127,6 +127,13 @@ public class AdapterLog extends CursorAdapter {
         this.organization = organization;
     }
 
+    void close() {
+        // CursorAdapter closes the current cursor when it is replaced. The
+        // activity owns this adapter, so release its last cursor explicitly
+        // instead of leaving it for the finalizer/StrictMode to detect.
+        changeCursor(null);
+    }
+
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
         return LayoutInflater.from(context).inflate(R.layout.log, parent, false);

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -81,6 +81,11 @@ public class AdapterLog extends CursorAdapter {
     private InetAddress vpn6 = null;
 
     public AdapterLog(Context context, Cursor cursor, boolean resolve, boolean organization) {
+        this(context, cursor, resolve, organization, true);
+    }
+
+    AdapterLog(Context context, Cursor cursor, boolean resolve, boolean organization,
+               boolean initializeNetworkConfiguration) {
         super(context, cursor, 0);
         this.resolve = resolve;
         this.organization = organization;
@@ -107,15 +112,17 @@ public class AdapterLog extends CursorAdapter {
 
         iconSize = Util.dips2pixels(24, context);
 
-        try {
-            List<InetAddress> lstDns = ServiceSinkhole.getDns(context);
-            dns1 = (lstDns.size() > 0 ? lstDns.get(0) : null);
-            dns2 = (lstDns.size() > 1 ? lstDns.get(1) : null);
-            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-            vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.1.10.1"));
-            vpn6 = InetAddress.getByName(prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1"));
-        } catch (UnknownHostException ex) {
-            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+        if (initializeNetworkConfiguration) {
+            try {
+                List<InetAddress> lstDns = ServiceSinkhole.getDns(context);
+                dns1 = (lstDns.size() > 0 ? lstDns.get(0) : null);
+                dns2 = (lstDns.size() > 1 ? lstDns.get(1) : null);
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+                vpn4 = InetAddress.getByName(prefs.getString("vpn4", "10.1.10.1"));
+                vpn6 = InetAddress.getByName(prefs.getString("vpn6", "fd00:1:fd00:1:fd00:1:fd00:1"));
+            } catch (UnknownHostException ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
         }
     }
 

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -97,11 +97,19 @@ public class Rule {
     private static List<PackageInfo> cachePackageInfo = null;
     private static Map<PackageInfo, String> cacheLabel = new HashMap<>();
     private static Map<String, Boolean> cacheSystem = new HashMap<>();
-    private static final Map<String, Boolean> cachePredefinedSystem = new HashMap<>();
-    private static boolean predefinedSystemLoaded = false;
+    private static final Object predefinedLock = new Object();
+    private static PredefinedRules cachePredefinedRules;
     private static Map<String, Boolean> cacheInternet = new HashMap<>();
     private static Map<PackageInfo, Boolean> cacheEnabled = new HashMap<>();
     private static Map<Integer, Long> trackerRecent = new HashMap<>();
+
+    private static final class PredefinedRules {
+        final Map<String, Boolean> wifiBlocked = new HashMap<>();
+        final Map<String, Boolean> otherBlocked = new HashMap<>();
+        final Map<String, Boolean> roaming = new HashMap<>();
+        final Map<String, String[]> related = new HashMap<>();
+        final Map<String, Boolean> system = new HashMap<>();
+    }
 
     public long getLastTrackerTime() {
         Long time = trackerRecent.get(uid);
@@ -126,7 +134,7 @@ public class Rule {
     public static boolean isSystem(String packageName, Context context) {
         if (!cacheSystem.containsKey(packageName)) {
             boolean system = Util.isSystem(packageName, context);
-            Boolean predefined = getPredefinedSystem(context).get(packageName);
+            Boolean predefined = getPredefinedRules(context).system.get(packageName);
             cacheSystem.put(packageName, resolveSystemClassification(system, predefined));
         }
         return cacheSystem.get(packageName);
@@ -136,26 +144,43 @@ public class Rule {
         return predefined == null ? system : predefined;
     }
 
-    private static Map<String, Boolean> getPredefinedSystem(Context context) {
-        synchronized (cachePredefinedSystem) {
-            if (predefinedSystemLoaded)
-                return cachePredefinedSystem;
+    private static PredefinedRules getPredefinedRules(Context context) {
+        synchronized (predefinedLock) {
+            if (cachePredefinedRules != null)
+                return cachePredefinedRules;
+
+            PredefinedRules rules = new PredefinedRules();
 
             try (XmlResourceParser xml = context.getResources().getXml(R.xml.predefined)) {
                 int eventType = xml.getEventType();
                 while (eventType != XmlPullParser.END_DOCUMENT) {
-                    if (eventType == XmlPullParser.START_TAG && "type".equals(xml.getName())) {
-                        String pkg = xml.getAttributeValue(null, "package");
-                        boolean system = xml.getAttributeBooleanValue(null, "system", true);
-                        cachePredefinedSystem.put(pkg, system);
-                    }
+                    if (eventType == XmlPullParser.START_TAG)
+                        if ("wifi".equals(xml.getName())) {
+                            String pkg = xml.getAttributeValue(null, "package");
+                            rules.wifiBlocked.put(pkg,
+                                    xml.getAttributeBooleanValue(null, "blocked", false));
+                        } else if ("other".equals(xml.getName())) {
+                            String pkg = xml.getAttributeValue(null, "package");
+                            rules.otherBlocked.put(pkg,
+                                    xml.getAttributeBooleanValue(null, "blocked", false));
+                            rules.roaming.put(pkg,
+                                    xml.getAttributeBooleanValue(null, "roaming", true));
+                        } else if ("relation".equals(xml.getName())) {
+                            String pkg = xml.getAttributeValue(null, "package");
+                            rules.related.put(pkg,
+                                    xml.getAttributeValue(null, "related").split(","));
+                        } else if ("type".equals(xml.getName())) {
+                            String pkg = xml.getAttributeValue(null, "package");
+                            rules.system.put(pkg,
+                                    xml.getAttributeBooleanValue(null, "system", true));
+                        }
                     eventType = xml.next();
                 }
             } catch (Throwable ex) {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }
-            predefinedSystemLoaded = true;
-            return cachePredefinedSystem;
+            cachePredefinedRules = rules;
+            return rules;
         }
     }
 
@@ -177,9 +202,8 @@ public class Rule {
             cachePackageInfo = null;
             cacheLabel.clear();
             cacheSystem.clear();
-            synchronized (cachePredefinedSystem) {
-                cachePredefinedSystem.clear();
-                predefinedSystemLoaded = false;
+            synchronized (predefinedLock) {
+                cachePredefinedRules = null;
             }
             cacheInternet.clear();
             cacheEnabled.clear();
@@ -288,44 +312,7 @@ public class Rule {
             boolean show_frozen = prefs.getBoolean("show_frozen", false);
             boolean strict_blocking = BlockingMode.isStrictMode(context);
 
-            // Get predefined rules
-            Map<String, Boolean> pre_wifi_blocked = new HashMap<>();
-            Map<String, Boolean> pre_other_blocked = new HashMap<>();
-            Map<String, Boolean> pre_roaming = new HashMap<>();
-            Map<String, String[]> pre_related = new HashMap<>();
-            Map<String, Boolean> pre_system = new HashMap<>();
-            try (XmlResourceParser xml = context.getResources().getXml(R.xml.predefined)) {
-                int eventType = xml.getEventType();
-                while (eventType != XmlPullParser.END_DOCUMENT) {
-                    if (eventType == XmlPullParser.START_TAG)
-                        if ("wifi".equals(xml.getName())) {
-                            String pkg = xml.getAttributeValue(null, "package");
-                            boolean pblocked = xml.getAttributeBooleanValue(null, "blocked", false);
-                            pre_wifi_blocked.put(pkg, pblocked);
-
-                        } else if ("other".equals(xml.getName())) {
-                            String pkg = xml.getAttributeValue(null, "package");
-                            boolean pblocked = xml.getAttributeBooleanValue(null, "blocked", false);
-                            boolean proaming = xml.getAttributeBooleanValue(null, "roaming", true);
-                            pre_other_blocked.put(pkg, pblocked);
-                            pre_roaming.put(pkg, proaming);
-
-                        } else if ("relation".equals(xml.getName())) {
-                            String pkg = xml.getAttributeValue(null, "package");
-                            String[] rel = xml.getAttributeValue(null, "related").split(",");
-                            pre_related.put(pkg, rel);
-
-                        } else if ("type".equals(xml.getName())) {
-                            String pkg = xml.getAttributeValue(null, "package");
-                            boolean system = xml.getAttributeBooleanValue(null, "system", true);
-                            pre_system.put(pkg, system);
-                        }
-
-                    eventType = xml.next();
-                }
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-            }
+            PredefinedRules predefined = getPredefinedRules(context);
 
             // Build rule list
             List<Rule> listRules = new ArrayList<>();
@@ -406,8 +393,8 @@ public class Rule {
 
                     trackerDefaultsChanged |= trackerBlocklist.ensureDefaults(rule.uid, strict_blocking);
 
-                    if (pre_system.containsKey(info.packageName))
-                        rule.system = pre_system.get(info.packageName);
+                    if (predefined.system.containsKey(info.packageName))
+                        rule.system = predefined.system.get(info.packageName);
                     // if (info.applicationInfo.uid == Process.myUid())
                     // rule.system = true;
 
@@ -434,8 +421,8 @@ public class Rule {
 
                         // Related packages
                         List<String> listPkg = new ArrayList<>();
-                        if (pre_related.containsKey(info.packageName))
-                            listPkg.addAll(Arrays.asList(pre_related.get(info.packageName)));
+                        if (predefined.related.containsKey(info.packageName))
+                            listPkg.addAll(Arrays.asList(predefined.related.get(info.packageName)));
                         for (PackageInfo pi : listPI)
                             if (pi.applicationInfo.uid == rule.uid && !pi.packageName.equals(rule.packageName)) {
                                 rule.relateduids = true;

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -97,6 +97,8 @@ public class Rule {
     private static List<PackageInfo> cachePackageInfo = null;
     private static Map<PackageInfo, String> cacheLabel = new HashMap<>();
     private static Map<String, Boolean> cacheSystem = new HashMap<>();
+    private static final Map<String, Boolean> cachePredefinedSystem = new HashMap<>();
+    private static boolean predefinedSystemLoaded = false;
     private static Map<String, Boolean> cacheInternet = new HashMap<>();
     private static Map<PackageInfo, Boolean> cacheEnabled = new HashMap<>();
     private static Map<Integer, Long> trackerRecent = new HashMap<>();
@@ -122,9 +124,39 @@ public class Rule {
     }
 
     public static boolean isSystem(String packageName, Context context) {
-        if (!cacheSystem.containsKey(packageName))
-            cacheSystem.put(packageName, Util.isSystem(packageName, context));
+        if (!cacheSystem.containsKey(packageName)) {
+            boolean system = Util.isSystem(packageName, context);
+            Boolean predefined = getPredefinedSystem(context).get(packageName);
+            cacheSystem.put(packageName, resolveSystemClassification(system, predefined));
+        }
         return cacheSystem.get(packageName);
+    }
+
+    static boolean resolveSystemClassification(boolean system, Boolean predefined) {
+        return predefined == null ? system : predefined;
+    }
+
+    private static Map<String, Boolean> getPredefinedSystem(Context context) {
+        synchronized (cachePredefinedSystem) {
+            if (predefinedSystemLoaded)
+                return cachePredefinedSystem;
+
+            try (XmlResourceParser xml = context.getResources().getXml(R.xml.predefined)) {
+                int eventType = xml.getEventType();
+                while (eventType != XmlPullParser.END_DOCUMENT) {
+                    if (eventType == XmlPullParser.START_TAG && "type".equals(xml.getName())) {
+                        String pkg = xml.getAttributeValue(null, "package");
+                        boolean system = xml.getAttributeBooleanValue(null, "system", true);
+                        cachePredefinedSystem.put(pkg, system);
+                    }
+                    eventType = xml.next();
+                }
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
+            predefinedSystemLoaded = true;
+            return cachePredefinedSystem;
+        }
     }
 
     private static boolean hasInternet(String packageName, Context context) {
@@ -145,6 +177,10 @@ public class Rule {
             cachePackageInfo = null;
             cacheLabel.clear();
             cacheSystem.clear();
+            synchronized (cachePredefinedSystem) {
+                cachePredefinedSystem.clear();
+                predefinedSystemLoaded = false;
+            }
             cacheInternet.clear();
             cacheEnabled.clear();
         }
@@ -258,8 +294,7 @@ public class Rule {
             Map<String, Boolean> pre_roaming = new HashMap<>();
             Map<String, String[]> pre_related = new HashMap<>();
             Map<String, Boolean> pre_system = new HashMap<>();
-            try {
-                XmlResourceParser xml = context.getResources().getXml(R.xml.predefined);
+            try (XmlResourceParser xml = context.getResources().getXml(R.xml.predefined)) {
                 int eventType = xml.getEventType();
                 while (eventType != XmlPullParser.END_DOCUMENT) {
                     if (eventType == XmlPullParser.START_TAG)

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -132,8 +132,12 @@ public class Util {
     static {
         try {
             System.loadLibrary("netguard");
-        } catch (UnsatisfiedLinkError ignored) {
-            System.exit(1);
+        } catch (UnsatisfiedLinkError error) {
+            // Robolectric runs on the host JVM and cannot load Android ABI
+            // libraries. Let unit tests exercise Java-only code paths, while
+            // keeping a missing native library fatal and diagnosable on-device.
+            if (!"robolectric".equals(Build.FINGERPRINT))
+                throw error;
         }
     }
 

--- a/app/src/test/java/eu/faircode/netguard/AdapterLogTest.java
+++ b/app/src/test/java/eu/faircode/netguard/AdapterLogTest.java
@@ -1,0 +1,28 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertTrue;
+
+import android.database.MatrixCursor;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class AdapterLogTest {
+
+    @Test
+    public void closeReleasesActiveCursor() {
+        MatrixCursor cursor = new MatrixCursor(new String[]{
+                "_id", "time", "version", "protocol", "flags", "saddr", "sport", "daddr", "dport",
+                "dname", "uid", "data", "allowed", "connection", "interactive"
+        });
+
+        AdapterLog adapter = new AdapterLog(
+                RuntimeEnvironment.getApplication(), cursor, false, false, false);
+        adapter.close();
+
+        assertTrue(cursor.isClosed());
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/RuleSystemClassificationRobolectricTest.java
+++ b/app/src/test/java/eu/faircode/netguard/RuleSystemClassificationRobolectricTest.java
@@ -1,0 +1,17 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class RuleSystemClassificationRobolectricTest {
+
+    @Test
+    public void chromeUsesPredefinedUserAppClassification() {
+        assertFalse(Rule.isSystem("com.android.chrome", RuntimeEnvironment.getApplication()));
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/RuleSystemClassificationTest.java
+++ b/app/src/test/java/eu/faircode/netguard/RuleSystemClassificationTest.java
@@ -1,0 +1,20 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RuleSystemClassificationTest {
+
+    @Test
+    public void chromeUsesPredefinedUserAppClassification() {
+        assertFalse(Rule.resolveSystemClassification(true, false));
+    }
+
+    @Test
+    public void rawClassificationIsUsedWithoutOverride() {
+        assertTrue(Rule.resolveSystemClassification(true, null));
+        assertFalse(Rule.resolveSystemClassification(false, null));
+    }
+}


### PR DESCRIPTION
## What changed

- close Traffic Log, DNS, and Forwarding cursors when their activities are destroyed
- replace Forwarding cursors instead of replacing whole adapters
- align VPN logging with the Apps tab's predefined system-app classification, so Chrome tracker contacts reach Timeline
- parse `predefined.xml` once and share the cached configuration
- make native-library loading Robolectric-safe without silently terminating test workers
- add JVM and Robolectric regressions for system classification and cursor disposal

## Root causes

`CursorAdapter` instances retained their final cursors after activity destruction. Separately, the Apps tab treated Chrome as a user-managed app via `predefined.xml`, while the VPN logger used Chrome's raw Android system-app flag and silently skipped Timeline aggregation. Robolectric workers were also terminated by `System.exit(1)` when the Android native library was unavailable on the host JVM.

## User impact

Chrome traffic now appears in Timeline consistently with the Apps tab, cursor resources are released deterministically, and Robolectric failures are reported normally instead of killing the Gradle worker.

## Validation

- focused JVM/Robolectric classification and cursor-disposal tests
- `:app:assembleGithubDebug`
- Android 17 emulator with active TrackerControl VPN
- verified Chrome TCP, UDP/QUIC, and IPv6 traffic in the raw Traffic Log
- verified `www.google-analytics.com` recorded as blocked and Chrome displayed in Timeline
- no TrackerControl StrictMode cursor-leak warning or app crash during the verification pass
