### PR TITLE
Add feedback when an app can't be launched from details screen (#514)

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -206,6 +206,8 @@ public class DetailsActivity extends AppCompatActivity {
             Intent launch = Common.getLaunchIntent(this, appPackageName);
             if (launch != null)
                 startActivity(launch);
+            else
+                Toast.makeText(this, R.string.launch_app_failed, Toast.LENGTH_SHORT).show();
             return true;
         } else if (itemId == R.id.action_uninstall) {
             Intent intent = new Intent(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -570,6 +570,7 @@ Sincerely,\n\n]]></string>
     <string name="device_not_supported_msg">The operating system of your device does not allow for monitoring and filtering of network communications. This is required for TrackerControl.</string>
 
     <string name="launch_app">Launch &amp; Find trackers</string>
+    <string name="launch_app_failed">This app can\'t be launched</string>
     <string name="countries">Destination Countries</string>
     <string name="countries_explanation">Find out where your phone sends tracking data.\n\nInformation is based on DNS lookups and IP information, and might be inaccurate.</string>
     <string name="countries_loading_failed">Oops.. The country map failed to load. Please tell tc@kollnig.net how this happened.</string>


### PR DESCRIPTION
## What this does

Issue #514 asks for a way to start/launch an app directly from TrackerControl's per-app details screen, instead of relying on a toast telling the user to restart the app manually.

While investigating, I found that `DetailsActivity` already has a "Launch & Find trackers" overflow menu item (`action_launch`, added in 2020 — well before this issue was filed) that calls `PackageManager.getLaunchIntentForPackage()` via `Common.getLaunchIntent()` and starts the target app. So the core capability the issue asks for already exists in the three-dot overflow menu on the details screen.

Rather than duplicating that with a second, confusingly-named "Open app" menu entry, this PR closes the one real gap in the existing implementation: when an app has no launchable activity (e.g. a pure background/system app), tapping "Launch" previously did nothing at all, with no feedback to the user. This PR adds a Toast for that case, so the existing launch action now reliably gives feedback either way.

## Files changed

- `app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java` — in `onOptionsItemSelected`, show a Toast (`R.string.launch_app_failed`) when `Common.getLaunchIntent()` returns null for the `action_launch` menu item, instead of silently doing nothing.
- `app/src/main/res/values/strings.xml` — added `launch_app_failed` = "This app can't be launched" (base locale only; other-locale files untouched).

## Relation to the issue

Closes #514. The reporter wanted a direct way to launch/restart the app from the details screen rather than a fleeting toast telling them to do it manually. That mechanism already existed via the overflow menu's "Launch & Find trackers" action; this PR makes it robust (visible feedback on failure) so it fully satisfies the request.

## Verification

- `./gradlew compileGithubDebugJavaWithJavac` — **BUILD SUCCESSFUL** (compiles cleanly, including resource processing/string reference checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)