### PR TITLE
Model Android underlying connectivity

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -111,10 +111,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -159,6 +161,16 @@ public class ServiceSinkhole extends VpnService {
     };
 
     private Object networkCallback = null;
+    private ConnectivityManager.NetworkCallback underlyingDefaultNetworkCallback = null;
+    private volatile Network callbackDefaultNetwork = null;
+    private final java.util.concurrent.atomic.AtomicLong underlyingTunEpoch =
+            new java.util.concurrent.atomic.AtomicLong(0);
+    private static final long UNDERLYING_NETWORK_DEBOUNCE_MS = 300L;
+    private static final Object UNDERLYING_NETWORK_TOKEN = new Object();
+    private final Handler underlyingNetworkHandler = new Handler(Looper.getMainLooper());
+    private final net.kollnig.missioncontrol.wg.UnderlyingNetworkReducer underlyingNetworkReducer =
+            new net.kollnig.missioncontrol.wg.UnderlyingNetworkReducer();
+    private volatile boolean destroying = false;
 
     private boolean registeredInteractiveState = false;
     private PhoneStateListener callStateListener = null;
@@ -1483,6 +1495,7 @@ public class ServiceSinkhole extends VpnService {
     private ParcelFileDescriptor startVPN(Builder builder) throws SecurityException {
         try {
             ParcelFileDescriptor pfd = builder.establish();
+            if (pfd != null) onTunTransition();
             updateUnderlyingNetworks();
             return pfd;
         } catch (SecurityException ex) {
@@ -2082,6 +2095,7 @@ public class ServiceSinkhole extends VpnService {
         Log.i(TAG, "Stopping");
         try {
             pfd.close();
+            onTunTransition();
         } catch (IOException ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
         }
@@ -2602,6 +2616,7 @@ public class ServiceSinkhole extends VpnService {
             Log.i(TAG, "Available network " + network + " " + ni);
             Log.i(TAG, "Capabilities=" + capabilities);
             checkConnectivity(network, ni, capabilities);
+            scheduleUnderlyingNetworkSnapshot(false);
         }
 
         @Override
@@ -2611,6 +2626,13 @@ public class ServiceSinkhole extends VpnService {
             Log.i(TAG, "New capabilities network " + network + " " + ni);
             Log.i(TAG, "Capabilities=" + capabilities);
             checkConnectivity(network, ni, capabilities);
+            scheduleUnderlyingNetworkSnapshot(false);
+        }
+
+        @Override
+        public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
+            Log.i(TAG, "New link properties network " + network + " " + linkProperties);
+            scheduleUnderlyingNetworkSnapshot(false);
         }
 
         @Override
@@ -2629,11 +2651,13 @@ public class ServiceSinkhole extends VpnService {
             synchronized (mapValidated) {
                 mapValidated.remove(network);
             }
+            scheduleUnderlyingNetworkSnapshot(false);
         }
 
         @Override
         public void onUnavailable() {
             Log.i(TAG, "No networks available");
+            scheduleUnderlyingNetworkSnapshot(false);
         }
 
         private void checkConnectivity(Network network, NetworkInfo ni, NetworkCapabilities capabilities) {
@@ -2937,10 +2961,17 @@ public class ServiceSinkhole extends VpnService {
 
         // Monitor networks
         ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        registerUnderlyingDefaultNetworkCallback(cm);
         cm.registerNetworkCallback(
                 new NetworkRequest.Builder()
-                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET).build(),
+                        .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        .addCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN).build(),
                 networkMonitorCallback);
+
+        // Do not wait for an asynchronous callback: callbacks can be delayed or
+        // missed while the VPN is being established. Mullvad uses the same
+        // eager-snapshot principle before consuming its callback stream.
+        scheduleUnderlyingNetworkSnapshot(true);
 
         // Setup house holding
         Intent alarmIntent = new Intent(this, ServiceSinkhole.class);
@@ -2975,6 +3006,11 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onAvailable(Network network) {
                 Log.i(TAG, "Available network=" + network);
+                NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+                if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
+                    callbackDefaultNetwork = network;
+                    scheduleUnderlyingNetworkSnapshot(false);
+                }
                 if (!isActiveNetwork(network))
                     return;
 
@@ -2988,6 +3024,7 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onLinkPropertiesChanged(Network network, LinkProperties linkProperties) {
                 Log.i(TAG, "Changed properties=" + network + " props=" + linkProperties);
+                scheduleUnderlyingNetworkSnapshot(false);
                 if (!isActiveNetwork(network))
                     return;
 
@@ -3011,6 +3048,10 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
                 Log.i(TAG, "Changed capabilities=" + network + " caps=" + networkCapabilities);
+                if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
+                    callbackDefaultNetwork = network;
+                    scheduleUnderlyingNetworkSnapshot(false);
+                }
                 if (!isActiveNetwork(network))
                     return;
 
@@ -3035,6 +3076,10 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onLost(Network network) {
                 Log.i(TAG, "Lost network=" + network + " active=" + isActiveNetwork(network));
+                if (network.equals(callbackDefaultNetwork)) {
+                    callbackDefaultNetwork = null;
+                    scheduleUnderlyingNetworkSnapshot(false);
+                }
                 if (last_active == null || !last_active.equals(network))
                     return;
 
@@ -3047,6 +3092,117 @@ public class ServiceSinkhole extends VpnService {
         };
         cm.registerNetworkCallback(builder.build(), nc);
         networkCallback = nc;
+    }
+
+    private void registerUnderlyingDefaultNetworkCallback(ConnectivityManager cm) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N || cm == null) return;
+        ConnectivityManager.NetworkCallback callback = new ConnectivityManager.NetworkCallback() {
+            @Override public void onAvailable(Network network) {
+                callbackDefaultNetwork = network;
+                scheduleUnderlyingNetworkSnapshot(false);
+            }
+            @Override public void onCapabilitiesChanged(
+                    Network network, NetworkCapabilities capabilities) {
+                callbackDefaultNetwork = network;
+                scheduleUnderlyingNetworkSnapshot(false);
+            }
+            @Override public void onLinkPropertiesChanged(
+                    Network network, LinkProperties properties) {
+                scheduleUnderlyingNetworkSnapshot(false);
+            }
+            @Override public void onLost(Network network) {
+                if (network.equals(callbackDefaultNetwork)) callbackDefaultNetwork = null;
+                scheduleUnderlyingNetworkSnapshot(false);
+            }
+            @Override public void onUnavailable() {
+                callbackDefaultNetwork = null;
+                scheduleUnderlyingNetworkSnapshot(false);
+            }
+        };
+        try {
+            cm.registerDefaultNetworkCallback(callback);
+            underlyingDefaultNetworkCallback = callback;
+        } catch (RuntimeException ex) {
+            // Android 11 can reject registration transiently. The eager
+            // snapshot plus the NOT_VPN stream remain a safe fallback.
+            Log.w(TAG, "Could not register default-network callback", ex);
+        }
+    }
+
+    /** Sample both callback views; the reducer removes callback ordering noise. */
+    private net.kollnig.missioncontrol.wg.UnderlyingNetworkReducer.Snapshot
+    sampleUnderlyingNetworks() {
+        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+        Set<String> nonVpn = new HashSet<>();
+        if (cm != null) {
+            for (Network network : cm.getAllNetworks()) {
+                NetworkCapabilities caps = cm.getNetworkCapabilities(network);
+                if (caps != null &&
+                        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&
+                        caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
+                    nonVpn.add(underlyingNetworkSignature(cm, network, caps));
+            }
+        }
+        Network defaultNetwork = callbackDefaultNetwork;
+        if (defaultNetwork == null) defaultNetwork = getActiveNetwork();
+        String defaultSignature = null;
+        if (defaultNetwork != null && cm != null) {
+            NetworkCapabilities caps = cm.getNetworkCapabilities(defaultNetwork);
+            if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
+                defaultSignature = underlyingNetworkSignature(cm, defaultNetwork, caps);
+        }
+        if (defaultSignature == null && cm != null) {
+            defaultNetwork = getActiveNetwork();
+            NetworkCapabilities caps = defaultNetwork == null ? null : cm.getNetworkCapabilities(defaultNetwork);
+            if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
+                defaultSignature = underlyingNetworkSignature(cm, defaultNetwork, caps);
+        }
+        return new net.kollnig.missioncontrol.wg.UnderlyingNetworkReducer.Snapshot(
+                defaultSignature, nonVpn, underlyingTunEpoch.get());
+    }
+
+    private String underlyingNetworkSignature(
+            ConnectivityManager cm, Network network, NetworkCapabilities caps) {
+        StringBuilder value = new StringBuilder(network.toString());
+        value.append("|validated=").append(
+                caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED));
+        value.append("|metered=").append(
+                !caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_METERED));
+        value.append("|transports=");
+        for (int transport = 0; transport <= 8; transport++)
+            if (caps.hasTransport(transport)) value.append(transport).append(',');
+        LinkProperties lp = cm.getLinkProperties(network);
+        if (lp != null) {
+            value.append("|iface=").append(lp.getInterfaceName());
+            value.append("|dns=").append(lp.getDnsServers());
+            value.append("|routes=").append(lp.getRoutes());
+            value.append("|addresses=").append(lp.getLinkAddresses());
+        }
+        return value.toString();
+    }
+
+    private void scheduleUnderlyingNetworkSnapshot(boolean eager) {
+        if (destroying) return;
+        underlyingNetworkReducer.offer(sampleUnderlyingNetworks());
+        underlyingNetworkHandler.removeCallbacksAndMessages(UNDERLYING_NETWORK_TOKEN);
+        Runnable emit = () -> {
+            // Re-sample after the burst settles; onLost and capability changes
+            // can arrive in either order across the two callbacks.
+            underlyingNetworkReducer.offer(sampleUnderlyingNetworks());
+            net.kollnig.missioncontrol.wg.UnderlyingNetworkReducer.Event event =
+                    underlyingNetworkReducer.flush();
+            if (event != null)
+                net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged(
+                        event.generation, event.snapshot.isConnected(), event.rebindRequired);
+        };
+        if (eager) emit.run();
+        else underlyingNetworkHandler.postAtTime(emit, UNDERLYING_NETWORK_TOKEN,
+                SystemClock.uptimeMillis() + UNDERLYING_NETWORK_DEBOUNCE_MS);
+    }
+
+    private void onTunTransition() {
+        underlyingTunEpoch.incrementAndGet();
+        if (!destroying) scheduleUnderlyingNetworkSnapshot(false);
     }
 
     // Network flapping (Wi-Fi<->cellular handoffs, DHCP renewals) fires several
