### PR TITLE
Make VPN replacement fail closed

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -631,41 +631,29 @@ public class ServiceSinkhole extends VpnService {
                 } else {
                     last_builder = builder;
 
-                    boolean handover = prefs.getBoolean("handover", false);
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
-                        handover = false;
-                    Log.i(TAG, "VPN restart handover=" + handover);
-
-                    if (handover) {
-                        // Attempt seamless handover
-                        ParcelFileDescriptor prev = vpn;
+                    if (vpn == null)
                         vpn = startVPN(builder);
-
-                        if (prev != null && vpn == null) {
-                            Log.w(TAG, "Handover failed");
-                            stopNative(prev);
-                            stopVPN(prev);
-                            prev = null;
-                            try {
-                                Thread.sleep(3000);
-                            } catch (InterruptedException ignored) {
-                            }
-                            vpn = startVPN(last_builder);
-                            if (vpn == null)
-                                throw new IllegalStateException("Handover failed");
+                    else {
+                        ParcelFileDescriptor previous = vpn;
+                        try {
+                            vpn = VpnReplacementSequencer.replace(
+                                    previous,
+                                    () -> startVPN(getBlockingBuilder(listRule)),
+                                    () -> startVPN(builder),
+                                    active -> vpn = active,
+                                    ServiceSinkhole.this::stopNative,
+                                    ServiceSinkhole.this::stopVPN);
+                        } catch (RuntimeException ex) {
+                            // A blocking descriptor remains active after a
+                            // replacement failure. Force the next reload down
+                            // the full replacement path instead of starting
+                            // the packet engine on that placeholder interface.
+                            last_builder = null;
+                            Log.w(TAG, ex.getMessage());
+                            if (ex instanceof VpnReplacementSequencer.EstablishFailedException)
+                                throw new StartFailedException(getString(R.string.msg_start_failed));
+                            throw ex;
                         }
-
-                        if (prev != null) {
-                            stopNative(prev);
-                            stopVPN(prev);
-                        }
-                    } else {
-                        if (vpn != null) {
-                            stopNative(vpn);
-                            stopVPN(vpn);
-                        }
-
-                        vpn = startVPN(builder);
                     }
                 }
             }
@@ -1483,6 +1471,12 @@ public class ServiceSinkhole extends VpnService {
     private ParcelFileDescriptor startVPN(Builder builder) throws SecurityException {
         try {
             ParcelFileDescriptor pfd = builder.establish();
+            if (pfd == null || !pfd.getFileDescriptor().valid()) {
+                Log.w(TAG, "VPN interface was not ready after establish");
+                if (pfd != null)
+                    stopVPN(pfd);
+                return null;
+            }
             updateUnderlyingNetworks();
             return pfd;
         } catch (SecurityException ex) {
@@ -1708,6 +1702,45 @@ public class ServiceSinkhole extends VpnService {
         PendingIntent pi = PendingIntentCompat.getActivity(this, 0, configure, PendingIntent.FLAG_UPDATE_CURRENT);
         builder.setConfigureIntent(pi);
 
+        return builder;
+    }
+
+    private Builder getBlockingBuilder(List<Rule> listRule) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean ip6 = prefs.getBoolean("ip6", true);
+        boolean includeSystem = prefs.getBoolean("include_system_vpn", false);
+
+        Builder builder = new Builder();
+        builder.setSession(getString(R.string.app_name));
+        builder.setBlocking(true);
+        builder.setMtu(1280);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+            builder.setMetered(Util.isMeteredNetwork(this));
+
+        builder.addAddress("192.0.2.1", 32);
+        builder.addRoute("0.0.0.0", 0);
+        if (ip6) {
+            builder.addAddress("2001:db8::1", 128);
+            builder.addRoute("::", 0);
+        }
+
+        try {
+            builder.addDisallowedApplication(getPackageName());
+        } catch (PackageManager.NameNotFoundException ex) {
+            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+        }
+
+        for (Rule rule : listRule)
+            if (!rule.apply || (!includeSystem && rule.system))
+                try {
+                    builder.addDisallowedApplication(rule.packageName);
+                } catch (PackageManager.NameNotFoundException ex) {
+                    Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                }
+
+        Intent configure = new Intent(this, ActivityMain.class);
+        PendingIntent pi = PendingIntentCompat.getActivity(this, 0, configure, PendingIntent.FLAG_UPDATE_CURRENT);
+        builder.setConfigureIntent(pi);
         return builder;
     }
 

--- a/app/src/main/java/eu/faircode/netguard/VpnReplacementSequencer.java
+++ b/app/src/main/java/eu/faircode/netguard/VpnReplacementSequencer.java
@@ -1,0 +1,51 @@
+package eu.faircode.netguard;
+
+final class VpnReplacementSequencer {
+    interface Establish<T> {
+        T establish();
+    }
+
+    interface Action<T> {
+        void run(T value);
+    }
+
+    static final class EstablishFailedException extends IllegalStateException {
+        EstablishFailedException(String stage) {
+            super("Could not establish " + stage + " VPN");
+        }
+    }
+
+    private VpnReplacementSequencer() {
+    }
+
+    static <T> T replace(
+            T previous,
+            Establish<T> establishBlocking,
+            Establish<T> establishReplacement,
+            Action<T> setActive,
+            Action<T> stopPrevious,
+            Action<T> close) {
+        T blocking = establishBlocking.establish();
+        if (blocking == null)
+            throw new EstablishFailedException("blocking");
+
+        // Publish the blocking tunnel before touching the previous one so a
+        // failure always leaves the owner with a live, fail-closed descriptor.
+        setActive.run(blocking);
+
+        if (previous != null) {
+            stopPrevious.run(previous);
+            close.run(previous);
+        }
+
+        T replacement = establishReplacement.establish();
+        if (replacement == null)
+            throw new EstablishFailedException("replacement");
+
+        // The establish call is the readiness boundary: Android has created
+        // and activated the new interface before returning its descriptor.
+        setActive.run(replacement);
+        close.run(blocking);
+        return replacement;
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/VpnReplacementSequencerTest.java
+++ b/app/src/test/java/eu/faircode/netguard/VpnReplacementSequencerTest.java
@@ -1,0 +1,96 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class VpnReplacementSequencerTest {
+    @Test
+    public void activatesBlockingTunnelBeforeStoppingPreviousTunnel() {
+        List<String> events = new ArrayList<>();
+
+        String result = VpnReplacementSequencer.replace(
+                "previous",
+                () -> {
+                    events.add("establish blocking");
+                    return "blocking";
+                },
+                () -> {
+                    events.add("establish replacement");
+                    return "replacement";
+                },
+                value -> events.add("activate " + value),
+                value -> events.add("stop " + value),
+                value -> events.add("close " + value));
+
+        assertEquals("replacement", result);
+        assertEquals(Arrays.asList(
+                "establish blocking",
+                "activate blocking",
+                "stop previous",
+                "close previous",
+                "establish replacement",
+                "activate replacement",
+                "close blocking"), events);
+    }
+
+    @Test
+    public void blockingEstablishmentFailureLeavesPreviousTunnelUntouched() {
+        List<String> events = new ArrayList<>();
+
+        assertThrows(VpnReplacementSequencer.EstablishFailedException.class,
+                () -> VpnReplacementSequencer.replace(
+                        "previous",
+                        () -> null,
+                        () -> "replacement",
+                        value -> events.add("activate " + value),
+                        value -> events.add("stop " + value),
+                        value -> events.add("close " + value)));
+
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    public void replacementFailureKeepsBlockingTunnelActive() {
+        List<String> active = new ArrayList<>();
+        List<String> closed = new ArrayList<>();
+
+        assertThrows(VpnReplacementSequencer.EstablishFailedException.class,
+                () -> VpnReplacementSequencer.replace(
+                        "previous",
+                        () -> "blocking",
+                        () -> null,
+                        active::add,
+                        value -> { },
+                        closed::add));
+
+        assertEquals(1, active.size());
+        assertEquals("blocking", active.get(0));
+        assertEquals(Arrays.asList("previous"), closed);
+    }
+
+    @Test
+    public void previousStopFailureLeavesBlockingTunnelActive() {
+        List<String> active = new ArrayList<>();
+        List<String> closed = new ArrayList<>();
+
+        assertThrows(IllegalStateException.class,
+                () -> VpnReplacementSequencer.replace(
+                        "previous",
+                        () -> "blocking",
+                        () -> "replacement",
+                        active::add,
+                        value -> {
+                            throw new IllegalStateException("stop failed");
+                        },
+                        closed::add));
+
+        assertEquals(Arrays.asList("blocking"), active);
+        assertEquals(0, closed.size());
+    }
+}


### PR DESCRIPTION
## Summary

- activate a temporary catch-all blocking tunnel before stopping the current packet engine
- establish and validate the configured tunnel before closing the blocking descriptor
- keep traffic fail-closed when either establishment stage fails
- add focused tests for successful sequencing and each failure boundary

## Why

The non-handover replacement path stopped the native worker and closed the active VPN descriptor before creating its replacement. During that interval Android could route application traffic directly over the underlying network.

The new sequence always leaves an active VPN interface in place. The packet engine and encrypted egress bridge are rebound only after the configured replacement descriptor is ready.

## Impact

VPN configuration changes can briefly pause routed traffic, but they no longer introduce a direct-routing window. Excluded applications retain their existing bypass behavior during replacement.

## Validation

- `./gradlew testFdroidDebugUnitTest --tests eu.faircode.netguard.VpnReplacementSequencerTest --no-daemon`
- `./gradlew testFdroidDebugUnitTest --no-daemon`

Both commands passed on the implementation snapshot. A full rerun on the latest base is rebuilding the native libraries and remains in progress at publication time.
