### PR TITLE
Add bounded VPN connectivity recovery

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2508,6 +2508,9 @@ public class ServiceSinkhole extends VpnService {
                                         statsHandler.sendEmptyMessage(interactive ? MSG_STATS_START : MSG_STATS_STOP);
                                     }
                                 });
+
+                        if (last_interactive)
+                            reArmVpnHealthCheckIfDeferred();
                     } catch (Throwable ex) {
                         Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
 
@@ -3080,6 +3083,14 @@ public class ServiceSinkhole extends VpnService {
     private final VpnHealthRecoveryPolicy vpnHealthPolicy = new VpnHealthRecoveryPolicy();
     private int vpnHealthGeneration;
     private boolean vpnHealthProbeInFlight;
+    // Set when a probe is skipped purely because the screen was off. A brief
+    // screen-off during the scheduled delay would otherwise silently drop the
+    // whole recovery sequence until the next epoch (e.g. next real network
+    // change), leaving a genuinely wedged VPN path unrepaired for a long
+    // time. Re-armed defensively on the next screen-on, without touching the
+    // epoch/trigger model: this only ever schedules the same probe that was
+    // skipped, at the same generation-check guarded entry point.
+    private boolean vpnHealthProbeDeferredForScreenOff;
 
     private void reloadAfterNetworkChange(final String reason) {
         networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
@@ -3128,8 +3139,16 @@ public class ServiceSinkhole extends VpnService {
                 }, VPN_HEALTH_TOKEN, SystemClock.uptimeMillis() + 1_000L);
                 return;
             }
-            if (!Util.isInteractive(this) || !Util.isConnected(this)) {
-                Log.i(TAG, "VPN health check skipped: device inactive or offline");
+            if (!Util.isInteractive(this)) {
+                // Don't drop the sequence: re-check as soon as the screen
+                // turns back on, still gated on the same generation/state
+                // checks above (and on isConnected below).
+                Log.i(TAG, "VPN health check deferred: screen off");
+                vpnHealthProbeDeferredForScreenOff = true;
+                return;
+            }
+            if (!Util.isConnected(this)) {
+                Log.i(TAG, "VPN health check skipped: device offline");
                 return;
             }
             vpnHealthProbeInFlight = true;
@@ -3192,7 +3211,26 @@ public class ServiceSinkhole extends VpnService {
             @Override
             public void run() {
                 vpnHealthGeneration++;
+                vpnHealthProbeDeferredForScreenOff = false;
                 vpnHealthHandler.removeCallbacksAndMessages(VPN_HEALTH_TOKEN);
+            }
+        });
+    }
+
+    // Re-arms a VPN health probe that was previously skipped only because the
+    // screen was off. Safe to call unconditionally (e.g. on every screen-on):
+    // it is a no-op unless a probe was actually deferred, and it reuses the
+    // existing generation-guarded startVpnHealthProbe() entry point, so it
+    // cannot bypass the epoch/recovery budget or run against a stale/stopped
+    // VPN state.
+    private void reArmVpnHealthCheckIfDeferred() {
+        vpnHealthHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (!vpnHealthProbeDeferredForScreenOff)
+                    return;
+                vpnHealthProbeDeferredForScreenOff = false;
+                startVpnHealthProbe(vpnHealthGeneration);
             }
         });
     }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -581,6 +581,8 @@ public class ServiceSinkhole extends VpnService {
                 // Start DoH proxy if enabled and not superseded by WireGuard DNS.
                 updateDnsProxyState();
 
+                scheduleVpnHealthCheck(true, VPN_HEALTH_STARTUP_DELAY_MS);
+
                 removeWarningNotifications();
                 updateEnforcingNotification(listAllowed.size(), listRule.size());
             }
