### PR TITLE
Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Automated dependency updates.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# Dependabot only opens PRs; nothing auto-merges, so every bump is still
+# reviewed. Version updates run weekly; security updates are always on
+# (they can bypass the version `ignore` rules below).
+
+version: 2
+updates:
+  # --- Android app (Gradle) ---
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+    groups:
+      # Collapse the routine, low-risk churn into a single weekly PR.
+      # Major bumps still come as individual PRs so they get real review.
+      gradle-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # MaxMind geoip2 is pinned to the 4.x line on purpose: 5.x uses Java
+      # language/runtime constructs that don't work on Android. Our usage is
+      # a single country-from-IP lookup (details/CountriesFragment.java), so
+      # there's nothing in 5.x worth a fork. Keep receiving 4.x patch/minor
+      # updates; block the 5.0 major. Security updates are exempt from this.
+      - dependency-name: "com.maxmind.geoip2:geoip2"
+        versions: [">=5.0.0"]
+
+  # --- WireGuard bridge (Rust / Cargo) ---
+  # Embeds gotatun (Mullvad's WireGuard). Updates here are sensitive; treat
+  # these PRs as informational and test on-device before merging.
+  - package-ecosystem: "cargo"
+    directory: "/wgbridge-rs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps(rust)"
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- GitHub Actions workflows ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -333,6 +333,8 @@ dependencies {
     annotationProcessor "com.github.bumptech.glide:compiler:$glide_version"
 
     implementation 'com.opencsv:opencsv:5.12.0'
+    // Pinned to 4.x: geoip2 5.x uses Java constructs incompatible with
+    // Android. Dependabot ignores the 5.0 major (see .github/dependabot.yml).
     implementation 'com.maxmind.geoip2:geoip2:4.4.0'
 
     // Crash reporting


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` to automate routine dependency bumps, and encodes the MaxMind `geoip2` version constraint as an enforced rule.

> Supersedes #626, which was branched off an unmerged triage-doc commit and conflicted with `master`. This is the same dependabot change, cleanly based on `master`.

## Why

Automate regular dependency updates, and stop MaxMind `geoip2` from being bumped to 5.x (which uses Java constructs incompatible with Android). Dependabot handles both — its `ignore` rule is the natural home for the MaxMind constraint, turning a fragile version pin into an enforced, documented rule.

## Details

- **Gradle** (`/`) — weekly; minor/patch grouped into one PR, majors individually for review.
- **Cargo** (`/wgbridge-rs`, the gotatun bridge) — weekly; sensitive, so treat as informational PRs to test on-device before merging.
- **GitHub Actions** (`/`) — weekly; keeps `checkout`, `setup-java`, `gradle/actions`, `cache` current.
- **MaxMind constraint:**
  ```yaml
  - dependency-name: "com.maxmind.geoip2:geoip2"
    versions: [">=5.0.0"]
  ```
  Usage is a single country-from-IP lookup (`details/CountriesFragment.java`), so nothing in 5.x is worth a fork. 4.x patch/minor still flow, and **security** updates bypass version ignores. An inline pin comment was added at the dependency so the rationale is visible in the build file.

## Notes

- Nothing auto-merges — every bump is a reviewed PR. Version updates activate once merged to `master`.
- Dependabot *alerts* are already enabled on the repo; Dependabot *security updates* (the auto-fix PRs) are currently **off** in Settings → Code security — worth enabling so a transitive CVE in the pinned 4.x line still gets a PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)