@@ -3065,8 +3221,6 @@ public class ServiceSinkhole extends VpnService {
         networkReloadDebounceHandler.postAtTime(new Runnable() {
             @Override
             public void run() {
-                if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
-                    net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged();
                 reload(reason, ServiceSinkhole.this, false);
             }
         }, NETWORK_RELOAD_TOKEN, SystemClock.uptimeMillis() + NETWORK_RELOAD_DEBOUNCE_MS);
@@ -3259,7 +3413,9 @@ public class ServiceSinkhole extends VpnService {
             }
 
             // Cancel any debounced network-change reload so it doesn't fire post-teardown
+            destroying = true;
             networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
+            underlyingNetworkHandler.removeCallbacksAndMessages(UNDERLYING_NETWORK_TOKEN);
 
             commandLooper.quit();
             logLooper.quit();
@@ -3310,6 +3466,14 @@ public class ServiceSinkhole extends VpnService {
             net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.removeStateListener(wgStateListener);
 
             ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            if (underlyingDefaultNetworkCallback != null) {
+                try {
+                    cm.unregisterNetworkCallback(underlyingDefaultNetworkCallback);
+                } catch (RuntimeException ex) {
+                    Log.w(TAG, "Could not unregister default-network callback", ex);
+                }
+                underlyingDefaultNetworkCallback = null;
+            }
             cm.unregisterNetworkCallback(networkMonitorCallback);
 
             try {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3007,10 +3007,8 @@ public class ServiceSinkhole extends VpnService {
             public void onAvailable(Network network) {
                 Log.i(TAG, "Available network=" + network);
                 NetworkCapabilities caps = cm.getNetworkCapabilities(network);
-                if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
-                    callbackDefaultNetwork = network;
+                if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
                     scheduleUnderlyingNetworkSnapshot(false);
-                }
                 if (!isActiveNetwork(network))
                     return;
 
@@ -3048,10 +3046,8 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
                 Log.i(TAG, "Changed capabilities=" + network + " caps=" + networkCapabilities);
-                if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN)) {
-                    callbackDefaultNetwork = network;
+                if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
                     scheduleUnderlyingNetworkSnapshot(false);
-                }
                 if (!isActiveNetwork(network))
                     return;
 
@@ -3076,10 +3072,7 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void onLost(Network network) {
                 Log.i(TAG, "Lost network=" + network + " active=" + isActiveNetwork(network));
-                if (network.equals(callbackDefaultNetwork)) {
-                    callbackDefaultNetwork = null;
-                    scheduleUnderlyingNetworkSnapshot(false);
-                }
+                scheduleUnderlyingNetworkSnapshot(false);
                 if (last_active == null || !last_active.equals(network))
                     return;
 
@@ -3183,7 +3176,6 @@ public class ServiceSinkhole extends VpnService {
 
     private void scheduleUnderlyingNetworkSnapshot(boolean eager) {
         if (destroying) return;
-        underlyingNetworkReducer.offer(sampleUnderlyingNetworks());
         underlyingNetworkHandler.removeCallbacksAndMessages(UNDERLYING_NETWORK_TOKEN);
         Runnable emit = () -> {
             // Re-sample after the burst settles; onLost and capability changes

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/UnderlyingNetworkReducer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/UnderlyingNetworkReducer.java
@@ -1,0 +1,88 @@
+package net.kollnig.missioncontrol.wg;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Reduces noisy Android connectivity callbacks to distinct underlying-network generations.
+ * Android scheduling is deliberately kept in ServiceSinkhole so this class is deterministic.
+ */
+public final class UnderlyingNetworkReducer {
+    /** Shared across ServiceSinkhole instances so generations never restart after recreation. */
+    private static final AtomicLong NEXT_GENERATION = new AtomicLong(0);
+    public static final class Snapshot {
+        public final String defaultNetwork;
+        public final Set<String> nonVpnNetworks;
+        public final long tunEpoch;
+
+        public Snapshot(String defaultNetwork, Set<String> nonVpnNetworks, long tunEpoch) {
+            this.defaultNetwork = defaultNetwork;
+            this.nonVpnNetworks = Collections.unmodifiableSet(new TreeSet<>(nonVpnNetworks));
+            this.tunEpoch = tunEpoch;
+        }
+
+        public boolean isConnected() {
+            return !nonVpnNetworks.isEmpty();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (!(other instanceof Snapshot)) return false;
+            Snapshot that = (Snapshot) other;
+            return tunEpoch == that.tunEpoch &&
+                    java.util.Objects.equals(defaultNetwork, that.defaultNetwork) &&
+                    nonVpnNetworks.equals(that.nonVpnNetworks);
+        }
+
+        @Override
+        public int hashCode() {
+            return java.util.Objects.hash(defaultNetwork, nonVpnNetworks, tunEpoch);
+        }
+    }
+
+    public static final class Event {
+        public final long generation;
+        public final Snapshot snapshot;
+        /** False for a TUN-only invalidation: refresh state, but do not rebind a replacement tunnel. */
+        public final boolean rebindRequired;
+
+        private Event(long generation, Snapshot snapshot, boolean rebindRequired) {
+            this.generation = generation;
+            this.snapshot = snapshot;
+            this.rebindRequired = rebindRequired;
+        }
+    }
+
+    private Snapshot emitted;
+    private Snapshot pending;
+
+    public synchronized void offer(Snapshot snapshot) {
+        pending = snapshot;
+    }
+
+    /** Emits the latest offered snapshot iff it is meaningfully distinct. */
+    public synchronized Event flush() {
+        Snapshot next = pending;
+        pending = null;
+        if (next == null || next.equals(emitted)) return null;
+        boolean rebindRequired;
+        if (emitted == null) {
+            rebindRequired = next.isConnected();
+        } else {
+            boolean connectivityChanged = emitted.isConnected() != next.isConnected();
+            boolean defaultChanged =
+                    !java.util.Objects.equals(emitted.defaultNetwork, next.defaultNetwork);
+            // Mullvad's NOT_VPN stream is primarily a reevaluation trigger.
+            // Candidate identity is the effective path only when Android does
+            // not provide a usable default-network signature.
+            boolean fallbackPathChanged = emitted.defaultNetwork == null &&
+                    next.defaultNetwork == null &&
+                    !emitted.nonVpnNetworks.equals(next.nonVpnNetworks);
+            rebindRequired = connectivityChanged || defaultChanged || fallbackPathChanged;
+        }
+        emitted = next;
+        return new Event(NEXT_GENERATION.incrementAndGet(), next, rebindRequired);
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -109,6 +109,8 @@ object WgEgress {
     private val rebindLock = Any()
     private var rebindInFlight: Boolean = false
     private var rebindDirty: Boolean = false
+    @Volatile private var underlyingNetworkGeneration: Long = 0
+    @Volatile private var underlyingNetworkConnected: Boolean = false
 
     @Volatile private var requestReloadCb: Runnable? = null
     @Volatile private var notifyBrokenCb: Runnable? = null
@@ -141,6 +143,7 @@ object WgEgress {
 
     fun addStateListener(l: Runnable) { listeners.add(l) }
     fun removeStateListener(l: Runnable) { listeners.remove(l) }
+
     private fun notifyStateChanged() {
         for (l in listeners) try { l.run() } catch (e: Throwable) { Log.w(TAG, "listener threw", e) }
     }
@@ -309,6 +312,13 @@ object WgEgress {
 
     private fun onMonitorBroken(expected: TunnelSnapshot) {
         if (!isCurrent(expected)) return
+        // No physical path exists. Keep the fail-closed tunnel in place and
+        // let the next distinct connectivity generation trigger the rebind;
+        // restarting now would only churn sockets against the same absence.
+        if (!underlyingNetworkConnected) {
+            Log.i(TAG, "connectivity monitor: no underlying network; waiting")
+            return
+        }
         // A full restart is already queued; it will rebind everything anyway.
         if (forceRestartPending) return
 
@@ -470,9 +480,18 @@ object WgEgress {
     fun latestHandshakeMillisOrNull(): Long? =
         try { tunnel?.latestHandshakeMillis() } catch (_: Throwable) { null }
 
-    fun onUnderlyingNetworkChanged() {
+    fun onUnderlyingNetworkChanged(generation: Long, connected: Boolean, rebindRequired: Boolean) {
+        synchronized(rebindLock) {
+            if (generation <= underlyingNetworkGeneration) return
+            underlyingNetworkGeneration = generation
+            underlyingNetworkConnected = connected
+        }
         verificationGeneration++
         clearEndpointCache()
+        // TUN replacement invalidates the service's snapshot but does not
+        // indicate an outer-path change. Publishing its generation is useful
+        // for stale-work checks; rebinding the intentionally replaced tunnel is not.
+        if (!rebindRequired || !connected) return
         if (tunnel == null) return
         // A full restart is already queued (and the accompanying reload() is
         // in flight); rebinding concurrently would just race it.
@@ -500,6 +519,15 @@ object WgEgress {
         rebindExecutor.execute {
             try {
                 while (true) {
+                    val expectedUnderlyingGeneration: Long
+                    synchronized(rebindLock) {
+                        if (!underlyingNetworkConnected) {
+                            rebindInFlight = false
+                            rebindDirty = false
+                            return@execute
+                        }
+                        expectedUnderlyingGeneration = underlyingNetworkGeneration
+                    }
                     val expected = captureTunnel()
                     if (expected == null) {
                         synchronized(rebindLock) {
@@ -508,22 +536,38 @@ object WgEgress {
                         }
                         return@execute
                     }
-                    when (tryCheapRecovery(expected)) {
-                        RecoveryResult.SUCCEEDED -> {
-                            if (isCurrent(expected)) lastCheapRecoveryMs = now()
-                        }
-                        RecoveryResult.FAILED -> {
-                            if (!forceRestartPending) {
-                                requestFullRestart(
-                                    "WG rebind failed after network change",
-                                    notify = false,
-                                    expected = expected
-                                )
-                            }
-                        }
-                        RecoveryResult.STALE -> Unit
-                    }
+                    val result = tryCheapRecovery(expected)
                     synchronized(rebindLock) {
+                        // Recovery can block in DNS. Discard its result if a
+                        // newer path (including offline) landed meanwhile.
+                        if (expectedUnderlyingGeneration != underlyingNetworkGeneration ||
+                            !underlyingNetworkConnected) {
+                            if (!underlyingNetworkConnected) {
+                                rebindInFlight = false
+                                rebindDirty = false
+                                return@execute
+                            }
+                            rebindDirty = true
+                        } else when (result) {
+                            RecoveryResult.SUCCEEDED -> {
+                                if (isCurrent(expected)) {
+                                    lastCheapRecoveryMs = now()
+                                    // The liveness loop stops before invoking
+                                    // onBroken. Reconnect must resume it.
+                                    startMonitor(expected)
+                                }
+                            }
+                            RecoveryResult.FAILED -> {
+                                if (!forceRestartPending) {
+                                    requestFullRestart(
+                                        "WG rebind failed after network change",
+                                        notify = false,
+                                        expected = expected
+                                    )
+                                }
+                            }
+                            RecoveryResult.STALE -> Unit
+                        }
                         if (!rebindDirty) {
                             rebindInFlight = false
                             return@execute

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/UnderlyingNetworkReducerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/UnderlyingNetworkReducerTest.java
@@ -1,0 +1,109 @@
+package net.kollnig.missioncontrol.wg;
+
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import org.junit.Test;
+
+public class UnderlyingNetworkReducerTest {
+    private static UnderlyingNetworkReducer.Snapshot snapshot(
+            String defaultNetwork, long tunEpoch, String... networks) {
+        return new UnderlyingNetworkReducer.Snapshot(
+                defaultNetwork, new HashSet<>(Arrays.asList(networks)), tunEpoch);
+    }
+
+    @Test public void eagerSnapshotGetsPositiveGeneration() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertNotNull(event);
+        assertTrue(event.generation > 0);
+        assertTrue(event.snapshot.isConnected());
+        assertTrue(event.rebindRequired);
+    }
+
+    @Test public void burstCollapsesToLatestSnapshot() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        reducer.offer(snapshot("cell", 0, "wifi", "cell"));
+        reducer.offer(snapshot("cell", 0, "cell"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertTrue(event.generation > 0);
+        assertEquals("cell", event.snapshot.defaultNetwork);
+        assertEquals(Collections.singleton("cell"), event.snapshot.nonVpnNetworks);
+    }
+
+    @Test public void redundantCallbacksDoNotAdvanceGeneration() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        long firstGeneration = reducer.flush().generation;
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        assertNull(reducer.flush());
+        reducer.offer(snapshot("cell", 0, "cell"));
+        assertTrue(reducer.flush().generation > firstGeneration);
+    }
+
+    @Test public void sameNetworkWithChangedPathSignatureAdvancesGeneration() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi|dns=one", 0, "wifi|dns=one"));
+        long firstGeneration = reducer.flush().generation;
+        reducer.offer(snapshot("wifi|dns=two", 0, "wifi|dns=two"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertTrue(event.generation > firstGeneration);
+        assertTrue(event.rebindRequired);
+    }
+
+    @Test public void candidatePresenceDefinesConnectivityEvenWithoutDefault() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot(null, 0, "cell"));
+        assertTrue(reducer.flush().snapshot.isConnected());
+        reducer.offer(snapshot(null, 0));
+        assertFalse(reducer.flush().snapshot.isConnected());
+    }
+
+    @Test public void secondaryCandidateDoesNotRebindWhenDefaultIsUnchanged() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        reducer.flush();
+        reducer.offer(snapshot("wifi", 0, "wifi", "cell"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertNotNull(event);
+        assertTrue(event.generation > 0);
+        assertFalse(event.rebindRequired);
+    }
+
+    @Test public void candidateHandoffRebindsWhenDefaultIsUnavailable() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot(null, 0, "wifi"));
+        reducer.flush();
+        reducer.offer(snapshot(null, 0, "cell"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertNotNull(event);
+        assertTrue(event.generation > 0);
+        assertTrue(event.rebindRequired);
+    }
+
+    @Test public void tunTransitionForcesFreshGeneration() {
+        UnderlyingNetworkReducer reducer = new UnderlyingNetworkReducer();
+        reducer.offer(snapshot("wifi", 0, "wifi"));
+        long firstGeneration = reducer.flush().generation;
+        reducer.offer(snapshot("wifi", 1, "wifi"));
+        UnderlyingNetworkReducer.Event event = reducer.flush();
+        assertTrue(event.generation > firstGeneration);
+        assertFalse(event.rebindRequired);
+    }
+
+    @Test public void generationsIncreaseAcrossReducerInstances() {
+        UnderlyingNetworkReducer first = new UnderlyingNetworkReducer();
+        first.offer(snapshot("wifi", 0, "wifi"));
+        long firstGeneration = first.flush().generation;
+
+        UnderlyingNetworkReducer replacement = new UnderlyingNetworkReducer();
+        replacement.offer(snapshot("cell", 0, "cell"));
+        long replacementGeneration = replacement.flush().generation;
+
+        assertTrue(replacementGeneration > firstGeneration);
+    }
+}


### PR DESCRIPTION
## Stacked on

- #615

This PR should be reviewed and merged after #615; its diff contains only the Android underlying-connectivity model.

## Summary

- combine Android's default-network callback with the `INTERNET + NOT_VPN` callback stream
- take an eager physical-network snapshot and debounce callback bursts for 300 ms
- reduce observations to distinct, process-global connectivity generations
- include default path identity, validation/metering, transports, interface, DNS, routes, and link addresses
- feed generation and connected state into `WgEgress`, discarding stale recovery results and avoiding offline restart churn
- invalidate state around TUN transitions without rebinding an intentionally replaced tunnel
- preserve the existing 1500 ms service reload policy as a separate concern

The design follows Mullvad's Android pattern of combining callback streams, debouncing/distincting state, taking an eager initial snapshot, and invalidating connectivity state around TUN transitions. It intentionally does not add `Network.bindSocket`.

## Impact

Wi-Fi/cellular handoffs, DHCP/DNS changes, and callback bursts now produce one coherent physical-path generation. Secondary candidate changes trigger reevaluation without rebinding when the resolved default path is unchanged. Recovery work is discarded when a newer network generation arrives, and liveness monitoring resumes after an offline path reconnects.

## Validation

- focused `UnderlyingNetworkReducerTest` and `WgEgressRecoveryTest`
- full `./gradlew :app:testFdroidDebugUnitTest`
- `./gradlew :app:assembleFdroidDebug`
- native build completed for arm64-v8a, armeabi-v7a, x86, and x86_64
- `git diff --check`
