### PR TITLE
Show app UID and shared-UID siblings, add uid: search filter (#229)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -412,16 +412,21 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                     listResult.addAll(listAll);
                 else {
                     String queryStr = query.toString().toLowerCase().trim();
+                    // Apps sharing a UID are controlled together by the VPN (#229), so let
+                    // users explicitly search for them all with a "uid:<number>" query.
+                    boolean uidOnly = queryStr.startsWith("uid:");
+                    String uidStr = uidOnly ? queryStr.substring(4).trim() : queryStr;
                     int uid;
                     try {
-                        uid = Integer.parseInt(queryStr);
+                        uid = Integer.parseInt(uidStr);
                     } catch (NumberFormatException ignore) {
                         uid = -1;
                     }
                     for (Rule rule : listAll)
-                        if (rule.uid == uid ||
-                                rule.packageName.toLowerCase().contains(queryStr) ||
-                                (rule.name != null && rule.name.toLowerCase().contains(queryStr)))
+                        if (uidOnly ? rule.uid == uid
+                                : rule.uid == uid ||
+                                        rule.packageName.toLowerCase().contains(queryStr) ||
+                                        (rule.name != null && rule.name.toLowerCase().contains(queryStr)))
                             listResult.add(rule);
                 }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -34,6 +34,7 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -153,6 +154,10 @@ public class DetailsActivity extends AppCompatActivity {
         toolbar.setTitle(getString(R.string.app_info));
         toolbar.setSubtitle(appName);
 
+        // Show the app's UID, and any other installed packages that share it (#229),
+        // since blocking rules are applied per-UID and can therefore affect siblings.
+        showUidInfo(appUid);
+
         // Apply window insets so content avoids status/navigation bars.
         // Use padding (not margin) so the AppBarLayout's colored background
         // extends behind the transparent status bar on API 35+.
@@ -180,6 +185,37 @@ public class DetailsActivity extends AppCompatActivity {
                     pagerInitialBottom + sysBars.bottom + extraPadding);
             return insets;
         });
+    }
+
+    /**
+     * Shows the app's UID and, if any other installed packages share it,
+     * their names. Blocking rules in TrackerControl are applied per-UID, so
+     * apps sharing a UID are controlled together (#229) — surfacing this
+     * avoids surprising users when a setting change affects siblings too.
+     *
+     * @param uid The UID of the app being shown
+     */
+    private void showUidInfo(int uid) {
+        TextView tvUid = findViewById(R.id.tvUid);
+        if (uid < 0)
+            return;
+
+        String[] packages = getPackageManager().getPackagesForUid(uid);
+        StringBuilder others = new StringBuilder();
+        if (packages != null)
+            for (String pkg : packages)
+                if (!pkg.equals(appPackageName)) {
+                    if (others.length() > 0)
+                        others.append(", ");
+                    others.append(pkg);
+                }
+
+        String text = getString(R.string.app_uid, uid);
+        if (others.length() > 0)
+            text += "\n" + getString(R.string.app_uid_shared_with, others.toString());
+
+        tvUid.setText(text);
+        tvUid.setVisibility(View.VISIBLE);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -25,6 +25,19 @@
             app:titleTextColor="@android:color/white"
             app:subtitleTextColor="@android:color/white" />
 
+        <TextView
+            android:id="@+id/tvUid"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="4dp"
+            android:textColor="@android:color/white"
+            android:textSize="12sp"
+            android:alpha="0.75"
+            android:visibility="gone"
+            tools:text="App ID (UID): 10123" />
+
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -636,6 +636,9 @@ Sincerely,\n\n]]></string>
     <string name="no_internet">No Internet access</string>
     <string name="bypass_vpn_error">"Cannot block Internet. App is excluded from TrackerControl."</string>
 
+    <string name="app_uid">App ID (UID): %1$d</string>
+    <string name="app_uid_shared_with">Shares app ID with: %1$s</string>
+
     <string name="back">Back</string>
 
     <string name="forever_free">Forever Free</string>


### PR DESCRIPTION
## Summary

Closes #229.

Android apps can share a UID (e.g. via `android:sharedUserId`, or when the
system assigns the same UID to multiple packages). TrackerControl's
blocking is applied per-UID, so a setting change for one app silently
affects its shared-UID siblings — several users found this surprising,
and one commenter specifically asked for visibility into this without
adding UI clutter or new toggles.

This PR adds minimal, unobtrusive visibility into UID sharing:

- **Details screen** (`DetailsActivity`): shows the app's UID under the
  toolbar, and — only if other installed packages share that UID — a
  second line "Shares app ID with: ..." listing them, using
  `PackageManager.getPackagesForUid`.
- **App-list search** (`AdapterRule`'s `Filter`): supports a `uid:<number>`
  query to filter the list down to every app sharing a given UID, so users
  can go find the siblings mentioned in the details screen. Existing
  free-text/UID search behavior is unchanged.
- New strings (`app_uid`, `app_uid_shared_with`) added to the base
  English `strings.xml` only, per the project's translation workflow.

No new settings/toggles were added, keeping the UI as simple as before.

## Test plan

- [x] `./gradlew :app:compileGithubDebugJavaWithJavac` passes.
- [ ] **Manual/screenshot verification needed**: open an app's details
      screen and confirm the UID line appears (and the "shares app ID
      with" line appears for an app that has a shared-UID sibling, e.g.
      two apps from the same vendor using `android:sharedUserId`).
- [ ] **Manual/screenshot verification needed**: in the main app list,
      search `uid:<uid>` for a known UID and confirm only apps with that
      UID are shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)