### PR TITLE
Add dynamic accessibility labels to app-list Internet toggle (#231)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -261,7 +261,9 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         // Show if Internet access blocked
         final ImageView iv = holder.ivIcon;
         InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
-        setGreyscale(iv, rule.internet && active && internetBlocklist.blockedInternet(rule.uid));
+        boolean blockedInternet = internetBlocklist.blockedInternet(rule.uid);
+        setGreyscale(iv, rule.internet && active && blockedInternet);
+        updateToggleContentDescription(iv, context, rule, blockedInternet);
         holder.ivIcon.setOnClickListener(view -> {
             if (!rule.internet)
                 return;
@@ -282,6 +284,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                 Toast.makeText(context, R.string.internet_blocked, Toast.LENGTH_SHORT).show();
             }
             setGreyscale(iv, !wasBlocked);
+            updateToggleContentDescription(iv, context, rule, !wasBlocked);
         });
 
         boolean pastWeekOnly = !("trackers_all".equals(cachedSort));
@@ -320,6 +323,22 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         // All binding work for those views has been removed to improve scroll performance.
         // The legacy expanded-state code (database queries, AdapterAccess creation,
         // click listeners on hidden views) was the primary cause of scroll jank.
+    }
+
+    /**
+     * Sets a screen-reader-friendly content description on the app icon /
+     * Internet toggle button, reflecting the app's name and current
+     * block/allow state (accessibility fix for #231).
+     */
+    private void updateToggleContentDescription(ImageView iv, Context context, Rule rule, boolean blocked) {
+        final String description;
+        if (!rule.internet)
+            description = context.getString(R.string.toggle_no_internet_description, rule.name);
+        else if (blocked)
+            description = context.getString(R.string.toggle_allow_internet_description, rule.name);
+        else
+            description = context.getString(R.string.toggle_block_internet_description, rule.name);
+        iv.setContentDescription(description);
     }
 
     private void setGreyscale(ImageView iv, boolean on) {

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -263,7 +263,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
         boolean blockedInternet = internetBlocklist.blockedInternet(rule.uid);
         setGreyscale(iv, rule.internet && active && blockedInternet);
-        updateToggleContentDescription(iv, context, rule, blockedInternet);
+        updateToggleContentDescription(iv, context, rule, active, blockedInternet);
         holder.ivIcon.setOnClickListener(view -> {
             if (!rule.internet)
                 return;
@@ -284,7 +284,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                 Toast.makeText(context, R.string.internet_blocked, Toast.LENGTH_SHORT).show();
             }
             setGreyscale(iv, !wasBlocked);
-            updateToggleContentDescription(iv, context, rule, !wasBlocked);
+            updateToggleContentDescription(iv, context, rule, true, !wasBlocked);
         });
 
         boolean pastWeekOnly = !("trackers_all".equals(cachedSort));