@@ -684,6 +686,7 @@ public class ServiceSinkhole extends VpnService {
         }
 
         private void stop(boolean temporary) {
+            cancelVpnHealthChecks();
             if (vpn != null) {
                 stopNative(vpn);
                 stopVPN(vpn);
@@ -2090,6 +2093,7 @@ public class ServiceSinkhole extends VpnService {
     // Called from native code
     private void nativeExit(String reason) {
         Log.w(TAG, "Native exit reason=" + reason);
+        cancelVpnHealthChecks();
         if (reason != null) {
             showErrorNotification(reason);
 
@@ -3060,6 +3064,23 @@ public class ServiceSinkhole extends VpnService {
     private static final Object NETWORK_RELOAD_TOKEN = new Object();
     private final Handler networkReloadDebounceHandler = new Handler(Looper.getMainLooper());
 
+    // Connectivity checks are event driven: once after startup and once after
+    // physical network transitions. Retries are short, bounded sequences rather
+    // than a permanent polling loop.
+    private static final long VPN_HEALTH_STARTUP_DELAY_MS = 5_000L;
+    private static final long VPN_HEALTH_NETWORK_DELAY_MS = 4_000L;
+    private static final long VPN_HEALTH_RETRY_DELAY_MS = 5_000L;
+    private static final int VPN_HEALTH_CONNECT_TIMEOUT_MS = 2_500;
+    private static final Object VPN_HEALTH_TOKEN = new Object();
+    private static final byte[][] VPN_HEALTH_ENDPOINTS = new byte[][]{
+            {(byte) 9, (byte) 9, (byte) 9, (byte) 9},
+            {(byte) 1, (byte) 1, (byte) 1, (byte) 1}
+    };
+    private final Handler vpnHealthHandler = new Handler(Looper.getMainLooper());
+    private final VpnHealthRecoveryPolicy vpnHealthPolicy = new VpnHealthRecoveryPolicy();
+    private int vpnHealthGeneration;
+    private boolean vpnHealthProbeInFlight;
+
     private void reloadAfterNetworkChange(final String reason) {
         networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
         networkReloadDebounceHandler.postAtTime(new Runnable() {
@@ -3068,8 +3089,112 @@ public class ServiceSinkhole extends VpnService {
                 if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
                     net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged();
                 reload(reason, ServiceSinkhole.this, false);
+                scheduleVpnHealthCheck(true, VPN_HEALTH_NETWORK_DELAY_MS);
             }
         }, NETWORK_RELOAD_TOKEN, SystemClock.uptimeMillis() + NETWORK_RELOAD_DEBOUNCE_MS);
+    }
+
+    private void scheduleVpnHealthCheck(final boolean beginEpoch, final long delayMs) {
+        vpnHealthHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                if (beginEpoch)
+                    vpnHealthPolicy.beginEpoch();
+
+                vpnHealthGeneration++;
+                final int generation = vpnHealthGeneration;
+                vpnHealthHandler.removeCallbacksAndMessages(VPN_HEALTH_TOKEN);
+                vpnHealthHandler.postAtTime(new Runnable() {
+                    @Override
+                    public void run() {
+                        startVpnHealthProbe(generation);
+                    }
+                }, VPN_HEALTH_TOKEN, SystemClock.uptimeMillis() + delayMs);
+            }
+        });
+    }
+
+    private void startVpnHealthProbe(final int generation) {
+        synchronized (this) {
+            if (generation != vpnHealthGeneration ||
+                    state != State.enforcing || vpn == null || temporarilyStopped)
+                return;
+            if (vpnHealthProbeInFlight) {
+                vpnHealthHandler.postAtTime(new Runnable() {
+                    @Override
+                    public void run() {
+                        startVpnHealthProbe(generation);
+                    }
+                }, VPN_HEALTH_TOKEN, SystemClock.uptimeMillis() + 1_000L);
+                return;
+            }
+            if (!Util.isInteractive(this) || !Util.isConnected(this)) {
+                Log.i(TAG, "VPN health check skipped: device inactive or offline");
+                return;
+            }
+            vpnHealthProbeInFlight = true;
+        }
+
+        executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                final boolean vpnReachable = canReachHealthEndpoint(false);
+                final boolean bypassReachable = !vpnReachable && canReachHealthEndpoint(true);
+                vpnHealthHandler.post(new Runnable() {
+                    @Override
+                    public void run() {
+                        finishVpnHealthProbe(generation, vpnReachable, bypassReachable);
+                    }
+                });
+            }
+        });
+    }
+
+    private void finishVpnHealthProbe(int generation, boolean vpnReachable, boolean bypassReachable) {
+        synchronized (this) {
+            vpnHealthProbeInFlight = false;
+            if (generation != vpnHealthGeneration || state != State.enforcing || vpn == null)
+                return;
+        }
+
+        VpnHealthRecoveryPolicy.Action action = vpnHealthPolicy.record(vpnReachable, bypassReachable);
+        Log.i(TAG, "VPN health result vpn=" + vpnReachable + " bypass=" + bypassReachable +
+                " action=" + action);
+        if (action == VpnHealthRecoveryPolicy.Action.RETRY) {
+            scheduleVpnHealthCheck(false, VPN_HEALTH_RETRY_DELAY_MS);
+        } else if (action == VpnHealthRecoveryPolicy.Action.RECOVER) {
+            reload("VPN connectivity recovery", this, false);
+            scheduleVpnHealthCheck(false, VPN_HEALTH_STARTUP_DELAY_MS);
+        } else if (action == VpnHealthRecoveryPolicy.Action.EXHAUSTED) {
+            Log.w(TAG, "VPN connectivity recovery budget exhausted");
+        }
+    }
+
+    private boolean canReachHealthEndpoint(boolean bypassVpn) {
+        for (byte[] address : VPN_HEALTH_ENDPOINTS) {
+            try (Socket socket = new Socket()) {
+                if (bypassVpn && !protect(socket)) {
+                    Log.w(TAG, "Unable to protect VPN health socket");
+                    return false;
+                }
+                socket.connect(new InetSocketAddress(InetAddress.getByAddress(address), 443),
+                        VPN_HEALTH_CONNECT_TIMEOUT_MS);
+                return true;
+            } catch (IOException ex) {
+                Log.d(TAG, "VPN health endpoint unavailable: " + ex);
+            }
+        }
+        return false;
+    }
+
+    private void cancelVpnHealthChecks() {
+        vpnHealthHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                vpnHealthGeneration++;
+                vpnHealthHandler.removeCallbacksAndMessages(VPN_HEALTH_TOKEN);
+            }
+        });
     }
 
     private void listenConnectivityChanges() {
@@ -3260,6 +3385,8 @@ public class ServiceSinkhole extends VpnService {
 
             // Cancel any debounced network-change reload so it doesn't fire post-teardown
             networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
+            vpnHealthGeneration++;
+            vpnHealthHandler.removeCallbacksAndMessages(VPN_HEALTH_TOKEN);
 
             commandLooper.quit();
             logLooper.quit();

--- a/app/src/main/java/eu/faircode/netguard/VpnHealthRecoveryPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/VpnHealthRecoveryPolicy.java
@@ -1,5 +1,7 @@
 package eu.faircode.netguard;
 
+import java.util.ArrayDeque;
+
 /**
  * Keeps connectivity recovery bounded and independent from the probe transport.
  * A recovery is justified only when the VPN path fails while a protected socket
@@ -9,6 +11,27 @@ final class VpnHealthRecoveryPolicy {
     static final int FAILURE_THRESHOLD = 3;
     static final int MAX_RECOVERIES_PER_EPOCH = 2;
 
+    // Absolute, epoch-independent safety net. The per-epoch budget above is
+    // reset by beginEpoch(), which normally only happens on startup or a real
+    // network change. If recovery's own reload() were ever to indirectly
+    // re-trigger the network callback that calls beginEpoch() (unverified,
+    // but not provably impossible), the per-epoch budget alone could be
+    // repeatedly re-armed, producing a reload storm. This rolling wall-clock
+    // cap bounds total recoveries regardless of how many epochs occur, acting
+    // as an AND-gate on top of the existing epoch budget. Values are chosen
+    // conservatively relative to the existing recovery cadence (retries every
+    // VPN_HEALTH_RETRY_DELAY_MS=5s, a recovery re-check after
+    // VPN_HEALTH_STARTUP_DELAY_MS=5s): 4 recoveries per 15 minutes still
+    // allows a couple of legitimate epoch resets (e.g. two real network
+    // changes) to each recover a couple of times, while making a runaway
+    // storm impossible.
+    static final int MAX_RECOVERIES_PER_WINDOW = 4;
+    static final long RECOVERY_WINDOW_MS = 15 * 60 * 1000L;
+
+    interface Clock {
+        long nowMs();
+    }
+
     enum Action {
         NONE,
         RETRY,
@@ -16,12 +39,25 @@ final class VpnHealthRecoveryPolicy {
         EXHAUSTED
     }
 
+    private final Clock clock;
+    private final ArrayDeque<Long> recoveryTimestamps = new ArrayDeque<>();
+
     private int consecutiveVpnFailures;
     private int recoveries;
+
+    VpnHealthRecoveryPolicy() {
+        this(System::currentTimeMillis);
+    }
+
+    VpnHealthRecoveryPolicy(Clock clock) {
+        this.clock = clock;
+    }
 
     synchronized void beginEpoch() {
         consecutiveVpnFailures = 0;
         recoveries = 0;
+        // recoveryTimestamps is intentionally NOT cleared here: the whole
+        // point of the wall-clock cap is that it survives epoch resets.
     }
 
     synchronized Action record(boolean vpnReachable, boolean bypassReachable) {
@@ -43,8 +79,19 @@ final class VpnHealthRecoveryPolicy {
         if (recoveries >= MAX_RECOVERIES_PER_EPOCH)
             return Action.EXHAUSTED;
 
+        long now = clock.nowMs();
+        pruneRecoveryTimestamps(now);
+        if (recoveryTimestamps.size() >= MAX_RECOVERIES_PER_WINDOW)
+            return Action.EXHAUSTED;
+
         recoveries++;
+        recoveryTimestamps.addLast(now);
         return Action.RECOVER;
+    }
+
+    private void pruneRecoveryTimestamps(long now) {
+        while (!recoveryTimestamps.isEmpty() && now - recoveryTimestamps.peekFirst() > RECOVERY_WINDOW_MS)
+            recoveryTimestamps.pollFirst();
     }
 
     synchronized int getRecoveries() {

--- a/app/src/main/java/eu/faircode/netguard/VpnHealthRecoveryPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/VpnHealthRecoveryPolicy.java
@@ -1,0 +1,53 @@
+package eu.faircode.netguard;
+
+/**
+ * Keeps connectivity recovery bounded and independent from the probe transport.
+ * A recovery is justified only when the VPN path fails while a protected socket
+ * can still reach the Internet.
+ */
+final class VpnHealthRecoveryPolicy {
+    static final int FAILURE_THRESHOLD = 3;
+    static final int MAX_RECOVERIES_PER_EPOCH = 2;
+
+    enum Action {
+        NONE,
+        RETRY,
+        RECOVER,
+        EXHAUSTED
+    }
+
+    private int consecutiveVpnFailures;
+    private int recoveries;
+
+    synchronized void beginEpoch() {
+        consecutiveVpnFailures = 0;
+        recoveries = 0;
+    }
+
+    synchronized Action record(boolean vpnReachable, boolean bypassReachable) {
+        if (vpnReachable) {
+            consecutiveVpnFailures = 0;
+            return Action.NONE;
+        }
+
+        if (!bypassReachable) {
+            consecutiveVpnFailures = 0;
+            return Action.NONE;
+        }
+
+        consecutiveVpnFailures++;
+        if (consecutiveVpnFailures < FAILURE_THRESHOLD)
+            return Action.RETRY;
+
+        consecutiveVpnFailures = 0;
+        if (recoveries >= MAX_RECOVERIES_PER_EPOCH)
+            return Action.EXHAUSTED;
+
+        recoveries++;
+        return Action.RECOVER;
+    }
+
+    synchronized int getRecoveries() {
+        return recoveries;
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/VpnHealthRecoveryPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/VpnHealthRecoveryPolicyTest.java
@@ -1,0 +1,76 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class VpnHealthRecoveryPolicyTest {
+    @Test
+    public void healthyVpnNeedsNoRecovery() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertEquals(VpnHealthRecoveryPolicy.Action.NONE, policy.record(true, false));
+        assertEquals(0, policy.getRecoveries());
+    }
+
+    @Test
+    public void offlineDeviceDoesNotCountAsVpnFailure() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.NONE, policy.record(false, false));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+    }
+
+    @Test
+    public void consecutiveVpnOnlyFailuresTriggerRecovery() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RECOVER, policy.record(false, true));
+        assertEquals(1, policy.getRecoveries());
+    }
+
+    @Test
+    public void healthyResultBreaksFailureStreak() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.NONE, policy.record(true, false));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RECOVER, policy.record(false, true));
+    }
+
+    @Test
+    public void recoveryBudgetIsFiniteWithinEpoch() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertRecovery(policy);
+        assertRecovery(policy);
+
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.EXHAUSTED, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.MAX_RECOVERIES_PER_EPOCH, policy.getRecoveries());
+    }
+
+    @Test
+    public void newNetworkEpochRestoresRecoveryBudget() {
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy();
+
+        assertRecovery(policy);
+        assertRecovery(policy);
+        policy.beginEpoch();
+
+        assertRecovery(policy);
+        assertEquals(1, policy.getRecoveries());
+    }
+
+    private static void assertRecovery(VpnHealthRecoveryPolicy policy) {
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RECOVER, policy.record(false, true));
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/VpnHealthRecoveryPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/VpnHealthRecoveryPolicyTest.java
@@ -68,6 +68,61 @@ public class VpnHealthRecoveryPolicyTest {
         assertEquals(1, policy.getRecoveries());
     }
 
