### PR TITLE
Fix Ukrainian blocking mode resources

### DIFF
--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -377,9 +377,9 @@
     <string name="title_log_port">Порт %1$d</string>
     <string name="title_log_copy">Копіювати</string>
     <string-array name="blockingModeNames">
-        <item>@string/режим_блокування_мінімальний</item>
-        <item>@string/режим_блокування_стандартний</item>
-        <item>@string/режим_блокування_суворий</item>
+        <item>@string/blocking_mode_minimal</item>
+        <item>@string/blocking_mode_standard</item>
+        <item>@string/blocking_mode_strict</item>
     </string-array>
     <!-- App Overview -->
     <string name="tracked_app_icon">Вимкнути доступ до Інтернету для цієї програми</string>


### PR DESCRIPTION
## What changed

- Point the Ukrainian `blockingModeNames` array at the existing `blocking_mode_*` string resources.

## Why

The translated array referenced nonexistent Cyrillic resource identifiers, causing Android resource linking to fail for `githubDebug`.

## Impact

GitHub debug builds link successfully, and Ukrainian blocking-mode labels continue to use their localized values.

## Validation

- `./gradlew assembleGithubDebug`
- Installed and verified `net.kollnig.missioncontrol.test` on a connected Pixel 8.
