### PR TITLE
deps: land safe Dependabot bumps; triage jni & gotatun

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -163,12 +163,12 @@ afterEvaluate {
 }
 
 android {
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId "net.kollnig.missioncontrol"
         minSdk 23
-        targetSdk 36
+        targetSdk 37
         //noinspection HighAppVersionCode
         versionCode 2026042701
         versionName "2026.04.27"
@@ -300,7 +300,7 @@ androidComponents {
 }
 
 dependencies {
-    implementation 'androidx.core:core-ktx:1.18.0'
+    implementation 'androidx.core:core-ktx:1.19.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16.1'
 
@@ -315,18 +315,18 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.android.material:material:1.14.0'
     implementation 'androidx.work:work-runtime:2.11.2'
     implementation 'com.google.guava:guava:33.6.0-android'
     annotationProcessor 'androidx.annotation:annotation:1.10.0'
 
     // fix errors with libraries
-    def lifecycle_version = '2.10.0'
+    def lifecycle_version = '2.11.0'
     //implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 
     // https://bumptech.github.io/glide/
-    def glide_version = "5.0.7"
+    def glide_version = "5.0.9"
     implementation("com.github.bumptech.glide:glide:$glide_version") {
         exclude group: "com.android.support"
     }
@@ -349,7 +349,7 @@ dependencies {
     implementation 'com.caverock:androidsvg-aar:1.4'
 
     // OkHttp for DNS-over-HTTPS
-    implementation 'com.squareup.okhttp3:okhttp:5.3.2'
+    implementation 'com.squareup.okhttp3:okhttp:5.4.0'
 }
 
 // Fix lint error on release builds

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         // https://developer.android.com/studio
-        classpath 'com.android.tools.build:gradle:9.0.1'
+        classpath 'com.android.tools.build:gradle:9.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Dec 15 12:41:56 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/wgbridge-rs/Cargo.lock
+++ b/wgbridge-rs/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
 
 [[package]]
 name = "android_logger"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b07e8e73d720a1f2e4b6014766e6039fd2e96a4fa44e2a78d0e1fa2ff49826"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
 dependencies = [
  "android_log-sys",
  "env_filter",
@@ -1018,7 +1018,7 @@ version = "0.1.0"
 dependencies = [
  "android_logger",
  "base64",
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
  "gotatun",
  "hex",
  "ipnetwork",

--- a/wgbridge-rs/Cargo.toml
+++ b/wgbridge-rs/Cargo.toml
@@ -14,13 +14,13 @@ tokio = { version = "1.43", features = ["rt-multi-thread", "net", "sync", "time"
 base64 = "0.22"
 hex = "0.4"
 ipnetwork = "0.21"
-getrandom = "0.2"
+getrandom = "0.3"
 libc = "0.2"
 log = "0.4"
 
 [target.'cfg(target_os = "android")'.dependencies]
 jni = "0.21"
-android_logger = "0.14"
+android_logger = "0.15"
 
 [profile.release]
 lto = true

--- a/wgbridge-rs/src/keys.rs
+++ b/wgbridge-rs/src/keys.rs
@@ -8,7 +8,7 @@ use gotatun::x25519::{PublicKey, StaticSecret};
 /// Returns a fresh base64 WireGuard private key.
 pub fn generate_private_key() -> Result<String, String> {
     let mut bytes = [0u8; 32];
-    getrandom::getrandom(&mut bytes).map_err(|e| format!("getrandom: {e}"))?;
+    getrandom::fill(&mut bytes).map_err(|e| format!("getrandom: {e}"))?;
     // StaticSecret::from clamps the scalar per X25519.
     let secret = StaticSecret::from(bytes);
     Ok(BASE64.encode(secret.to_bytes()))


### PR DESCRIPTION
## Summary

Triage of the five open Dependabot PRs (#629, #630, #631, #632, #633). Each was investigated in an isolated worktree and its fix compiled + tested. This PR **carries the three that are verified green** and **documents the two that need manual work** (left as their own Dependabot PRs).

All five were red in CI. The common thread: four of them (#629–#632) touch the shared Rust crate `wgbridge-rs`, and #633 was blocked by an unrelated `compileSdk` floor. None were safe to merge blind.

## ✅ Included in this PR (verified green)

### #633 — gradle-minor-patch group (8 updates)
- `androidx.core:core-ktx` 1.18.0 → 1.19.0
- `com.google.android.material` 1.13.0 → 1.14.0
- `androidx.lifecycle` 2.10.0 → 2.11.0
- `glide` 5.0.7 → 5.0.9
- `okhttp` 5.3.2 → 5.4.0
- AGP 9.0.1 → 9.2.1, Gradle wrapper 9.2.1 → 9.6.1

**Why CI failed:** `core-ktx:1.19.0` and `glide:5.0.9` declare `minCompileSdk=37` (confirmed from their AAR metadata), but the project was on `compileSdk = 36`, so `:app:checkGithubDebugAarMetadata` failed. AGP ≥9.1.0 is also required — the group's bump to 9.2.1 satisfies that.

**Fix:** bump `compileSdk`/`targetSdk` 36 → 37. Platform 37 is released and installed; **SDK 38 is _not_ needed** (correcting an earlier assumption). `targetSdk` moved in lockstep with `compileSdk`, matching this file's existing convention — this is the one judgment call, since only `compileSdk` is strictly forced by the AAR metadata.

**Verified:** `./gradlew :app:assembleGithubDebug` → BUILD SUCCESSFUL, including the native `wgbridge-rs` build via cargo-ndk.

> Note: the checked-in `gradlew`/`gradlew.bat`/`gradle-wrapper.jar` bootstrap regen from Dependabot's diff is **not** included here — only `distributionUrl` was bumped. The old bootstrap correctly downloads and runs Gradle 9.6.1. If you prefer the full wrapper regen, take those files from #633.

### #631 — android_logger 0.14 → 0.15
Not breaking for our single call site in `jni_bindings.rs` (`Config::with_max_level`/`with_tag`/`init_once` are unchanged in 0.15). Cargo.toml + lock only, no code change. Verified via `cargo ndk` arm64 cross-compile.

### #630 — getrandom 0.2 → 0.3
0.3 renamed the free function `getrandom::getrandom()` → `getrandom::fill()`. Updated the single call site in `keys.rs` (WireGuard private-key generation). **getrandom 0.3.4 was already in the tree** via `gotatun → rand 0.9 → rand_core 0.9`, so this adds no new version; 0.2.17 remains for `ring`/`chacha20poly1305`. Not blocked by any other dep. Verified `cargo build` + `cargo test` (18/18) + arm64 cross-compile.

## ⚠️ NOT included — need manual work (kept as separate Dependabot PRs)

### #629 — jni 0.21 → 0.22  · _fix exists, needs on-device test_
jni 0.22 is a ground-up API redesign, not a signature tweak: `JNIEnv` split into `EnvUnowned`/`Env` (closure-based `with_env` upgrade + `ErrorPolicy`), closure-based thread attachment (`attach_current_thread_permanently` removed), `GlobalRef` → `Global<T>`, `call_method` now takes compile-time `jni_str!`/`jni_sig!`, and `jboolean` changed from `u8` to `bool`.

A full rewrite of `jni_bindings.rs` was produced that **compiles cleanly for all four ABIs** and preserves the exported FFI symbols (verified with `llvm-nm` against the Kotlin `native` declarations). **But** it changes runtime semantics (exception propagation via `ThrowRuntimeExAndDefault`, worker thread attach/detach lifecycle) on the most safety-critical FFI path. **Recommendation:** review + on-device test (tunnel start/stop, key gen, DNS recording) before merging. Too large for a rubber-stamp. The ready fix can be dropped in when someone can validate on a device.

### #632 — gotatun 0.7.2 → 0.8.0  · _defer / file upstream_
**Root cause:** 0.8.0 made `UdpSocket`'s inner an opaque enum (`Socket` / `DisabledIpv6`) to support IPv4-only fallback, and **removed the public `impl AsFd for UdpSocket`**. There is now **no public API to obtain the raw fd** that our code hands to Android's `VpnService.protect(fd)` — this is our loop-prevention / socket-protection path.

A workaround compiles (bind our own `tokio::net::UdpSocket`, protect it, implement gotatun's `UdpSend`/`UdpRecv` on it), but it **swaps gotatun's optimized Linux datapath (`sendmmsg`/`recvmmsg` + UDP GRO) for per-packet send/recv** — more syscalls/wakeups under load, which is a direct throughput **and battery/radio-wakeup** concern for this app. **Recommendation:** don't merge as-is. Preferred path: file an upstream request for a public fallible fd accessor (e.g. `UdpSocket::as_raw_fd() -> Option<RawFd>`) so the optimized datapath is retained, and defer #632 until then. gotatun also migrated internal logging `log` → `tracing` (lock churn only) and added `DeviceBuilder::suspended` (additive).

## Verification summary
| PR | Status | Verification |
|----|--------|--------------|
| #633 gradle group | ✅ included | `assembleGithubDebug` passes (incl. native build) |
| #631 android_logger | ✅ included | arm64 cross-compile clean |
| #630 getrandom | ✅ included | host build + 18/18 tests + arm64 cross-compile |
| #629 jni | ⚠️ documented | fix compiles 4 ABIs, FFI symbols match — needs on-device test |
| #632 gotatun | ⚠️ documented | workaround compiles but regresses UDP datapath — defer |

## Suggested follow-up
- Merge this PR; close #633, #631, #630 as superseded.
- Leave #629 open until someone can on-device test the jni rewrite.
- Leave #632 open (or close with a note) pending an upstream fd accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)