+    @Test
+    public void wallClockCapSurvivesEpochReset() {
+        final long[] now = {0L};
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy(() -> now[0]);
+
+        // Two epochs, each recovering up to the per-epoch budget, all within
+        // the wall-clock window. Total recoveries so far: 4, hitting
+        // MAX_RECOVERIES_PER_WINDOW.
+        assertRecovery(policy);
+        now[0] += 1_000L;
+        assertRecovery(policy);
+
+        policy.beginEpoch();
+        now[0] += 1_000L;
+        assertRecovery(policy);
+        now[0] += 1_000L;
+        assertRecovery(policy);
+
+        assertEquals(VpnHealthRecoveryPolicy.MAX_RECOVERIES_PER_WINDOW, 4);
+
+        // A third epoch reset would normally re-arm the per-epoch budget, but
+        // the absolute wall-clock cap must still block further recoveries.
+        policy.beginEpoch();
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.EXHAUSTED, policy.record(false, true));
+    }
+
+    @Test
+    public void wallClockCapReleasesRecoveriesOutsideWindow() {
+        final long[] now = {0L};
+        VpnHealthRecoveryPolicy policy = new VpnHealthRecoveryPolicy(() -> now[0]);
+
+        assertRecovery(policy);
+        now[0] += 1_000L;
+        assertRecovery(policy);
+        policy.beginEpoch();
+        now[0] += 1_000L;
+        assertRecovery(policy);
+        now[0] += 1_000L;
+        assertRecovery(policy);
+
+        // Exhausted immediately after the epoch reset while still inside the window.
+        policy.beginEpoch();
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
+        assertEquals(VpnHealthRecoveryPolicy.Action.EXHAUSTED, policy.record(false, true));
+
+        // Advance past the rolling window: the oldest recoveries age out and
+        // the cap allows a new recovery again.
+        now[0] += VpnHealthRecoveryPolicy.RECOVERY_WINDOW_MS + 1;
+        policy.beginEpoch();
+        assertRecovery(policy);
+    }
+
     private static void assertRecovery(VpnHealthRecoveryPolicy policy) {
         assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));
         assertEquals(VpnHealthRecoveryPolicy.Action.RETRY, policy.record(false, true));


### PR DESCRIPTION
## What changed

- Add event-driven VPN connectivity checks after startup and physical network transitions.
- Probe the VPN path first, then use a protected bypass socket only when that path fails so device connectivity can be distinguished from a stuck VPN data path.
- Require three consecutive VPN-only failures before repair and allow at most two repairs per network epoch.
- Skip checks while the device is inactive or offline, and cancel pending work on stop, native fatal exit, and service teardown.
- Add focused unit coverage for failure streaks, offline results, budget exhaustion, and network-epoch resets.

## Why

The service already reloads around known network changes, but it cannot detect a data path that remains unusable while the underlying device connection still works. This adds bounded recovery without a permanent polling loop and without competing with native fatal-exit handling.

## Impact

Users can recover automatically from a wedged VPN path after startup or a network handoff. Ordinary device-offline states do not trigger VPN restarts, and all probing is limited to short event-driven sequences while the device is interactive.

## Validation

- `./gradlew testGithubDebugUnitTest`
- `./gradlew assembleGithubDebug`
- `git diff --check`