@@ -330,10 +330,14 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
      * Internet toggle button, reflecting the app's name and current
      * block/allow state (accessibility fix for #231).
      */
-    private void updateToggleContentDescription(ImageView iv, Context context, Rule rule, boolean blocked) {
+    private void updateToggleContentDescription(ImageView iv, Context context, Rule rule,
+            boolean active, boolean blocked) {
         final String description;
         if (!rule.internet)
             description = context.getString(R.string.toggle_no_internet_description, rule.name);
+        else if (!active)
+            description = context.getString(R.string.toggle_internet_unavailable_description,
+                    rule.name);
         else if (blocked)
             description = context.getString(R.string.toggle_allow_internet_description, rule.name);
         else

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -266,7 +266,11 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             holder.mUncertain.setVisibility(trackerCategory.isUncertain() ? View.VISIBLE : View.GONE);
 
             // Add data to view
-            holder.mTrackerCategoryName.setText(trackerCategory.getDisplayName(mContext));
+            String categoryDisplayName = trackerCategory.getDisplayName(mContext);
+            holder.mTrackerCategoryName.setText(categoryDisplayName);
+            holder.mSwitchTracker.setContentDescription(
+                    String.format(mContext.getString(R.string.toggle_block_category_description),
+                            categoryDisplayName));
             final ArrayAdapter<Tracker> trackersAdapter = new ArrayAdapter<Tracker>(mContext,
                     R.layout.list_item_trackers_details, trackerCategory.getChildren()) {
                 @Override

--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -233,6 +233,7 @@
                     android:layout_height="wrap_content"
                     android:minHeight="0dp"
                     android:textColor="?android:textColorPrimary"
+                    android:contentDescription="@string/vpn_exclude"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/vpn_exclude_name" />
 
@@ -281,6 +282,7 @@
                     android:layout_height="wrap_content"
                     android:minHeight="0dp"
                     android:textColor="?android:textColorPrimary"
+                    android:contentDescription="@string/exclude_vpn"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/root_name" />
 
@@ -327,6 +329,7 @@
                     android:layout_height="wrap_content"
                     android:minHeight="0dp"
                     android:textColor="?android:textColorPrimary"
+                    android:contentDescription="@string/internet_access"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@+id/root_name2" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -468,6 +468,12 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <!-- App Overview -->
     <string name="tracked_app_icon">Disable internet access for this application</string>
     <string name="tracked_app_name">Application Name</string>
+    <!-- Dynamic content descriptions for the app-icon Internet toggle in the app list (issue #231) -->
+    <string name="toggle_block_internet_description">Block internet access for %1$s</string>
+    <string name="toggle_allow_internet_description">Allow internet access for %1$s</string>
+    <string name="toggle_no_internet_description">%1$s has no internet access</string>
+    <!-- Dynamic content description for the per-category tracker-blocking switch -->
+    <string name="toggle_block_category_description">Block trackers in category %1$s</string>
     <plurals name="n_companies_found_week">
         <item quantity="one">contacted %d company last week</item>
         <item quantity="other">contacted %d companies last week</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -472,8 +472,9 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="toggle_block_internet_description">Block internet access for %1$s</string>
     <string name="toggle_allow_internet_description">Allow internet access for %1$s</string>
     <string name="toggle_no_internet_description">%1$s has no internet access</string>
+    <string name="toggle_internet_unavailable_description">Internet access control unavailable for %1$s</string>
     <!-- Dynamic content description for the per-category tracker-blocking switch -->
-    <string name="toggle_block_category_description">Block trackers in category %1$s</string>
+    <string name="toggle_block_category_description">Tracker blocking for category %1$s</string>
     <plurals name="n_companies_found_week">
         <item quantity="one">contacted %d company last week</item>
         <item quantity="other">contacted %d companies last week</item>


### PR DESCRIPTION
## What changed

Fixes the accessibility gap reported in #231: the app icon in the main app list is actually a button that blocks/allows Internet access for that app, but TalkBack had nothing meaningful to announce beyond a static, non-state-aware `contentDescription` added years ago (`tracked_app_icon`, still present as an inert XML default).

- **`app/src/main/java/eu/faircode/netguard/AdapterRule.java`**: added `updateToggleContentDescription()`, called on bind and again right after each tap, that sets the icon's `contentDescription` to reflect the app name and current state:
  - "Block internet access for {name}" when currently allowed
  - "Allow internet access for {name}" when currently blocked
  - "{name} has no internet access" when the app has no Internet permission at all (tapping is a no-op)
- **`app/src/main/res/values/strings.xml`**: added the three new string resources above, plus one more (see below), in the base (English) file only — translations are expected to follow via the usual localization process.
- **`app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java`** and **`app/src/main/res/layout/list_item_trackers_header.xml`**: extended the same fix to the per-tracker details screen, which has the same class of unlabeled-toggle problem:
  - the per-category "Block" `MaterialSwitch` now gets a dynamic content description naming its tracker category (`toggle_block_category_description`)
  - the header's Tracker Protection / Internet Access / Exclude from VPN switches (previously no accessible name at all beyond adjacency to a nearby TextView) now get their existing visible label text as `contentDescription`

No behavior/blocking-logic changes — this is purely accessibility labeling, per the issue's scope.

## Verification

- `./gradlew compileGithubDebugJavaWithJavac` — **BUILD SUCCESSFUL**.
- Not yet spot-checked on-device with TalkBack — please verify the announced text and that state updates correctly after a tap before merging.

Part of #231 (kept open as a tracking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)