### PR TITLE
Harden WireGuard bridge integration

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -44,6 +44,13 @@ object WgEgress {
     private const val RESTART_BACKOFF_MAX_MS = 5 * 60_000L
 
     @Volatile private var tunnel: WgTunnel? = null
+    // Monotonically identifies the tunnel instance published in [tunnel].
+    // Recovery runs off-thread and may finish after startOrUpdate has replaced
+    // that instance, so object identity alone is not enough to associate its
+    // result with the lifecycle that launched it. AtomicLong also makes the
+    // read/modify/write safe across the VPN, monitor, and rebind threads.
+    private val tunnelGeneration = java.util.concurrent.atomic.AtomicLong(0)
+    private val tunnelLifecycleLock = Any()
     @Volatile private var lastError: String? = null
     @Volatile private var verificationGeneration: Long = 0
     @Volatile private var currentConfig: String? = null
@@ -66,13 +73,28 @@ object WgEgress {
     // init on paths that never scheduled anything (e.g. plain-JUnit-tested
     // no-tunnel callers that never touch the main-thread Looper).
     @Volatile private var restartScheduled: Boolean = false
+    @Volatile private var pendingRestartTunnel: WgTunnel? = null
+    @Volatile private var pendingRestartTunnelGeneration: Long = -1
     private val pendingRestartRunnable = Runnable {
         restartScheduled = false
         // If forceRestartPending was cleared while this was queued, the tunnel
         // was already (re)started by another path (e.g. a network-change
         // reload consumed the pending restart in startOrUpdate) — firing now
         // would kick a redundant restart of an already-healthy tunnel.
-        if (forceRestartPending) requestReloadCb?.run()
+        synchronized(tunnelLifecycleLock) {
+            val expected = TunnelSnapshot(
+                pendingRestartTunnel ?: return@synchronized,
+                pendingRestartTunnelGeneration
+            )
+            // Keep validation and callback dispatch atomic with publication.
+            // The callback only posts the service reload; if that ever changes
+            // to synchronously start the tunnel, JVM monitors are re-entrant.
+            if (forceRestartPending && isCurrentLocked(expected)) {
+                pendingRestartTunnel = null
+                pendingRestartTunnelGeneration = -1
+                requestReloadCb?.run()
+            }
+        }
     }
 
     // Single-thread executor for network-change rebinds: bounds the thread
@@ -216,19 +238,18 @@ object WgEgress {
             }
         }
 
-        try {
-            tunnel = Wgbridge.startTunnel(
+        val startedTunnel = try {
+            Wgbridge.startTunnel(
                 resolved.toUapi(keepaliveEnabled), rxFd, desiredFd, mtu, protector, logger, dnsRecorder
             )
         } catch (e: Throwable) {
             lastError = "WireGuard tunnel failed to start: ${e.message ?: e.javaClass.simpleName}"
             Log.e(TAG, "Wgbridge.startTunnel failed", e)
-            closeRawFd(rxFd)
             stopSocketpair()
             notifyStateChanged()
             return false
         } finally {
-            if (tunnel != null) closeRawFd(rxFd)
+            closeRawFd(rxFd)
         }
 
         currentConfig = configText
@@ -236,6 +257,12 @@ object WgEgress {
         currentTunPfd = vpnFd
         currentInteractive = interactive
         currentKeepaliveAlwaysOn = keepaliveAlwaysOn
+        synchronized(tunnelLifecycleLock) {
+            tunnelGeneration.incrementAndGet()
+            // Volatile publication happens only after all companion state has
+            // been installed above.
+            tunnel = startedTunnel
+        }
         Log.i(TAG, "WG up: tunFd=$desiredFd mtu=$mtu peers=${resolved.peers.size}")
         notifyStateChanged()
         scheduleFreshHandshakeNotificationCheck()
@@ -244,18 +271,31 @@ object WgEgress {
     }
 
     private fun startMonitor() {
+        val expected = captureTunnel() ?: return
+        startMonitor(expected)
+    }
+
+    private fun startMonitor(expected: TunnelSnapshot) {
+        if (!isCurrent(expected)) return
         synchronized(monitorLock) {
+            if (!isCurrent(expected)) return
             monitor?.stop()
             monitor = WgConnectivityMonitor(
-                statsProvider = { statsOrNull() },
-                prod = { try { tunnel?.sendKeepalive() } catch (e: Throwable) { Log.w(TAG, "prod keepalive threw", e) } },
-                onBroken = { onMonitorBroken() },
-                onConnected = { notifyStateChanged() },
+                statsProvider = { statsOrNull(expected) },
+                prod = {
+                    if (isCurrent(expected)) try {
+                        expected.tunnel.sendKeepalive()
+                    } catch (e: Throwable) {
+                        Log.w(TAG, "prod keepalive threw", e)
+                    }
+                },
+                onBroken = { if (isCurrent(expected)) onMonitorBroken(expected) },
+                onConnected = { if (isCurrent(expected)) notifyStateChanged() },
                 // Reset the restart backoff only on observed return traffic:
                 // a fresh handshake shortly after a restart is exactly the
                 // signal a handshake-passes-but-data-drops failure loop also
                 // produces, so resetting on it would defeat the backoff.
-                onRxAdvanced = { restartAttempts = 0 }
+                onRxAdvanced = { if (isCurrent(expected)) restartAttempts = 0 }
             ).also { it.start() }
         }
     }
@@ -267,8 +307,8 @@ object WgEgress {
         }
     }
 
-    private fun onMonitorBroken() {
-        if (tunnel == null) return
+    private fun onMonitorBroken(expected: TunnelSnapshot) {
+        if (!isCurrent(expected)) return
         // A full restart is already queued; it will rebind everything anyway.
         if (forceRestartPending) return
 
@@ -277,28 +317,49 @@ object WgEgress {
         // IP change) without redoing the handshake or dropping packets.
         // Escalate to a full restart if a recent cheap recovery didn't stick.
         val now = now()
-        if (now - lastCheapRecoveryMs > CHEAP_RECOVERY_ESCALATION_MS && tryCheapRecovery()) {
-            lastCheapRecoveryMs = now
-            Log.w(TAG, "connectivity monitor: tunnel broken; rebound sockets, watching")
-            startMonitor()
-            return
+        if (now - lastCheapRecoveryMs > CHEAP_RECOVERY_ESCALATION_MS) {
+            when (tryCheapRecovery(expected)) {
+                RecoveryResult.STALE -> return
+                RecoveryResult.SUCCEEDED -> {
+                    if (!isCurrent(expected)) return
+                    lastCheapRecoveryMs = now
+                    Log.w(TAG, "connectivity monitor: tunnel broken; rebound sockets, watching")
+                    startMonitor(expected)
+                    return
+                }
+                RecoveryResult.FAILED -> Unit
+            }
         }
 
-        requestFullRestart("connectivity monitor: tunnel still broken after cheap recovery", notify = true)
+        requestFullRestart(
+            "connectivity monitor: tunnel still broken after cheap recovery",
+            notify = true,
+            expected = expected
+        )
     }
 
-    private fun requestFullRestart(reason: String, notify: Boolean) {
-        val attempt = restartAttempts++
-        val delay = if (attempt == 0) 0L
-        else minOf(RESTART_BACKOFF_MAX_MS, RESTART_BACKOFF_BASE_MS shl (attempt - 1).coerceAtMost(10))
+    private fun requestFullRestart(reason: String, notify: Boolean, expected: TunnelSnapshot) {
+        val attempt: Int
+        val delay: Long
+        synchronized(tunnelLifecycleLock) {
+            // This check and installation of pending state must be atomic with
+            // tunnel replacement. Otherwise a replacement can land between
+            // them and inherit forceRestartPending from an obsolete failure.
+            if (!isCurrentLocked(expected)) return
+            clearEndpointCache()
+            attempt = restartAttempts++
+            delay = if (attempt == 0) 0L
+            else minOf(RESTART_BACKOFF_MAX_MS, RESTART_BACKOFF_BASE_MS shl (attempt - 1).coerceAtMost(10))
+            forceRestartPending = true
+            pendingRestartTunnel = expected.tunnel
+            pendingRestartTunnelGeneration = expected.generation
+        }
         Log.w(TAG, "$reason; forcing restart (attempt=${attempt + 1}, delay=${delay}ms)")
-        clearEndpointCache()
-        forceRestartPending = true
         if (notify) scheduleRecoveryNotificationCheck()
         verifyHandler.removeCallbacks(pendingRestartRunnable)
         if (delay <= 0L) {
             restartScheduled = false
-            requestReloadCb?.run()
+            pendingRestartRunnable.run()
         } else {
             restartScheduled = true
             verifyHandler.postDelayed(pendingRestartRunnable, delay)
@@ -327,18 +388,23 @@ object WgEgress {
      * re-resolves peer hostnames (bypassing the endpoint cache), and prods
      * the tunnel. Runs synchronously; callers must be off the main thread.
      */
-    private fun tryCheapRecovery(): Boolean {
-        val t = tunnel ?: return false
-        val configText = currentConfig ?: return false
-        return try {
+    private fun tryCheapRecovery(expected: TunnelSnapshot): RecoveryResult {
+        synchronized(tunnelLifecycleLock) {
+            if (!isCurrentLocked(expected)) return RecoveryResult.STALE
             clearEndpointCache()
-            t.rebind()
-            refreshPeerEndpoints(t, configText)
-            t.sendKeepalive()
-            true
+        }
+        val configText = currentConfig ?: return RecoveryResult.STALE
+        return try {
+            if (!isCurrent(expected)) return RecoveryResult.STALE
+            expected.tunnel.rebind()
+            if (!isCurrent(expected)) return RecoveryResult.STALE
+            if (!refreshPeerEndpoints(expected, configText)) return RecoveryResult.STALE
+            if (!isCurrent(expected)) return RecoveryResult.STALE
+            expected.tunnel.sendKeepalive()
+            if (isCurrent(expected)) RecoveryResult.SUCCEEDED else RecoveryResult.STALE
         } catch (e: Throwable) {
             Log.w(TAG, "WG rebind/re-resolve failed", e)
-            false
+            if (isCurrent(expected)) RecoveryResult.FAILED else RecoveryResult.STALE
         }
     }
 
@@ -348,20 +414,24 @@ object WgEgress {
      * roaming across resolver views (e.g. after crossing a border) picks up
      * the new server IP.
      */
-    private fun refreshPeerEndpoints(t: WgTunnel, configText: String) {
+    private fun refreshPeerEndpoints(expected: TunnelSnapshot, configText: String): Boolean {
         val parsed = WgConfigParser.parse(configText)
         for (peer in parsed.peers) {
             val endpoint = peer.endpoint ?: continue
             try {
-                t.updateEndpoint(peer.publicKey, resolveEndpoint(endpoint))
+                val resolved = resolveEndpoint(endpoint)
+                if (!isCurrent(expected)) return false
+                expected.tunnel.updateEndpoint(peer.publicKey, resolved)
             } catch (e: Throwable) {
                 Log.w(TAG, "endpoint refresh for $endpoint failed", e)
             }
         }
+        return isCurrent(expected)
     }
 
-    private fun statsOrNull(): WgStats? = try {
-        tunnel?.stats()?.let {
+    private fun statsOrNull(expected: TunnelSnapshot? = captureTunnel()): WgStats? = try {
+        if (expected == null || !isCurrent(expected)) null
+        else expected.tunnel.stats().let {
             // hasFreshHandshake deliberately uses WireGuard's REJECT_AFTER_TIME
             // (180s): while a handshake is younger than the session lifetime,
             // "tx without rx" is not proof of breakage — an idle tunnel whose
@@ -430,10 +500,28 @@ object WgEgress {
         rebindExecutor.execute {
             try {
                 while (true) {
-                    if (tryCheapRecovery()) {
-                        lastCheapRecoveryMs = now()
-                    } else if (tunnel != null && !forceRestartPending) {
-                        requestFullRestart("WG rebind failed after network change", notify = false)
+                    val expected = captureTunnel()
+                    if (expected == null) {
+                        synchronized(rebindLock) {
+                            rebindInFlight = false
+                            rebindDirty = false
+                        }
+                        return@execute
+                    }
+                    when (tryCheapRecovery(expected)) {
+                        RecoveryResult.SUCCEEDED -> {
+                            if (isCurrent(expected)) lastCheapRecoveryMs = now()
+                        }
+                        RecoveryResult.FAILED -> {
+                            if (!forceRestartPending) {
+                                requestFullRestart(
+                                    "WG rebind failed after network change",
+                                    notify = false,
+                                    expected = expected
+                                )
+                            }
+                        }
+                        RecoveryResult.STALE -> Unit
                     }
                     synchronized(rebindLock) {
                         if (!rebindDirty) {
@@ -480,8 +568,20 @@ object WgEgress {
 
     private fun stopInternal(stopSocketpair: () -> Unit) {
         stopMonitor()
-        val t = tunnel
-        tunnel = null
+        val t = synchronized(tunnelLifecycleLock) {
+            val old = tunnel
+            // Invalidate in-flight recovery before stopping the old object.
+            // Any later success/failure result is now harmlessly stale.
+            tunnel = null
+            tunnelGeneration.incrementAndGet()
+            // stop() calls clearRecoveryState first, but a recovery failure may
+            // land between that call and this invalidation. Clear again while
+            // holding the same lock used to install pending restart state.
+            forceRestartPending = false
+            pendingRestartTunnel = null
+            pendingRestartTunnelGeneration = -1
+            old
+        }
         currentConfig = null
         currentTunFd = -1
         currentTunPfd = null
@@ -538,6 +638,8 @@ object WgEgress {
         verificationGeneration++
         recoveryNotificationGeneration++
         forceRestartPending = false
+        pendingRestartTunnel = null
+        pendingRestartTunnelGeneration = -1
         restartAttempts = 0
         // restartScheduled guards the lazy init: this runs on every no-tunnel
         // /disable path, most of which never scheduled a delayed restart and
@@ -679,4 +781,25 @@ object WgEgress {
         val endpoint: String,
         val resolvedAtMillis: Long
     )
+
+    private data class TunnelSnapshot(
+        val tunnel: WgTunnel,
+        val generation: Long
+    )
+
+    private enum class RecoveryResult { SUCCEEDED, FAILED, STALE }
+
+    private fun captureTunnel(): TunnelSnapshot? {
+        synchronized(tunnelLifecycleLock) {
+            val generation = tunnelGeneration.get()
+            val current = tunnel ?: return null
+            return TunnelSnapshot(current, generation)
+        }
+    }
+
+    private fun isCurrent(expected: TunnelSnapshot): Boolean =
+        synchronized(tunnelLifecycleLock) { isCurrentLocked(expected) }
+
+    private fun isCurrentLocked(expected: TunnelSnapshot): Boolean =
+        expected.generation == tunnelGeneration.get() && tunnel === expected.tunnel
 }

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -24,8 +24,6 @@
 int max_tun_msg = 0;
 extern int loglevel;
 extern FILE *pcap_file;
-extern _Atomic int wg_enabled;
-extern _Atomic int wg_outbound_fd;
 extern _Atomic int wg_required;
 
 static atomic_long wg_drop_count = 0;
@@ -414,10 +412,28 @@ void handle_ip(const struct arguments *args,
         // user's physical network.
         int is_dns = (dport == 53 &&
                       (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP));
-        int wg_is_enabled = atomic_load_explicit(&wg_enabled, memory_order_acquire);
         int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
-        int wg_fd = atomic_load_explicit(&wg_outbound_fd, memory_order_acquire);
         int wg_dest = !is_local_dest(version, daddr) || is_dns;
+
+        if (wg_dest) {
+            ssize_t w;
+            int write_errno;
+            if (write_wireguard_packet(pkt, length, &w, &write_errno)) {
+                if (w != (ssize_t) length) {
+                    if (w < 0 && (write_errno == EAGAIN || write_errno == EWOULDBLOCK)) {
+                        long drops = atomic_fetch_add_explicit(
+                                &wg_drop_count, 1, memory_order_relaxed) + 1;
+                        if ((drops & 1023L) == 1)
+                            log_android(ANDROID_LOG_WARN,
+                                        "wg socket buffer full, dropped %ld packets", drops);
+                    } else
+                        log_android(ANDROID_LOG_WARN, "wg write %zd/%zu errno %d: %s",
+                                    w, length, write_errno, strerror(write_errno));
+                }
+                // Fail-closed: if the write fails, drop. Do not fall through to direct.
+                return;
+            }
+        }
 
         // Fail closed while WG is required but not (yet) running — e.g. the
         // brief window during a tunnel restart, or after a failed start.
@@ -427,30 +443,12 @@ void handle_ip(const struct arguments *args,
         // (the resolver runs on the VPN network). This briefly exposes DNS
         // queries to the configured (WG/public fallback) DNS server over the
         // physical network, which is far less than leaking all traffic.
-        if (wg_is_required && !(wg_is_enabled && wg_fd >= 0)
-                && wg_dest && !is_dns) {
+        if (wg_is_required && wg_dest && !is_dns) {
             long drops = atomic_fetch_add_explicit(
                     &wg_gap_drop_count, 1, memory_order_relaxed) + 1;
             if ((drops & 255L) == 1)
                 log_android(ANDROID_LOG_WARN,
                             "wg not running, dropped %ld packets (fail closed)", drops);
-            return;
-        }
-
-        if (wg_is_enabled && wg_fd >= 0 && wg_dest) {
-            ssize_t w = write(wg_fd, pkt, length);
-            if (w != (ssize_t) length) {
-                if (w < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-                    long drops = atomic_fetch_add_explicit(
-                            &wg_drop_count, 1, memory_order_relaxed) + 1;
-                    if ((drops & 1023L) == 1)
-                        log_android(ANDROID_LOG_WARN,
-                                    "wg socket buffer full, dropped %ld packets", drops);
-                } else
-                    log_android(ANDROID_LOG_WARN, "wg write %zd/%zu errno %d: %s",
-                                w, length, errno, strerror(errno));
-            }
-            // Fail-closed: if the write fails, drop. Do not fall through to direct.
             return;
         }
 

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -29,8 +29,11 @@ char socks5_addr[INET6_ADDRSTRLEN + 1];
 int socks5_port = 0;
 char socks5_username[127 + 1];
 char socks5_password[127 + 1];
-_Atomic int wg_enabled = 0;
-_Atomic int wg_outbound_fd = -1;
+static int wg_outbound_fd = -1;
+// Guards the complete outbound descriptor lifetime: publish, check+write,
+// detach, and close. The descriptor is non-blocking, so writers hold this only
+// for one bounded socket operation.
+static pthread_mutex_t wg_outbound_lock = PTHREAD_MUTEX_INITIALIZER;
 // Set while the user wants WireGuard egress, independently of whether the
 // tunnel is currently up. When required but not enabled (restart window,
 // failed start), ip.c drops hijack-eligible traffic instead of forwarding
@@ -146,8 +149,16 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
     socks5_port = 0;
     *socks5_username = 0;
     *socks5_password = 0;
-    atomic_store_explicit(&wg_enabled, 0, memory_order_release);
-    atomic_store_explicit(&wg_outbound_fd, -1, memory_order_release);
+    if (pthread_mutex_lock(&wg_outbound_lock))
+        log_android(ANDROID_LOG_ERROR, "wg outbound lock failed during init");
+    else {
+        int fd = wg_outbound_fd;
+        wg_outbound_fd = -1;
+        if (fd >= 0)
+            close(fd);
+        if (pthread_mutex_unlock(&wg_outbound_lock))
+            log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed during init");
+    }
     atomic_store_explicit(&wg_required, 0, memory_order_release);
     pcap_file = NULL;
 
@@ -370,16 +381,12 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1sni(JNIEnv *env, jobject instance
 }
 
 // Allocate a SOCK_DGRAM socketpair: the C side keeps the write end (sv[0])
-// in wg_outbound_fd and atomically sets wg_enabled=1. The read end (sv[1]) is
+// in wg_outbound_fd. The read end (sv[1]) is
 // returned to Java, which passes it to Wgbridge.startTunnel so the WireGuard
 // engine (gotatun) can pull outbound IP packets. SOCK_DGRAM preserves
 // IP-packet boundaries.
 JNIEXPORT jint JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1start(JNIEnv *env, jobject instance) {
-    if (atomic_load_explicit(&wg_enabled, memory_order_acquire)) {
-        log_android(ANDROID_LOG_WARN, "WireGuard already started");
-        return -1;
-    }
     int sv[2];
     if (socketpair(AF_UNIX, SOCK_DGRAM, 0, sv) < 0) {
         log_android(ANDROID_LOG_ERROR, "wg socketpair errno %d: %s", errno, strerror(errno));
@@ -388,12 +395,56 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1start(JNIEnv *env, job
     set_wg_socket_buffer(sv[0], SO_SNDBUF, "tx snd");
     set_wg_socket_buffer(sv[1], SO_RCVBUF, "rx rcv");
     int flags = fcntl(sv[0], F_GETFL, 0);
-    if (flags >= 0)
-        fcntl(sv[0], F_SETFL, flags | O_NONBLOCK);
-    atomic_store_explicit(&wg_outbound_fd, sv[0], memory_order_release);
-    atomic_store_explicit(&wg_enabled, 1, memory_order_release);
+    if (flags < 0 || fcntl(sv[0], F_SETFL, flags | O_NONBLOCK) < 0) {
+        log_android(ANDROID_LOG_ERROR, "wg tx O_NONBLOCK failed errno %d: %s",
+                    errno, strerror(errno));
+        close(sv[0]);
+        close(sv[1]);
+        return -1;
+    }
+
+    if (pthread_mutex_lock(&wg_outbound_lock)) {
+        log_android(ANDROID_LOG_ERROR, "wg outbound lock failed during start");
+        close(sv[0]);
+        close(sv[1]);
+        return -1;
+    }
+    if (wg_outbound_fd >= 0) {
+        pthread_mutex_unlock(&wg_outbound_lock);
+        close(sv[0]);
+        close(sv[1]);
+        log_android(ANDROID_LOG_WARN, "WireGuard already started");
+        return -1;
+    }
+    wg_outbound_fd = sv[0];
+    if (pthread_mutex_unlock(&wg_outbound_lock))
+        log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed during start");
     log_android(ANDROID_LOG_WARN, "WireGuard egress enabled tx=%d rx=%d", sv[0], sv[1]);
     return sv[1];
+}
+
+int write_wireguard_packet(const void *packet, size_t length,
+                           ssize_t *written, int *write_errno) {
+    *written = -1;
+    *write_errno = 0;
+
+    if (pthread_mutex_lock(&wg_outbound_lock)) {
+        // Claim and drop the packet: falling through could leak it directly.
+        *write_errno = EIO;
+        return 1;
+    }
+
+    if (wg_outbound_fd < 0) {
+        pthread_mutex_unlock(&wg_outbound_lock);
+        return 0;
+    }
+
+    *written = write(wg_outbound_fd, packet, length);
+    if (*written < 0)
+        *write_errno = errno;
+    if (pthread_mutex_unlock(&wg_outbound_lock))
+        log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed after write");
+    return 1;
 }
 
 JNIEXPORT void JNICALL
@@ -404,12 +455,19 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1required(JNIEnv *env, 
 
 JNIEXPORT void JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1stop(JNIEnv *env, jobject instance) {
-    atomic_store_explicit(&wg_enabled, 0, memory_order_release);
-    int fd = atomic_exchange_explicit(&wg_outbound_fd, -1, memory_order_acq_rel);
+    if (pthread_mutex_lock(&wg_outbound_lock)) {
+        // Do not close without the lock: an in-flight writer may own the fd.
+        log_android(ANDROID_LOG_ERROR, "wg outbound lock failed during stop");
+        return;
+    }
+    int fd = wg_outbound_fd;
+    wg_outbound_fd = -1;
     if (fd >= 0) {
         close(fd);
         log_android(ANDROID_LOG_WARN, "WireGuard egress disabled, closed tx=%d", fd);
     }
+    if (pthread_mutex_unlock(&wg_outbound_lock))
+        log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed during stop");
 }
 
 JNIEXPORT void JNICALL

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -110,6 +110,12 @@ struct allowed {
     uint16_t rport; // host notation
 };
 
+// Writes one packet to the active WireGuard socketpair while protecting the
+// descriptor from concurrent stop/close. Returns 1 when WireGuard claimed the
+// packet (including a failed write, which must be dropped) and 0 when inactive.
+int write_wireguard_packet(const void *packet, size_t length,
+                           ssize_t *written, int *write_errno);
+
 struct segment {
     uint32_t seq;
     uint16_t len;

--- a/wgbridge-rs/src/dns.rs
+++ b/wgbridge-rs/src/dns.rs
@@ -2,8 +2,10 @@
 //! wgbridge/dns.go). Extracts A/AAAA answers from UDP:53 responses and hands
 //! them to the [`DnsSink`]; packets are never modified or blocked here.
 
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::time::{Duration, Instant};
 
 use crate::callbacks::DnsSink;
 
@@ -18,14 +20,164 @@ const IP_PROTO_ROUTING: u8 = 43;
 const IP_PROTO_FRAGMENT: u8 = 44;
 const IP_PROTO_DST_OPTS: u8 = 60;
 
-pub fn inspect_dns_response(packet: &[u8], recorder: &dyn DnsSink) {
-    if packet.is_empty() {
-        return;
+const MAX_TCP_DNS_FLOWS: usize = 64;
+const MAX_TCP_DNS_BUFFER: usize = u16::MAX as usize + 2;
+const TCP_DNS_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct TcpFlowKey {
+    src: IpAddr,
+    dst: IpAddr,
+    src_port: u16,
+    dst_port: u16,
+}
+
+struct TcpDnsFlow {
+    next_seq: u32,
+    buffer: Vec<u8>,
+    last_seen: Instant,
+}
+
+/// Stateful passive DNS inspector. UDP messages are handled directly; TCP
+/// messages are reassembled per flow using sequence numbers and the DNS-over-
+/// TCP two-byte length prefix.
+#[derive(Default)]
+pub struct DnsInspector {
+    tcp_flows: HashMap<TcpFlowKey, TcpDnsFlow>,
+}
+
+impl DnsInspector {
+    pub fn inspect(&mut self, packet: &[u8], recorder: &dyn DnsSink) {
+        if packet.is_empty() {
+            return;
+        }
+        let Some((proto, segment)) = transport_segment(packet) else {
+            return;
+        };
+        match proto {
+            IP_PROTO_UDP => {
+                if let Some(msg) = udp_dns_payload(segment) {
+                    record_answers(msg, recorder);
+                }
+            }
+            IP_PROTO_TCP => self.inspect_tcp(packet, segment, recorder),
+            _ => {}
+        }
     }
-    let Some(payload) = dns_message_from_response(packet) else {
-        return;
-    };
-    for rr in parse_dns_answers(payload) {
+
+    fn inspect_tcp(&mut self, packet: &[u8], tcp: &[u8], recorder: &dyn DnsSink) {
+        let Some(segment) = tcp_segment(packet, tcp) else {
+            return;
+        };
+        let now = Instant::now();
+        self.tcp_flows
+            .retain(|_, flow| now.duration_since(flow.last_seen) <= TCP_DNS_IDLE_TIMEOUT);
+
+        if segment.rst {
+            self.tcp_flows.remove(&segment.key);
+            return;
+        }
+        if segment.syn {
+            if !self.tcp_flows.contains_key(&segment.key) {
+                self.ensure_capacity();
+            }
+            self.tcp_flows.insert(
+                segment.key.clone(),
+                TcpDnsFlow {
+                    next_seq: segment.seq.wrapping_add(1),
+                    buffer: Vec::new(),
+                    last_seen: now,
+                },
+            );
+        }
+
+        if !segment.payload.is_empty() {
+            if !self.tcp_flows.contains_key(&segment.key) {
+                self.ensure_capacity();
+            }
+            let data_seq = segment.seq.wrapping_add(u32::from(segment.syn));
+            let flow = self
+                .tcp_flows
+                .entry(segment.key.clone())
+                .or_insert_with(|| TcpDnsFlow {
+                    // Best-effort bootstrap for a connection that pre-dates the
+                    // inspector. A later gap invalidates the stream until a SYN.
+                    next_seq: data_seq,
+                    buffer: Vec::new(),
+                    last_seen: now,
+                });
+            flow.last_seen = now;
+
+            let already_seen = flow.next_seq.wrapping_sub(data_seq);
+            let payload = if data_seq == flow.next_seq {
+                segment.payload
+            } else if already_seen < 0x8000_0000 && already_seen as usize <= segment.payload.len() {
+                &segment.payload[already_seen as usize..]
+            } else {
+                // A forward gap means bytes needed to find message boundaries
+                // are missing. Drop the flow instead of parsing a mid-message
+                // payload as a new length prefix.
+                self.tcp_flows.remove(&segment.key);
+                return;
+            };
+
+            if flow.buffer.len() + payload.len() > MAX_TCP_DNS_BUFFER {
+                self.tcp_flows.remove(&segment.key);
+                return;
+            }
+            flow.buffer.extend_from_slice(payload);
+            flow.next_seq = flow.next_seq.wrapping_add(payload.len() as u32);
+
+            while flow.buffer.len() >= 2 {
+                let msg_len = u16::from_be_bytes([flow.buffer[0], flow.buffer[1]]) as usize;
+                if msg_len == 0 {
+                    flow.buffer.drain(..2);
+                    continue;
+                }
+                if flow.buffer.len() < msg_len + 2 {
+                    break;
+                }
+                let msg = flow.buffer[2..2 + msg_len].to_vec();
+                flow.buffer.drain(..2 + msg_len);
+                record_answers(&msg, recorder);
+            }
+        }
+
+        if segment.fin {
+            self.tcp_flows.remove(&segment.key);
+        }
+    }
+
+    fn ensure_capacity(&mut self) {
+        if self.tcp_flows.len() < MAX_TCP_DNS_FLOWS {
+            return;
+        }
+        if let Some(oldest) = self
+            .tcp_flows
+            .iter()
+            .min_by_key(|(_, flow)| flow.last_seen)
+            .map(|(key, _)| key.clone())
+        {
+            self.tcp_flows.remove(&oldest);
+        }
+    }
+}
+
+struct TcpSegment<'a> {
+    key: TcpFlowKey,
+    seq: u32,
+    syn: bool,
+    fin: bool,
+    rst: bool,
+    payload: &'a [u8],
+}
+
+pub fn inspect_dns_response(packet: &[u8], recorder: &dyn DnsSink) {
+    DnsInspector::default().inspect(packet, recorder);
+}
+
+fn record_answers(msg: &[u8], recorder: &dyn DnsSink) {
+    for rr in parse_dns_answers(msg) {
         // The recorder crosses into Java; never let a failure there take
         // down the packet path.
         let _ = catch_unwind(AssertUnwindSafe(|| {
@@ -34,23 +186,55 @@ pub fn inspect_dns_response(packet: &[u8], recorder: &dyn DnsSink) {
     }
 }
 
-/// Extracts the DNS message from a UDP:53 or TCP:53 response packet.
-///
-/// UDP responses carry the whole message in one datagram. TCP responses are a
-/// byte stream framed with a 2-byte length prefix; here we only see individual
-/// decrypted IP packets, not a reassembled stream, so we parse a TCP response
-/// only when a single segment carries the length prefix and the entire message
-/// that follows it. Responses split across segments (large answer sets, DNSSEC)
-/// are skipped rather than misparsed — best effort, but strictly more coverage
-/// than the UDP-only handling it replaces. Resolvers commonly fall back to TCP
-/// when a UDP answer is truncated, and without this those mappings were lost.
-fn dns_message_from_response(packet: &[u8]) -> Option<&[u8]> {
-    let (proto, segment) = transport_segment(packet)?;
-    match proto {
-        IP_PROTO_UDP => udp_dns_payload(segment),
-        IP_PROTO_TCP => tcp_dns_payload(segment),
-        _ => None,
+fn tcp_segment<'a>(packet: &[u8], tcp: &'a [u8]) -> Option<TcpSegment<'a>> {
+    if tcp.len() < 20 || u16::from_be_bytes([tcp[0], tcp[1]]) != 53 {
+        return None;
     }
+    let (src, dst) = match packet[0] >> 4 {
+        4 => {
+            // Reject IPv4 fragments: TCP sequence framing alone cannot fill
+            // gaps created below the transport layer.
+            let fragment = u16::from_be_bytes([packet[6], packet[7]]);
+            if fragment & 0x3fff != 0 {
+                return None;
+            }
+            (
+                IpAddr::V4(Ipv4Addr::new(
+                    packet[12], packet[13], packet[14], packet[15],
+                )),
+                IpAddr::V4(Ipv4Addr::new(
+                    packet[16], packet[17], packet[18], packet[19],
+                )),
+            )
+        }
+        6 => {
+            let src: [u8; 16] = packet[8..24].try_into().ok()?;
+            let dst: [u8; 16] = packet[24..40].try_into().ok()?;
+            (
+                IpAddr::V6(Ipv6Addr::from(src)),
+                IpAddr::V6(Ipv6Addr::from(dst)),
+            )
+        }
+        _ => return None,
+    };
+    let data_off = ((tcp[12] >> 4) as usize) * 4;
+    if data_off < 20 || tcp.len() < data_off {
+        return None;
+    }
+    let flags = tcp[13];
+    Some(TcpSegment {
+        key: TcpFlowKey {
+            src,
+            dst,
+            src_port: 53,
+            dst_port: u16::from_be_bytes([tcp[2], tcp[3]]),
+        },
+        seq: u32::from_be_bytes(tcp[4..8].try_into().ok()?),
+        syn: flags & 0x02 != 0,
+        fin: flags & 0x01 != 0,
+        rst: flags & 0x04 != 0,
+        payload: &tcp[data_off..],
+    })
 }
 
 /// Returns the (transport protocol, transport segment) for an IPv4/IPv6 packet,
@@ -126,6 +310,7 @@ fn udp_dns_payload(udp: &[u8]) -> Option<&[u8]> {
     Some(&udp[8..udp_len])
 }
 
+#[cfg(test)]
 fn tcp_dns_payload(tcp: &[u8]) -> Option<&[u8]> {
     if tcp.len() < 20 {
         return None;
@@ -365,6 +550,10 @@ mod tests {
     }
 
     fn ipv4_tcp(payload: &[u8]) -> Vec<u8> {
+        ipv4_tcp_segment(payload, 1000, 0x18)
+    }
+
+    fn ipv4_tcp_segment(payload: &[u8], seq: u32, flags: u8) -> Vec<u8> {
         // payload is the TCP data (already framed with the 2-byte DNS length).
         let tcp_hdr = 20;
         let seg_len = tcp_hdr + payload.len();
@@ -378,7 +567,9 @@ mod tests {
         packet[16..20].copy_from_slice(&[10, 0, 0, 2]);
         packet[20..22].copy_from_slice(&53u16.to_be_bytes()); // src port
         packet[22..24].copy_from_slice(&12345u16.to_be_bytes()); // dst port
+        packet[24..28].copy_from_slice(&seq.to_be_bytes());
         packet[32] = 5 << 4; // data offset = 5 words (20-byte header)
+        packet[33] = flags;
         packet[40..].copy_from_slice(payload);
         packet
     }
@@ -465,7 +656,8 @@ mod tests {
         let mut packet = ipv4_udp(&msg);
         packet.extend_from_slice(&[0xaa, 0xbb, 0xcc]);
 
-        let payload = dns_message_from_response(&packet).expect("packet not recognized");
+        let (_, segment) = transport_segment(&packet).expect("packet not recognized");
+        let payload = udp_dns_payload(segment).expect("UDP payload not recognized");
         assert_eq!(payload.len(), msg.len());
     }
 
@@ -477,7 +669,8 @@ mod tests {
         ]);
         let packet = ipv6_udp_with_destination_options(&msg);
 
-        let payload = dns_message_from_response(&packet).expect("packet not recognized");
+        let (_, segment) = transport_segment(&packet).expect("packet not recognized");
+        let payload = udp_dns_payload(segment).expect("UDP payload not recognized");
         assert_eq!(payload.len(), msg.len());
     }
 
@@ -486,7 +679,7 @@ mod tests {
         let msg = dns_message(&[dns_question("tracker.example", DNS_TYPE_A)]);
         let mut packet = ipv6_udp_with_destination_options(&msg);
         packet[6] = IP_PROTO_FRAGMENT;
-        assert!(dns_message_from_response(&packet).is_none());
+        assert!(transport_segment(&packet).is_none());
     }
 
     #[test]
@@ -497,7 +690,8 @@ mod tests {
         ]);
         let packet = ipv4_tcp(&tcp_dns_framed(&msg));
 
-        let payload = dns_message_from_response(&packet).expect("tcp packet not recognized");
+        let (_, segment) = transport_segment(&packet).expect("tcp packet not recognized");
+        let payload = tcp_dns_payload(segment).expect("TCP payload not recognized");
         assert_eq!(payload, msg.as_slice());
 
         let answers = parse_dns_answers(payload);
@@ -507,19 +701,62 @@ mod tests {
     }
 
     #[test]
-    fn tcp_dns_partial_segment_is_skipped() {
+    fn stateful_inspector_reassembles_split_tcp_dns_response() {
         let msg = dns_message(&[
             dns_question("tracker.example", DNS_TYPE_A),
             dns_answer_bytes("tracker.example", DNS_TYPE_A, 300, &[203, 0, 113, 7]),
         ]);
-        let mut framed = tcp_dns_framed(&msg);
-        // Claim a message longer than the segment actually carries: a response
-        // split across TCP segments must be skipped, not misparsed.
-        let claimed = (msg.len() as u16) + 10;
-        framed[0..2].copy_from_slice(&claimed.to_be_bytes());
-        let packet = ipv4_tcp(&framed);
+        let framed = tcp_dns_framed(&msg);
+        let split = framed.len() / 2;
+        let first = ipv4_tcp_segment(&framed[..split], 1000, 0x18);
+        let second = ipv4_tcp_segment(&framed[split..], 1000 + split as u32, 0x18);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+        let mut inspector = DnsInspector::default();
 
-        assert!(dns_message_from_response(&packet).is_none());
+        inspector.inspect(&first, &sink);
+        assert!(sink.0.lock().unwrap().is_empty());
+        inspector.inspect(&second, &sink);
+
+        let records = sink.0.lock().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, "tracker.example");
+        assert_eq!(records[0].2, "203.0.113.7");
+    }
+
+    #[test]
+    fn stateful_inspector_ignores_retransmitted_tcp_bytes() {
+        let msg = dns_message(&[
+            dns_question("tracker.example", DNS_TYPE_A),
+            dns_answer_bytes("tracker.example", DNS_TYPE_A, 300, &[203, 0, 113, 7]),
+        ]);
+        let framed = tcp_dns_framed(&msg);
+        let packet = ipv4_tcp_segment(&framed, 1000, 0x18);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+        let mut inspector = DnsInspector::default();
+
+        inspector.inspect(&packet, &sink);
+        inspector.inspect(&packet, &sink);
+
+        assert_eq!(sink.0.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn stateful_inspector_discards_stream_after_sequence_gap() {
+        let msg = dns_message(&[
+            dns_question("tracker.example", DNS_TYPE_A),
+            dns_answer_bytes("tracker.example", DNS_TYPE_A, 300, &[203, 0, 113, 7]),
+        ]);
+        let framed = tcp_dns_framed(&msg);
+        let split = framed.len() / 2;
+        let first = ipv4_tcp_segment(&framed[..split], 1000, 0x18);
+        let after_gap = ipv4_tcp_segment(&framed[split..], 1001 + split as u32, 0x18);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+        let mut inspector = DnsInspector::default();
+
+        inspector.inspect(&first, &sink);
+        inspector.inspect(&after_gap, &sink);
+
+        assert!(sink.0.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/wgbridge-rs/src/dns.rs
+++ b/wgbridge-rs/src/dns.rs
@@ -111,14 +111,18 @@ impl DnsInspector {
             let already_seen = flow.next_seq.wrapping_sub(data_seq);
             let payload = if data_seq == flow.next_seq {
                 segment.payload
-            } else if already_seen < 0x8000_0000 && already_seen as usize <= segment.payload.len() {
-                &segment.payload[already_seen as usize..]
-            } else {
+            } else if already_seen >= 0x8000_0000 {
                 // A forward gap means bytes needed to find message boundaries
                 // are missing. Drop the flow instead of parsing a mid-message
                 // payload as a new length prefix.
                 self.tcp_flows.remove(&segment.key);
                 return;
+            } else {
+                // A wholly-old or partially-overlapping retransmission: skip
+                // the bytes we've already consumed and keep the flow alive.
+                // If the retransmission lies entirely behind the frontier,
+                // this yields an empty tail, which is a harmless no-op.
+                &segment.payload[(already_seen as usize).min(segment.payload.len())..]
             };
 
             if flow.buffer.len() + payload.len() > MAX_TCP_DNS_BUFFER {
@@ -738,6 +742,34 @@ mod tests {
         inspector.inspect(&packet, &sink);
 
         assert_eq!(sink.0.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn stateful_inspector_ignores_wholly_old_retransmission() {
+        let msg = dns_message(&[
+            dns_question("tracker.example", DNS_TYPE_A),
+            dns_answer_bytes("tracker.example", DNS_TYPE_A, 300, &[203, 0, 113, 7]),
+        ]);
+        let framed = tcp_dns_framed(&msg);
+        let split = framed.len() / 2;
+        let first = ipv4_tcp_segment(&framed[..split], 1000, 0x18);
+        // Retransmission of a prefix that lies entirely behind the frontier
+        // already advanced past by `first` (i.e. already_seen > payload.len()).
+        let old_retransmit = ipv4_tcp_segment(&framed[..split / 4], 1000, 0x18);
+        let second = ipv4_tcp_segment(&framed[split..], 1000 + split as u32, 0x18);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+        let mut inspector = DnsInspector::default();
+
+        inspector.inspect(&first, &sink);
+        assert!(sink.0.lock().unwrap().is_empty());
+        inspector.inspect(&old_retransmit, &sink);
+        assert!(sink.0.lock().unwrap().is_empty());
+        inspector.inspect(&second, &sink);
+
+        let records = sink.0.lock().unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, "tracker.example");
+        assert_eq!(records[0].2, "203.0.113.7");
     }
 
     #[test]

--- a/wgbridge-rs/src/jni_bindings.rs
+++ b/wgbridge-rs/src/jni_bindings.rs
@@ -51,10 +51,13 @@ impl JavaCallback {
         Some(Self { vm, obj })
     }
 
-    /// Runs `f` with a JNIEnv attached to the current thread. Worker threads
-    /// stay attached for their lifetime (they are long-lived tokio threads).
-    fn with_env<R>(&self, f: impl FnOnce(&mut JNIEnv, &GlobalRef) -> jni::errors::Result<R>) -> Option<R> {
-        let mut env = self.vm.attach_current_thread_permanently().ok()?;
+    /// Runs `f` with a JNIEnv attached as a daemon. Worker threads stay
+    /// attached for their lifetime without keeping the JVM alive at shutdown.
+    fn with_env<R>(
+        &self,
+        f: impl FnOnce(&mut JNIEnv, &GlobalRef) -> jni::errors::Result<R>,
+    ) -> Option<R> {
+        let mut env = self.vm.attach_current_thread_as_daemon().ok()?;
         match f(&mut env, &self.obj) {
             Ok(r) => Some(r),
             Err(_) => {
@@ -205,7 +208,7 @@ pub extern "system" fn Java_net_kollnig_missioncontrol_wgbridge_Wgbridge_nativeS
     let dns: Option<Arc<dyn DnsSink>> =
         JavaCallback::new(&env, dns_recorder).map(|cb| Arc::new(JavaDnsSink(cb)) as _);
 
-    // Attach each tokio worker to the JVM as it spins up, so the Java
+    // Attach each tokio worker to the JVM as a daemon as it spins up, so the Java
     // GlobalRefs the callbacks hold are dropped on attached threads at
     // teardown (avoids the jni "detached thread" GlobalRef warning).
     let Ok(vm) = env.get_java_vm() else {
@@ -213,7 +216,7 @@ pub extern "system" fn Java_net_kollnig_missioncontrol_wgbridge_Wgbridge_nativeS
         return 0;
     };
     let on_worker_start: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
-        let _ = vm.attach_current_thread_permanently();
+        let _ = vm.attach_current_thread_as_daemon();
     });
 
     match start_tunnel(

--- a/wgbridge-rs/src/transport/ip_send.rs
+++ b/wgbridge-rs/src/transport/ip_send.rs
@@ -10,11 +10,12 @@ use gotatun::packet::{Ip, Packet};
 use gotatun::tun::IpSend;
 
 use crate::callbacks::DnsSink;
-use crate::dns::inspect_dns_response;
+use crate::dns::DnsInspector;
 
 pub struct TunFdSend {
     fd: Arc<OwnedFd>,
     dns: Option<Arc<dyn DnsSink>>,
+    dns_inspector: DnsInspector,
     write_errors: Arc<AtomicU64>,
 }
 
@@ -24,6 +25,7 @@ impl TunFdSend {
         Self {
             fd: Arc::new(fd),
             dns,
+            dns_inspector: DnsInspector::default(),
             write_errors: Arc::new(AtomicU64::new(0)),
         }
     }
@@ -40,7 +42,7 @@ impl IpSend for TunFdSend {
         let data = packet.as_ref();
 
         if let Some(dns) = &self.dns {
-            inspect_dns_response(data, dns.as_ref());
+            self.dns_inspector.inspect(data, dns.as_ref());
         }
 
         let n = write_fd(self.fd.as_raw_fd(), data);

--- a/wgbridge-rs/src/tunnel.rs
+++ b/wgbridge-rs/src/tunnel.rs
@@ -59,15 +59,16 @@ fn dup_fd(fd: i32) -> io::Result<OwnedFd> {
 ///
 /// * `uapi_config`   – UAPI text produced by WgConfig.toUapi() on the Java side.
 /// * `outbound_rx_fd`– read end of a socketpair held by C; C writes raw IP
-///                     packets, gotatun reads them as its "TUN".
+///   packets, gotatun reads them as its "TUN".
 /// * `tun_write_fd`  – VpnService TUN fd; decrypted inbound IP packets are
-///                     written here.
+///   written here.
 /// * `mtu`           – payload MTU (typically 1420).
 /// * `protector`     – Java callback to VpnService.protect(int).
 /// * `logger`        – Java callback for bridge log lines.
 /// * `dns`           – Java callback for passive DNS answer recording (may be None).
 ///
 /// The supplied fds are duplicated; stop() closes only our duplicates.
+#[allow(clippy::too_many_arguments)] // Mirrors the fixed JNI startTunnel API.
 pub fn start_tunnel(
     uapi_config: &str,
     outbound_rx_fd: i32,


### PR DESCRIPTION
## Summary

- serialize the native WireGuard socketpair descriptor lifetime across publish, write, detach, and close
- add bounded TCP DNS stream reassembly with sequence, retransmission, gap, timeout, and flow-limit handling
- bind connectivity monitors, recovery work, and delayed reloads to a tunnel generation and object identity
- attach JNI worker threads as daemon threads and keep restart backoff intact across forced restarts

## Root cause

The bridge treated an atomically loaded raw file descriptor as if it owned the descriptor lifetime, parsed DNS-over-TCP only when a full message fit in one segment, and allowed asynchronous recovery results from an obsolete tunnel to affect its replacement.

## Impact

This prevents writes to reused descriptors, restores tracker DNS mapping for segmented TCP responses, and stops stale recovery tasks from restarting a healthy replacement tunnel.

## Validation

- `cargo test --all-targets` (20 tests)
- `cargo clippy --all-targets -- -D warnings`
- `./gradlew :app:wgbridgeBuild :app:externalNativeBuildFdroidDebug :app:testFdroidDebugUnitTest --no-daemon`
- native build completed for arm64-v8a, armeabi-v7a, x86, and x86_64
