### PR TITLE
Make Insights blocked/allowed stat cards tap through to the detailed log

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
@@ -46,6 +46,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.floatingactionbutton.FloatingActionButton
+import eu.faircode.netguard.ActivityLog
 import eu.faircode.netguard.Util
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -77,6 +78,8 @@ class InsightsActivity : AppCompatActivity() {
     private lateinit var llTopDomains: LinearLayout
     private lateinit var llNoData: LinearLayout
     private lateinit var llBlockedAllowed: LinearLayout
+    private lateinit var llBlockedCard: LinearLayout
+    private lateinit var llAllowedCard: LinearLayout
     private lateinit var progressBar: ProgressBar
     private lateinit var fabShare: FloatingActionButton
 
@@ -108,12 +111,27 @@ class InsightsActivity : AppCompatActivity() {
         llTopDomains = findViewById(R.id.llTopDomains)
         llNoData = findViewById(R.id.llNoData)
         llBlockedAllowed = findViewById(R.id.llBlockedAllowed)
+        llBlockedCard = findViewById(R.id.llBlockedCard)
+        llAllowedCard = findViewById(R.id.llAllowedCard)
         progressBar = findViewById(R.id.progressBar)
         fabShare = findViewById(R.id.fabShare)
 
         fabShare.setOnClickListener {
             shareInsights()
         }
+
+        // Tapping the blocked/allowed stat cards opens the detailed traffic
+        // log, so users can see exactly which connections were blocked or
+        // allowed (see issue #563).
+        val openLog = View.OnClickListener {
+            if (Util.canFilter(this)) {
+                startActivity(Intent(this, ActivityLog::class.java))
+            } else {
+                Toast.makeText(this, R.string.msg_unavailable, Toast.LENGTH_SHORT).show()
+            }
+        }
+        llBlockedCard.setOnClickListener(openLog)
+        llAllowedCard.setOnClickListener(openLog)
 
         // Pad the scroll content so the last card isn't hidden behind the navigation bar.
         val scroll = findViewById<ScrollView>(R.id.insightsScroll)

--- a/app/src/main/res/layout/activity_insights.xml
+++ b/app/src/main/res/layout/activity_insights.xml
@@ -90,11 +90,16 @@
 
             <!-- Blocked Card -->
             <LinearLayout
+                android:id="@+id/llBlockedCard"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginEnd="8dp"
                 android:background="@drawable/bg_stat_card_blocked"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:contentDescription="@string/insights_view_blocked_log"
                 android:orientation="vertical"
                 android:paddingStart="20dp"
                 android:paddingEnd="12dp"
@@ -137,11 +142,16 @@
 
             <!-- Allowed Card -->
             <LinearLayout
+                android:id="@+id/llAllowedCard"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:layout_marginStart="8dp"
                 android:background="@drawable/bg_stat_card_allowed"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:contentDescription="@string/insights_view_allowed_log"
                 android:orientation="vertical"
                 android:paddingStart="20dp"
                 android:paddingEnd="12dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -747,6 +747,8 @@ Sincerely,\n\n]]></string>
     <string name="insights_tracking_attempts">Tracker Hosts Contacted</string>
     <string name="insights_blocked">Blocked</string>
     <string name="insights_allowed">Allowed Through</string>
+    <string name="insights_view_blocked_log">View blocked connections in the detailed log</string>
+    <string name="insights_view_allowed_log">View allowed connections in the detailed log</string>
     <string name="insights_tracker_companies">Tracking Companies</string>
     <string name="insights_apps_with_trackers">Apps with Trackers</string>
     <string name="insights_top_tracking_apps">Worst Offending Apps</string>


### PR DESCRIPTION
## Summary

Closes #563.

The Insights screen (`InsightsActivity`) shows aggregate "Blocked" and "Allowed" tracker-attempt counts for the past 7 days, but there was no way to drill into which individual connections were blocked or allowed. This PR makes those two stat cards tappable so they navigate into the existing detailed traffic log (`ActivityLog`, the NetGuard-style per-connection log already reachable from the main menu), where users can see individual blocked/allowed connections.

## What changed

- `app/src/main/res/layout/activity_insights.xml`: gave the "Blocked" and "Allowed" stat card `LinearLayout`s ids (`llBlockedCard` / `llAllowedCard`), made them clickable/focusable with a ripple (`?android:attr/selectableItemBackground`), and added content descriptions for accessibility.
- `app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt`: wires both cards to launch `ActivityLog` via a plain `Intent`, guarded by the same `Util.canFilter()` check (and `msg_unavailable` toast fallback) already used at the existing `ActivityLog` launch site in `ActivityMain.java`, so behavior is consistent across old/new Android versions.
- `app/src/main/res/values/strings.xml`: added two content-description strings (`insights_view_blocked_log`, `insights_view_allowed_log`).

## Investigation notes

- Found the stats screen described in the issue: the "Blocked"/"Allowed" cards in `activity_insights.xml`, rendered by `InsightsActivity`.
- Found the detailed log destination: `eu.faircode.netguard.ActivityLog` — the per-connection NetGuard-style log, already a standalone in-app `Activity` (declared in `AndroidManifest.xml`), currently launched only from `ActivityMain`'s `menu_log` item.
- Confirmed `ActivityLog` has no Intent-extra based pre-filter — its blocked/allowed/protocol filters are driven by persisted `SharedPreferences` toggled from its own options menu, not from an Intent extra a caller can set. Rather than repurpose those shared prefs as a side-channel filter (which would leave a persistent, possibly surprising, change to the user's log-filter settings), this PR just opens the log plainly, per the "keep scope tight" guidance — no new filtering subsystem was built.
- The per-app `TimelineFragment`/`TimelineAdapter` list was considered as an alternative destination, but it only shows tracker-company rollups per app, not the raw per-connection log the issue screenshot's counts refer to.

## Verification

- `./gradlew compileGithubDebugJavaWithJavac` — BUILD SUCCESSFUL (compiles both the Kotlin and Java sources, including the edited `InsightsActivity.kt`).
- Not manually verified on-device in this session (no Android environment attached to the sandbox); the change is a straightforward `OnClickListener` + `Intent` addition using patterns already present elsewhere in the codebase.

## Limitations

- Opens the detailed log without a pre-applied blocked/allowed filter, since `ActivityLog` doesn't expose an Intent-based filter mechanism (see investigation notes above). Users can still toggle "Show allowed"/"Show blocked" from the log's own options menu after arriving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)