### PR TITLE
Reproducible updaters for bundled lists + Disconnect category-drift flag

### DIFF
--- a/.github/workflows/update-lists.yml
+++ b/.github/workflows/update-lists.yml
@@ -1,0 +1,96 @@
+name: Update bundled lists
+
+# Refreshes the slow-moving bundled tracker/host lists and opens a PR with the
+# result. Runs monthly; can also be triggered manually. The PR's normal CI (Test
+# workflow, incl. the blocking baseline and DisconnectCategoryCoverageTest) is
+# the gate that catches a bad upstream or a new Disconnect category before ship.
+#
+# Each list has its own reproducible, stdlib-only updater under scripts/
+# (update_*.py). update_exodus_trackers.py comes from PR #622; it is run here if
+# present so the two efforts share one Exodus updater instead of duplicating it.
+
+on:
+  schedule:
+    - cron: '0 6 1 * *'   # 06:00 UTC on the 1st of each month
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Refresh lists
+        env:
+          # Optional: set the repo/org secret to also refresh GeoLite2.
+          MAXMIND_LICENSE_KEY: ${{ secrets.MAXMIND_LICENSE_KEY }}
+        run: |
+          set -uo pipefail
+          updaters=(update_disconnect_list.py update_ddg_tds.py update_exodus_trackers.py)
+          if [ -n "${MAXMIND_LICENSE_KEY:-}" ]; then
+            updaters+=(update_geolite2.py)
+          else
+            echo "::notice::MAXMIND_LICENSE_KEY not set — skipping GeoLite2"
+          fi
+
+          failed=()
+          for u in "${updaters[@]}"; do
+            if [ ! -f "scripts/$u" ]; then
+              echo "::notice::scripts/$u not present — skipping"
+              continue
+            fi
+            echo "=== $u ==="
+            python3 "scripts/$u" || failed+=("$u")
+          done
+
+          if [ "${#failed[@]}" -ne 0 ]; then
+            echo "::warning::updater(s) failed: ${failed[*]} (continuing to PR whatever changed)"
+          fi
+
+      - name: Open PR if anything changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- app/src/main/assets; then
+            echo "No list changes."
+            exit 0
+          fi
+
+          BRANCH="automation/update-lists"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add app/src/main/assets
+          git commit -m "Update bundled tracker/host lists"
+          git push --force-with-lease origin "$BRANCH"
+
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "PR already open for $BRANCH — updated in place."
+          else
+            gh pr create \
+              --base "${GITHUB_REF_NAME}" \
+              --head "$BRANCH" \
+              --title "Update bundled tracker/host lists" \
+              --body "$(cat <<'EOF'
+          Automated refresh of the slow-moving bundled lists via the
+          `scripts/update_*.py` updaters.
+
+          **Review checklist**
+          - [ ] CI (Test workflow) is green — incl. blocking baseline and
+                DisconnectCategoryCoverageTest.
+          - [ ] Diff sizes look sane — no list collapsed to near-empty.
+
+          The `disconnect-blacklist.reversed.json` diff is unreadable by design
+          (stored byte-reversed); rely on the tests instead.
+          EOF
+          )"
+          fi

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerCategory.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerCategory.java
@@ -23,6 +23,7 @@ import net.kollnig.missioncontrol.R;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,23 @@ public class TrackerCategory {
         m.put("ConsentManagers", R.string.tracker_consent);
         m.put(UNCATEGORISED, R.string.tracker_uncategorised);
         LABELS = Collections.unmodifiableMap(m);
+    }
+
+    // Disconnect.me ships finer-grained category names than the UI buckets in
+    // LABELS. This maps each raw Disconnect category to one of those buckets.
+    // Disconnect occasionally renames or adds categories; keep this in sync with
+    // the categories in disconnect-blacklist.reversed.json. Anything neither
+    // aliased here nor already a LABELS key silently folds into UNCATEGORISED —
+    // DisconnectCategoryCoverageTest turns that silent drift into a build failure.
+    private static final Map<String, String> DISCONNECT_ALIASES;
+    static {
+        Map<String, String> m = new HashMap<>();
+        m.put("FingerprintingGeneral", "Fingerprinting");
+        m.put("FingerprintingInvasive", "Fingerprinting");
+        m.put("EmailStrict", "Email");
+        m.put("EmailAggressive", "Email");
+        m.put("Anti-fraud", "Content");
+        DISCONNECT_ALIASES = Collections.unmodifiableMap(m);
     }
 
     public String category;
