### PR TITLE
Respect per-app monitoring toggle when recording tracker access (#435)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -217,6 +217,7 @@ public class ServiceSinkhole extends VpnService {
 
     // Cached preferences for shouldTrackApp() - refreshed in reload()
     private volatile SharedPreferences cachedTrackerProtectPrefs;
+    private volatile SharedPreferences cachedApplyPrefs;
     private volatile boolean cachedManageSystem;
 
     private static final int NOTIFY_ENFORCING = 1;
@@ -615,6 +616,7 @@ public class ServiceSinkhole extends VpnService {
 
             // Refresh cached preferences for shouldTrackApp()
             cachedTrackerProtectPrefs = getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+            cachedApplyPrefs = getSharedPreferences("apply", Context.MODE_PRIVATE);
             cachedManageSystem = prefs.getBoolean("manage_system", false);
 
             if (state != State.enforcing) {
@@ -2340,7 +2342,8 @@ public class ServiceSinkhole extends VpnService {
     /**
      * Check if tracking should be applied to this app (blocking/logging).
      * Returns false if:
-     * - Tracker Protection (apply) is disabled for this app
+     * - Monitoring (apply) is disabled for this app
+     * - Tracker Protection (tracker_protect) is disabled for this app
      * - It's a system app and manage_system is disabled
      */
     private boolean shouldTrackApp(int uid) {
@@ -2361,6 +2364,18 @@ public class ServiceSinkhole extends VpnService {
             }
             packageName = packages[0];
             uidToPackage.put(uid, packageName);
+        }
+
+        // Check if monitoring is enabled for this app. When monitoring is off the
+        // app is excluded from the VPN (addDisallowedApplication), but traffic from
+        // system daemons sharing this UID can still reach the tunnel, so no tracker
+        // access must be recorded for it either.
+        SharedPreferences applyPrefs = cachedApplyPrefs;
+        if (applyPrefs == null) {
+            applyPrefs = getSharedPreferences("apply", Context.MODE_PRIVATE);
+        }
+        if (!applyPrefs.getBoolean(packageName, true)) {
+            return false;
         }
 
         // Check if tracker protection is enabled for this app


### PR DESCRIPTION
Fixes #435.

## Problem
With **Manage system apps** on, a user turned **monitoring off** for the "GPS daemon" system app, yet the app list kept showing *"contacted 1 company last week"* (google.com). Clearing the tracker data made it reappear hours later. Expected: with per-app monitoring disabled, no new tracker-contact data should accrue for that app.

## Root cause
The app-list count comes from access rows written by `updateAccess()`. That write is gated by `shouldTrackApp(packet.uid)`:

- Write site: `ServiceSinkhole.java:988` (application log -> `dh.updateAccess(...)`)
- Gate: `ServiceSinkhole.java` `shouldTrackApp(int uid)`

`shouldTrackApp()` checked **tracker protection** (`tracker_protect`) and **`manage_system`**, but never the **`apply`** (monitoring) preference. Turning monitoring off adds the package to `addDisallowedApplication` (`ServiceSinkhole.java:1713-1716`, `1756-1758`), so its own traffic bypasses the VPN — but traffic from **system daemons sharing the same UID** still reaches the tunnel. Because the count query (`TrackerList.getTrackerCountsAndTotal()`) is keyed by UID, those rows kept being written and displayed on the monitoring-off app, and re-accrued after a clear.

## Fix
Add an `apply`/monitoring check to `shouldTrackApp()`, using a cached prefs handle refreshed in `reload()` — matching the existing `cachedTrackerProtectPrefs` pattern. When monitoring is off for the resolved package, no tracker access is recorded. This mirrors the VPN-exclusion semantics already applied when `apply` is false; blocking behaviour for monitored apps is unchanged, and no new setting is introduced.

## Verification
- `./gradlew :app:compileGithubDebugJavaWithJavac` passes.
- **Needs on-device verification:** with Manage system apps on, disable monitoring for a system app (e.g. GPS daemon / a shared-UID system component), clear its tracker data, and confirm over several hours that the "contacted N companies" line does not reappear, while blocking/monitoring of other apps continues normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)