@@ -104,6 +122,32 @@ public class TrackerCategory {
     public static String canonicalise(String category) {
         if (category != null && LABELS.containsKey(category)) return category;
         return UNCATEGORISED;
+    }
+
+    /**
+     * Map a raw Disconnect.me category name to its canonical TrackerControl
+     * category, applying Disconnect-specific aliases first. Unknown categories
+     * still collapse to {@link #UNCATEGORISED} via {@link #canonicalise}.
+     */
+    public static String mapDisconnectCategory(String category) {
+        String aliased = DISCONNECT_ALIASES.containsKey(category)
+                ? DISCONNECT_ALIASES.get(category)
+                : category;
+        return canonicalise(aliased);
+    }
+
+    /**
+     * Whether a raw Disconnect.me category maps to a real UI bucket rather than
+     * silently folding into {@link #UNCATEGORISED}. Used by
+     * DisconnectCategoryCoverageTest to flag when Disconnect adds or renames a
+     * category the app doesn't yet handle.
+     */
+    public static boolean isRecognisedDisconnectCategory(String category) {
+        if (category == null) return false;
+        String aliased = DISCONNECT_ALIASES.containsKey(category)
+                ? DISCONNECT_ALIASES.get(category)
+                : category;
+        return LABELS.containsKey(aliased) && !UNCATEGORISED.equals(aliased);
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -606,19 +606,10 @@ public class TrackerList {
                     while (reader.hasNext()) {
                         String categoryName = reader.nextName();
 
-                        switch (categoryName) {
-                            case "FingerprintingGeneral":
-                            case "FingerprintingInvasive":
-                                categoryName = "Fingerprinting";
-                                break;
-                            case "EmailStrict":
-                            case "EmailAggressive":
-                                categoryName = "Email";
-                                break;
-                            case "Anti-fraud":
-                                categoryName = "Content";
-                                break;
-                        }
+                        // Map Disconnect's category names onto our UI buckets. The
+                        // mapping lives in TrackerCategory so it is a single source
+                        // of truth that DisconnectCategoryCoverageTest can verify.
+                        String canonicalCategory = TrackerCategory.mapDisconnectCategory(categoryName);
 
                         reader.beginArray();
                         while (reader.hasNext()) {
@@ -637,7 +628,7 @@ public class TrackerList {
                                 }
                                 trackerConsumed = true;
 
-                                Tracker tracker = new Tracker(trackerName, categoryName);
+                                Tracker tracker = new Tracker(trackerName, canonicalCategory);
 
                                 // Parse tracker domains
                                 reader.beginObject();

--- a/app/src/test/java/net/kollnig/missioncontrol/data/DisconnectCategoryCoverageTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/DisconnectCategoryCoverageTest.java
@@ -1,0 +1,101 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Flags when the bundled Disconnect.me list introduces a tracker category that
+ * TrackerControl cannot place into a real UI bucket.
+ *
+ * <p>Disconnect occasionally renames or adds categories. When that happens the
+ * app does not crash — the category simply folds into "Uncategorised" via
+ * {@link TrackerCategory#canonicalise} — but that is a silent loss of signal
+ * nobody would notice. This test turns such drift into a build failure so a
+ * maintainer can add an alias in {@code TrackerCategory.DISCONNECT_ALIASES} or a
+ * new bucket in {@code TrackerCategory.LABELS} (plus a string resource).
+ *
+ * <p>Runs on every unit-test build, so it guards <em>any</em> update to the
+ * bundled asset — the automated {@code update-disconnect.sh} refresh, a manual
+ * edit, or a future change of update mechanism.
+ */
+public class DisconnectCategoryCoverageTest {
+
+    // A Disconnect category is the only place a bare "Name": [ ... ] array key
+    // appears: tracker names are followed by objects and domain keys are URLs,
+    // so neither matches this pattern. Verified against jq's parse of the list.
+    private static final Pattern CATEGORY_KEY =
+            Pattern.compile("\"([A-Za-z][A-Za-z0-9 -]*)\"\\s*:\\s*\\[");
+
+    @Test
+    public void everyBundledDisconnectCategoryMapsToAKnownBucket() throws IOException {
+        Set<String> categories = bundledDisconnectCategories();
+
+        assertTrue("Could not extract any categories from the Disconnect asset — "
+                + "did its format change?", categories.size() >= 5);
+
+        List<String> unrecognised = new ArrayList<>();
+        for (String category : categories) {
+            if (!TrackerCategory.isRecognisedDisconnectCategory(category))
+                unrecognised.add(category);
+        }
+
+        assertTrue("Disconnect.me introduced categories the app can't place: " + unrecognised
+                + ". Add an alias in TrackerCategory.DISCONNECT_ALIASES or a bucket in "
+                + "TrackerCategory.LABELS (+ a string resource) so they stop folding "
+                + "silently into Uncategorised.", unrecognised.isEmpty());
+    }
+
+    private static Set<String> bundledDisconnectCategories() throws IOException {
+        String reversed = new String(
+                Files.readAllBytes(assetPath("disconnect-blacklist.reversed.json")),
+                StandardCharsets.UTF_8);
+        String json = new StringBuilder(reversed).reverse().toString();
+
+        // Scan only from the "categories" object so prose in the license field
+        // can never produce a false positive.
+        int start = json.indexOf("\"categories\"");
+        Matcher m = CATEGORY_KEY.matcher(start >= 0 ? json.substring(start) : json);
+
+        Set<String> categories = new LinkedHashSet<>();
+        while (m.find())
+            categories.add(m.group(1));
+        return categories;
+    }
+
+    private static Path assetPath(String assetName) {
+        Path moduleRelative = Path.of("src", "main", "assets", assetName);
+        if (Files.exists(moduleRelative))
+            return moduleRelative;
+
+        return Path.of("app", "src", "main", "assets", assetName);
+    }
+}

--- a/scripts/update_ddg_tds.py
+++ b/scripts/update_ddg_tds.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Refresh the bundled DuckDuckGo Tracker Radar list.
+
+TrackerControl uses DuckDuckGo's Android Tracker Data Set (TDS) for additional,
+mobile-specific tracker identification (see ``TrackerList.loadDuckDuckGoTrackers``).
+The loader only reads, per tracker domain, ``owner.displayName`` and ``default``
+("block"/"ignore"). The full upstream TDS is ~1.6 MB of rules / prevalence /
+entities the app never touches, so the committed asset
+``app/src/main/assets/duckduckgo-android-tds.json`` keeps only the consumed
+fields: ``{ owner: {name, displayName}, default }`` per tracker (≈100 KB).
+
+This script fetches the current TDS, strips it to those fields, validates that
+every entry still exposes a string ``default`` and ``owner.displayName`` (the
+Java loader aborts the whole list otherwise), and rewrites the asset only when
+the content actually changed.
+
+Note: this tracks the *current* upstream tracker set. If it has grown since the
+last bundled snapshot, more domains become labelled/blockable — which the
+blocking baseline test in CI is there to vet.
+
+Usage:
+    python3 scripts/update_ddg_tds.py           # fetch + refresh asset
+    python3 scripts/update_ddg_tds.py --check    # validate only, never write
+    python3 scripts/update_ddg_tds.py --input f  # use a local android-tds.json
+
+Exit status:
+    0  asset already up to date, or successfully refreshed / validated
+    1  fetch or validation failed (asset left untouched)
+
+Data license: Tracker Radar is Apache-2.0 (DuckDuckGo). This script only mirrors
+their published data and does not relicense it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+DDG_TDS_URL = "https://staticcdn.duckduckgo.com/trackerblocking/v5/current/android-tds.json"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ASSET_PATH = REPO_ROOT / "app" / "src" / "main" / "assets" / "duckduckgo-android-tds.json"
+
+# Guard against an obviously-broken/truncated response.
+MIN_TRACKERS = 100
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "TrackerControl-updater"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"HTTP {resp.status} from {url}")
+        return resp.read().decode("utf-8")
+
+
+def strip(raw: str) -> tuple[str, dict]:
+    """Parse, validate and field-strip the TDS. Returns (asset_text, stats)."""
+    try:
+        root = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"payload is not valid JSON: {e}") from e
+
+    if not isinstance(root, dict) or "trackers" not in root:
+        raise RuntimeError("payload has no top-level 'trackers' object")
+
+    trackers = root["trackers"]
+    if not isinstance(trackers, dict) or not trackers:
+        raise RuntimeError("'trackers' is empty or not an object")
+
+    if len(trackers) < MIN_TRACKERS:
+        raise RuntimeError(
+            f"only {len(trackers)} trackers (< {MIN_TRACKERS}); response looks truncated"
+        )
+
+    stripped: dict = {}
+    for domain, entry in trackers.items():
+        if not isinstance(entry, dict):
+            raise RuntimeError(f"tracker '{domain}' is not an object")
+        owner = entry.get("owner")
+        default = entry.get("default")
+        if not isinstance(owner, dict) or not isinstance(owner.get("displayName"), str):
+            raise RuntimeError(f"tracker '{domain}' lacks a string owner.displayName")
+        if not isinstance(default, str):
+            raise RuntimeError(f"tracker '{domain}' lacks a string 'default'")
+        stripped[domain] = {
+            "owner": {"name": owner.get("name"), "displayName": owner["displayName"]},
+            "default": default,
+        }
+
+    asset = {"version": root.get("version"), "trackers": stripped}
+    # Compact + sorted keys: deterministic output so future diffs are meaningful.
+    text = json.dumps(asset, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return text, {"trackers": len(stripped)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the (fetched or --input) payload but never write the asset",
+    )
+    ap.add_argument(
+        "--input",
+        metavar="FILE",
+        help="read android-tds.json from a local file instead of the network",
+    )
+    ap.add_argument(
+        "--url",
+        default=DDG_TDS_URL,
+        help=f"override the source URL (default: {DDG_TDS_URL})",
+    )
+    args = ap.parse_args()
+
+    try:
+        if args.input:
+            raw = Path(args.input).read_text(encoding="utf-8")
+            source = args.input
+        else:
+            raw = fetch(args.url)
+            source = args.url
+    except Exception as e:  # noqa: BLE001 - report any fetch/read failure cleanly
+        print(f"ERROR: could not obtain payload: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        asset_text, stats = strip(raw)
+    except RuntimeError as e:
+        print(f"ERROR: validation failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Fetched from: {source}")
+    print(f"  trackers (after field-strip): {stats['trackers']}")
+
+    if args.check:
+        print("Validation OK (--check: asset not written).")
+        return 0
+
+    existing = ASSET_PATH.read_text(encoding="utf-8") if ASSET_PATH.exists() else None
+    if existing == asset_text:
+        print(f"Asset already up to date: {ASSET_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    ASSET_PATH.write_text(asset_text, encoding="utf-8")
+    print(f"Updated asset: {ASSET_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_disconnect_list.py
+++ b/scripts/update_disconnect_list.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Refresh the bundled Disconnect.me tracker list.
+
+TrackerControl identifies tracker companies (and, in domain-based blocking mode,
+blocks them) using Disconnect.me's ``services.json`` — the same list Mozilla
+repackages and serves to Firefox via its "shavar" endpoint. TrackerControl
+consumes the canonical upstream directly (see ``TrackerList.loadDisconnectTrackers``).
+
+The committed asset ``app/src/main/assets/disconnect-blacklist.reversed.json`` is
+the whole ``services.json`` object stored *reversed* character-by-character — an
+old workaround for anti-virus scanners flagging the raw domain list (see
+issue #30). This script fetches the current ``services.json``, validates it, and
+rewrites the reversed asset only when the content actually changed.
+
+Note: Disconnect occasionally renames or adds categories. This script does not
+police that (categories fold safely to "Uncategorised" at runtime); the
+``DisconnectCategoryCoverageTest`` unit test is the flag that fails the build
+when a category can no longer be mapped to a UI bucket.
+
+Usage:
+    python3 scripts/update_disconnect_list.py           # fetch + refresh asset
+    python3 scripts/update_disconnect_list.py --check    # validate only, never write
+    python3 scripts/update_disconnect_list.py --input f  # use a local services.json
+
+Exit status:
+    0  asset already up to date, or successfully refreshed / validated
+    1  fetch or validation failed (asset left untouched)
+
+Data license: ``services.json`` is CC BY-NC-SA 4.0 (Disconnect, Inc.); its
+"license" field is preserved verbatim inside the asset. This script only mirrors
+the published list and does not relicense it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+DISCONNECT_URL = (
+    "https://raw.githubusercontent.com/disconnectme/"
+    "disconnect-tracking-protection/master/services.json"
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ASSET_PATH = REPO_ROOT / "app" / "src" / "main" / "assets" / "disconnect-blacklist.reversed.json"
+
+# Guard against an obviously-broken/truncated response.
+MIN_BYTES = 50_000
+
+
+def fetch(url: str) -> str:
+    req = urllib.request.Request(url, headers={"User-Agent": "TrackerControl-updater"})
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"HTTP {resp.status} from {url}")
+        return resp.read().decode("utf-8")
+
+
+def validate(raw: str) -> dict:
+    """Parse and structurally validate services.json. Returns stats on success."""
+    if len(raw.encode("utf-8")) < MIN_BYTES:
+        raise RuntimeError(f"payload is only {len(raw)} chars (< {MIN_BYTES}); looks truncated")
+
+    try:
+        root = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"payload is not valid JSON: {e}") from e
+
+    if not isinstance(root, dict) or "categories" not in root:
+        raise RuntimeError("payload has no top-level 'categories' object")
+
+    categories = root["categories"]
+    if not isinstance(categories, dict) or not categories:
+        raise RuntimeError("'categories' is empty or not an object")
+
+    return {"categories": sorted(categories.keys())}
+
+
+def reverse(text: str) -> str:
+    """Reverse by code point, mirroring Java's StringBuilder(str).reverse()."""
+    reversed_text = text[::-1]
+    if reversed_text[::-1] != text:  # defensive; true for all BMP text
+        raise RuntimeError("reverse round-trip mismatch")
+    return reversed_text
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the (fetched or --input) payload but never write the asset",
+    )
+    ap.add_argument(
+        "--input",
+        metavar="FILE",
+        help="read services.json from a local file instead of the network",
+    )
+    ap.add_argument(
+        "--url",
+        default=DISCONNECT_URL,
+        help=f"override the source URL (default: {DISCONNECT_URL})",
+    )
+    args = ap.parse_args()
+
+    try:
+        if args.input:
+            raw = Path(args.input).read_text(encoding="utf-8")
+            source = args.input
+        else:
+            raw = fetch(args.url)
+            source = args.url
+    except Exception as e:  # noqa: BLE001 - report any fetch/read failure cleanly
+        print(f"ERROR: could not obtain payload: {e}", file=sys.stderr)
+        return 1
+
+    try:
+        stats = validate(raw)
+    except RuntimeError as e:
+        print(f"ERROR: validation failed: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Fetched from: {source}")
+    print(f"  categories ({len(stats['categories'])}): {', '.join(stats['categories'])}")
+
+    if args.check:
+        print("Validation OK (--check: asset not written).")
+        return 0
+
+    reversed_text = reverse(raw)
+    existing = ASSET_PATH.read_text(encoding="utf-8") if ASSET_PATH.exists() else None
+    if existing == reversed_text:
+        print(f"Asset already up to date: {ASSET_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    ASSET_PATH.write_text(reversed_text, encoding="utf-8")
+    print(f"Updated asset: {ASSET_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_geolite2.py
+++ b/scripts/update_geolite2.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Refresh the bundled MaxMind GeoLite2 Country database.
+
+TrackerControl maps tracker server IPs to countries for its country-level
+visualisation using MaxMind's GeoLite2-Country database
+(``app/src/main/assets/GeoLite2-Country.mmdb``).
+
+Unlike the other bundled lists, GeoLite2 is license-gated: downloading it needs a
+(free) GeoLite2 account license key, and its EULA governs redistribution. That is
+exactly why it can only be refreshed through credentialed tooling like this and
+never fetched on-device. Provide the key via the ``MAXMIND_LICENSE_KEY``
+environment variable (or ``--license-key``).
+
+This script downloads the current database tarball, extracts the ``.mmdb``,
+sanity-checks it, and rewrites the asset only when the bytes actually changed.
+
+Usage:
+    MAXMIND_LICENSE_KEY=xxxx python3 scripts/update_geolite2.py         # refresh asset
+    MAXMIND_LICENSE_KEY=xxxx python3 scripts/update_geolite2.py --check  # validate only
+    python3 scripts/update_geolite2.py --input GeoLite2-Country.tar.gz   # use a local tarball
+
+Exit status:
+    0  asset already up to date, or successfully refreshed / validated
+    1  missing key, download, or validation failed (asset left untouched)
+
+Data license: GeoLite2 data is © MaxMind, Inc. and distributed under the GeoLite2
+End User License Agreement. This script only automates the licensed download.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import sys
+import tarfile
+import urllib.request
+from pathlib import Path
+
+EDITION = "GeoLite2-Country"
+DOWNLOAD_URL = (
+    "https://download.maxmind.com/app/geoip_download"
+    "?edition_id={edition}&license_key={key}&suffix=tar.gz"
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ASSET_PATH = REPO_ROOT / "app" / "src" / "main" / "assets" / f"{EDITION}.mmdb"
+
+MIN_BYTES = 1_000_000
+MMDB_MARKER = b"MaxMind.com"  # metadata marker near the end of every .mmdb
+
+
+def fetch(url: str) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": "TrackerControl-updater"})
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        if resp.status != 200:
+            raise RuntimeError(f"HTTP {resp.status} from MaxMind download endpoint")
+        return resp.read()
+
+
+def extract_mmdb(tar_bytes: bytes) -> bytes:
+    """Pull the single .mmdb out of the GeoLite2 tarball."""
+    target = f"{EDITION}.mmdb"
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:gz") as tar:
+        # Match the exact basename of a regular file. Using endswith() here would
+        # also match AppleDouble/pax sidecars like "._GeoLite2-Country.mmdb" that
+        # some tar implementations add.
+        members = [m for m in tar.getmembers() if m.isfile() and Path(m.name).name == target]
+        if not members:
+            raise RuntimeError(f"no {target} found in downloaded archive")
+        if len(members) > 1:
+            raise RuntimeError(f"multiple {target} entries in archive: {[m.name for m in members]}")
+        extracted = tar.extractfile(members[0])
+        if extracted is None:
+            raise RuntimeError("could not read .mmdb from archive")
+        return extracted.read()
+
+
+def validate(mmdb: bytes) -> dict:
+    if len(mmdb) < MIN_BYTES:
+        raise RuntimeError(f"database is only {len(mmdb)} bytes (< {MIN_BYTES}); looks truncated")
+    if MMDB_MARKER not in mmdb[-200_000:]:
+        raise RuntimeError("file does not look like a MaxMind DB (missing metadata marker)")
+    return {"bytes": len(mmdb)}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="download/validate but never write the asset",
+    )
+    ap.add_argument(
+        "--input",
+        metavar="FILE",
+        help="read a local GeoLite2 .tar.gz instead of downloading",
+    )
+    ap.add_argument(
+        "--license-key",
+        default=os.environ.get("MAXMIND_LICENSE_KEY"),
+        help="MaxMind license key (defaults to $MAXMIND_LICENSE_KEY)",
+    )
+    args = ap.parse_args()
+
+    try:
+        if args.input:
+            tar_bytes = Path(args.input).read_bytes()
+            source = args.input
+        else:
+            if not args.license_key:
+                raise RuntimeError(
+                    "no license key: set MAXMIND_LICENSE_KEY or pass --license-key"
+                )
+            source = "MaxMind download endpoint"
+            tar_bytes = fetch(DOWNLOAD_URL.format(edition=EDITION, key=args.license_key))
+        mmdb = extract_mmdb(tar_bytes)
+        stats = validate(mmdb)
+    except Exception as e:  # noqa: BLE001 - report any failure cleanly
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Fetched from: {source}")
+    print(f"  database size: {stats['bytes']} bytes")
+
+    if args.check:
+        print("Validation OK (--check: asset not written).")
+        return 0
+
+    existing = ASSET_PATH.read_bytes() if ASSET_PATH.exists() else None
+    if existing == mmdb:
+        print(f"Asset already up to date: {ASSET_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    ASSET_PATH.write_bytes(mmdb)
+    print(f"Updated asset: {ASSET_PATH.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What & why

Several remote datasets are bundled in `app/src/main/assets/` and read straight from the read-only APK, so they can only be refreshed by shipping a new build. Only the on-device hosts blocklist had an update path; the identification lists (Disconnect/shavar, DuckDuckGo TDS, GeoLite2) were refreshed by hand — easy to forget, and their provenance was undocumented.

Rather than add on-device fetches (a privacy cost for data that changes slowly, and GeoLite2 is license-gated anyway), this refreshes them **at build time** and captures the source + transform for each.

## Updaters (stdlib-only, `--check`/`--input`, validate-before-write, write-only-on-change)

| Script | Source | Transform |
|---|---|---|
| `scripts/update_disconnect_list.py` | Disconnect `services.json` (the list Mozilla repackages as Firefox "shavar") | byte-reverse (AV workaround, #30) |
| `scripts/update_ddg_tds.py` | DuckDuckGo Android TDS | field-strip to `{owner:{name,displayName}, default}` — the only fields the loader reads (~1.6 MB → ~100 KB) |
| `scripts/update_geolite2.py` | MaxMind GeoLite2 (needs `MAXMIND_LICENSE_KEY`) | download tar.gz → extract `.mmdb` |

These follow the same convention as `scripts/update_exodus_trackers.py` from #622, which **stays the single Exodus updater** — the workflow calls it if present and no-ops otherwise, so there's no duplication.

`.github/workflows/update-lists.yml` runs the set monthly (and on demand) and opens a PR. The PR's existing **Test** CI is the gate that vets a bad upstream.

## Disconnect category-drift flag

Disconnect occasionally renames/adds categories. The app already handles unknown categories safely — they fold to *Uncategorised* via `canonicalise` (#571) — but **silently**, so a rename would quietly drop trackers out of their bucket unnoticed.

- The Disconnect→bucket mapping is refactored out of the inline `switch` in `loadDisconnectTrackers` into `TrackerCategory` (`DISCONNECT_ALIASES` + `mapDisconnectCategory` / `isRecognisedDisconnectCategory`) — one testable source of truth. Behavior-preserving.
- `DisconnectCategoryCoverageTest` reads the bundled list and **fails the build** if any category can no longer be mapped to a UI bucket — turning silent drift into a loud CI failure, regardless of how the asset was updated.

## Notes

- **No asset data changes here.** The updaters were run and reverted; this PR ships mechanism only (data refreshes belong in their own test-gated PRs, as in #622).
- Depends on #622 for Exodus (skipped gracefully until it lands).
- GeoLite2 needs a `MAXMIND_LICENSE_KEY` repo secret to be included; otherwise it's skipped.

## Verification

- All three scripts: live `--check`, real write + idempotency, clean revert; GeoLite2 no-key path errors cleanly.
- `testFdroidDebugUnitTest` green: `DisconnectCategoryCoverageTest` + `TrackerListModeTest` + `BlockingBaselineSubsetTest` pass; the refactor is behavior-preserving.

Related: #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)