### PR TITLE
Accessibility follow-ups: insights contrast, stat grouping, lint sweep

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -246,6 +246,8 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         ivQueue = actionView.findViewById(R.id.ivQueue);
         swEnabled = actionView.findViewById(R.id.swEnabled);
         ivMetered = actionView.findViewById(R.id.ivMetered);
+        ivQueue.setContentDescription(getString(R.string.msg_queue));
+        ivMetered.setContentDescription(getString(R.string.msg_metered));
 
         // Get daily changing title
         if (!Util.isPlayStoreInstall())

--- a/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
@@ -121,10 +121,12 @@ public class AdapterAccess extends CursorAdapter {
 
         // Set values
         tvTime.setText(new SimpleDateFormat("dd HH:mm").format(time));
-        if (block < 0)
+        if (block < 0) {
             ivBlock.setImageDrawable(null);
-        else {
+            ivBlock.setContentDescription(null);
+        } else {
             ivBlock.setImageResource(block > 0 ? R.drawable.host_blocked : R.drawable.host_allowed);
+            ivBlock.setContentDescription(context.getString(block > 0 ? R.string.blocked : R.string.allowed));
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
                 Drawable wrap = DrawableCompat.wrap(ivBlock.getDrawable());
                 DrawableCompat.setTint(wrap, block > 0 ? colorOff : colorOn);

--- a/app/src/main/java/eu/faircode/netguard/WidgetMain.java
+++ b/app/src/main/java/eu/faircode/netguard/WidgetMain.java
@@ -55,6 +55,9 @@ public class WidgetMain extends AppWidgetProvider {
                     RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widgetmain);
                     views.setOnClickPendingIntent(R.id.ivEnabled, pi);
                     views.setImageViewResource(R.id.ivEnabled, enabled ? R.drawable.ic_rocket_colour : R.drawable.ic_rocket_white_60);
+                    views.setContentDescription(R.id.ivEnabled, context.getString(
+                            enabled ? R.string.widget_toggle_disable_description
+                                    : R.string.widget_toggle_enable_description));
                     appWidgetManager.updateAppWidget(id, views);
                 }
             } catch (Throwable ex) {

--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsHeaderAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsHeaderAdapter.java
@@ -108,12 +108,24 @@ public class InsightsHeaderAdapter extends RecyclerView.Adapter<InsightsHeaderAd
         }
 
         NumberFormat nf = NumberFormat.getNumberInstance(Locale.getDefault());
-        holder.tvBlocked.setText(nf.format(data.getTotalTrackingAttempts()));
-        holder.tvCompanies.setText(String.valueOf(data.getUniqueTrackerCompanies()));
+        String blockedText = nf.format(data.getTotalTrackingAttempts());
+        String companiesText = String.valueOf(data.getUniqueTrackerCompanies());
+        holder.tvBlocked.setText(blockedText);
+        holder.tvCompanies.setText(companiesText);
 
         // Protection percentage + bar (weights divide the bar into blocked/allowed)
         int pct = data.getBlockedPercentage();
-        holder.tvBlockedPct.setText(pct + "%");
+        String pctText = pct + "%";
+        holder.tvBlockedPct.setText(pctText);
+
+        // Group each stat number + label so TalkBack announces them as a
+        // single unit instead of two separate reads.
+        holder.llBlockedStat.setContentDescription(
+                blockedText + ", " + context.getString(R.string.insights_tracking_attempts));
+        holder.llCompaniesStat.setContentDescription(
+                companiesText + ", " + context.getString(R.string.insights_tracker_companies));
+        holder.llBlockedPctStat.setContentDescription(
+                pctText + ", " + context.getString(R.string.insights_blocked));
         LinearLayout.LayoutParams blockedLp =
                 (LinearLayout.LayoutParams) holder.vBlockedProgress.getLayoutParams();
         blockedLp.weight = pct;
@@ -280,6 +292,9 @@ public class InsightsHeaderAdapter extends RecyclerView.Adapter<InsightsHeaderAd
         TextView tvBlockedPct;
         View vBlockedProgress;
         View vAllowedProgress;
+        View llBlockedStat;
+        View llCompaniesStat;
+        View llBlockedPctStat;
 
         ViewHolder(View itemView) {
             super(itemView);
@@ -292,6 +307,9 @@ public class InsightsHeaderAdapter extends RecyclerView.Adapter<InsightsHeaderAd
             tvBlockedPct = itemView.findViewById(R.id.tvHeroBlockedPct);
             vBlockedProgress = itemView.findViewById(R.id.vBlockedProgress);
             vAllowedProgress = itemView.findViewById(R.id.vAllowedProgress);
+            llBlockedStat = itemView.findViewById(R.id.llHeroBlockedStat);
+            llCompaniesStat = itemView.findViewById(R.id.llHeroCompaniesStat);
+            llBlockedPctStat = itemView.findViewById(R.id.llHeroBlockedPctStat);
         }
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsHeaderAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsHeaderAdapter.java
@@ -121,11 +121,14 @@ public class InsightsHeaderAdapter extends RecyclerView.Adapter<InsightsHeaderAd
         // Group each stat number + label so TalkBack announces them as a
         // single unit instead of two separate reads.
         holder.llBlockedStat.setContentDescription(
-                blockedText + ", " + context.getString(R.string.insights_tracking_attempts));
+                context.getString(R.string.accessibility_stat_description, blockedText,
+                        context.getString(R.string.insights_tracking_attempts)));
         holder.llCompaniesStat.setContentDescription(
-                companiesText + ", " + context.getString(R.string.insights_tracker_companies));
+                context.getString(R.string.accessibility_stat_description, companiesText,
+                        context.getString(R.string.insights_tracker_companies)));
         holder.llBlockedPctStat.setContentDescription(
-                pctText + ", " + context.getString(R.string.insights_blocked));
+                context.getString(R.string.accessibility_stat_description, pctText,
+                        context.getString(R.string.insights_blocked)));
         LinearLayout.LayoutParams blockedLp =
                 (LinearLayout.LayoutParams) holder.vBlockedProgress.getLayoutParams();
         blockedLp.weight = pct;

--- a/app/src/main/res/layout/activity_insights.xml
+++ b/app/src/main/res/layout/activity_insights.xml
@@ -399,6 +399,7 @@
             <ImageView
                 android:layout_width="64dp"
                 android:layout_height="64dp"
+                android:importantForAccessibility="no"
                 android:src="@drawable/ic_shield_off"
                 app:tint="?android:attr/textColorSecondary"
                 android:alpha="0.5" />

--- a/app/src/main/res/layout/item_insights_header.xml
+++ b/app/src/main/res/layout/item_insights_header.xml
@@ -52,7 +52,7 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:alpha="0.9"
+                    android:alpha="0.95"
                     android:text="@string/insights_subtitle_7days"
                     android:textColor="@android:color/white"
                     android:textSize="13sp"
@@ -92,15 +92,18 @@
 
                 <!-- Hosts contacted -->
                 <LinearLayout
+                    android:id="@+id/llHeroBlockedStat"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
+                    android:focusable="true"
                     android:orientation="vertical">
 
                     <TextView
                         android:id="@+id/tvHeroBlocked"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:importantForAccessibility="no"
                         android:textColor="@android:color/white"
                         android:textSize="36sp"
                         android:textStyle="bold" />
@@ -108,7 +111,8 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:alpha="0.85"
+                        android:alpha="0.95"
+                        android:importantForAccessibility="no"
                         android:text="@string/insights_tracking_attempts"
                         android:textColor="@android:color/white"
                         android:textSize="11sp" />
@@ -117,15 +121,18 @@
 
                 <!-- Companies count -->
                 <LinearLayout
+                    android:id="@+id/llHeroCompaniesStat"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
+                    android:focusable="true"
                     android:orientation="vertical">
 
                     <TextView
                         android:id="@+id/tvHeroCompanies"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:importantForAccessibility="no"
                         android:textColor="@android:color/white"
                         android:textSize="36sp"
                         android:textStyle="bold" />
@@ -133,7 +140,8 @@
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:alpha="0.85"
+                        android:alpha="0.95"
+                        android:importantForAccessibility="no"
                         android:text="@string/insights_tracker_companies"
                         android:textColor="@android:color/white"
                         android:textSize="11sp" />
@@ -142,8 +150,10 @@
 
                 <!-- Protection % -->
                 <LinearLayout
+                    android:id="@+id/llHeroBlockedPctStat"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:focusable="true"
                     android:gravity="end"
                     android:orientation="vertical">
 
@@ -152,7 +162,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="end"
-                        android:textColor="#A5D6A7"
+                        android:importantForAccessibility="no"
+                        android:textColor="#F1F8E9"
                         android:textSize="36sp"
                         android:textStyle="bold" />
 
@@ -160,7 +171,8 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="end"
-                        android:alpha="0.85"
+                        android:alpha="0.95"
+                        android:importantForAccessibility="no"
                         android:text="@string/insights_blocked"
                         android:textColor="@android:color/white"
                         android:textSize="11sp" />

--- a/app/src/main/res/layout/item_onboarding.xml
+++ b/app/src/main/res/layout/item_onboarding.xml
@@ -18,6 +18,7 @@
             android:layout_height="120dp"
             android:layout_marginBottom="24dp"
             android:layout_gravity="start"
+            android:importantForAccessibility="no"
             android:src="@drawable/ic_rocket2"
             app:tint="?attr/colorAccent" />
 

--- a/app/src/main/res/layout/item_onboarding_blocking_mode.xml
+++ b/app/src/main/res/layout/item_onboarding_blocking_mode.xml
@@ -18,6 +18,7 @@
             android:layout_height="80dp"
             android:layout_marginBottom="16dp"
             android:layout_gravity="start"
+            android:importantForAccessibility="no"
             android:src="@drawable/ic_rocket2"
             app:tint="?attr/colorAccent" />
 

--- a/app/src/main/res/layout/legend.xml
+++ b/app/src/main/res/layout/legend.xml
@@ -18,7 +18,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:src="@drawable/ic_rocket_colour"/>
+            android:src="@drawable/ic_rocket_colour"
+            android:importantForAccessibility="no"/>
 
         <TextView
             android:layout_width="wrap_content"
@@ -53,7 +54,8 @@
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
                     android:background="?attr/colorPrimary"
-                    android:src="@drawable/ic_rocket_white_60"/>
+                    android:src="@drawable/ic_rocket_white_60"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -75,7 +77,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="?attr/iconQueue"/>
+                    android:src="?attr/iconQueue"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -97,7 +100,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="?attr/iconMetered"/>
+                    android:src="?attr/iconMetered"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -120,7 +124,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/wifi_on"/>
+                    android:src="@drawable/wifi_on"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -143,7 +148,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/wifi_off"/>
+                    android:src="@drawable/wifi_off"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -165,7 +171,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/wifi_off_disabled"/>
+                    android:src="@drawable/wifi_off_disabled"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -188,7 +195,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/other_on"/>
+                    android:src="@drawable/other_on"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -211,7 +219,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/other_off"/>
+                    android:src="@drawable/other_off"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -233,7 +242,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/other_off_disabled"/>
+                    android:src="@drawable/other_off_disabled"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -256,7 +266,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/screen_on"/>
+                    android:src="@drawable/screen_on"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -303,7 +314,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/host_allowed"/>
+                    android:src="@drawable/host_allowed"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"
@@ -326,7 +338,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="@drawable/host_blocked"/>
+                    android:src="@drawable/host_blocked"
+                    android:importantForAccessibility="no"/>
 
                 <TextView
                     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,6 +477,9 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="toggle_internet_unavailable_description">Internet access control unavailable for %1$s</string>
     <!-- Dynamic content description for the per-category tracker-blocking switch -->
     <string name="toggle_block_category_description">Tracker blocking for category %1$s</string>
+    <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
+    <string name="widget_toggle_enable_description">Enable tracker blocking</string>
+    <string name="widget_toggle_disable_description">Disable tracker blocking</string>
     <plurals name="n_companies_found_week">
         <item quantity="one">contacted %d company last week</item>
         <item quantity="other">contacted %d companies last week</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,7 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
     <string name="widget_toggle_enable_description">Enable tracker blocking</string>
     <string name="widget_toggle_disable_description">Disable tracker blocking</string>
+    <string name="accessibility_stat_description">%1$s, %2$s</string>
     <plurals name="n_companies_found_week">
         <item quantity="one">contacted %d company last week</item>
         <item quantity="other">contacted %d companies last week</item>


### PR DESCRIPTION
Refs #636

## Summary

Addresses the three "Candidate follow-ups" items from the a11y tracking issue that were in scope for automated work (color contrast, stat grouping, lint triage). The remaining items (on-device TalkBack pass, live-region announcements, focus/traversal order review) are intentionally left for a follow-up, as noted in the issue.

## 1. Color-contrast fixes (insights hero card)

`app/src/main/res/layout/item_insights_header.xml` sits on the `bg_insights_hero` gradient (`#8B0000` → `#B71C1C` → `#D32F2F`, darkest to lightest). Contrast was measured against both the darkest stop (best case) and the lightest stop (worst case, where the text sits over `#D32F2F`), using the standard WCAG relative-luminance formula.

| Element | Before | Contrast (darkest / lightest stop) | After | Contrast (darkest / lightest stop) |
|---|---|---|---|---|
| "Last 7 Days" subtitle (13sp bold, alpha 0.9) | white @ 90% alpha | 8.2:1 / **4.28:1** (fails 4.5:1) | white @ 95% alpha | 9.2:1 / **4.62:1** (passes) |
| Stat labels: "Tracker Hosts Contacted" / "Tracking Companies" / "Blocked" (11sp, alpha 0.85) | white @ 85% alpha | 7.0:1 / **3.96:1** (fails) | white @ 95% alpha | 9.2:1 / **4.62:1** (passes) |
| Protection % value (36sp bold) | hardcoded `#A5D6A7` | 6.09:1 / **3.03:1** (marginal, large-text-only) | `#F1F8E9` (pale green, same accent family) | 9.22:1 / **4.59:1** (passes AA for all text sizes) |
| Stat numbers (36sp bold), "Last 7 Days" icon, Share button | white, full alpha | 4.98:1–10:1 | unchanged | unchanged |

All text now clears 4.5:1 against the gradient's lightest stop, not just the 3:1 "large text" bar. The green accent on the percentage was kept (spirit of the original design) but lightened enough to pass at its actual (non-large-text-only) contrast requirement.

## 2. Group stat number + label for TalkBack

`item_insights_header.xml`: each of the three stat blocks (tracking attempts, tracker companies, protection %) is now a single `focusable="true"` `LinearLayout` container; the number and label `TextView`s inside are marked `importantForAccessibility="no"`. `InsightsHeaderAdapter.onBindViewHolder` sets a combined `contentDescription` on each container (e.g. `"128, Tracker Hosts Contacted"`), so TalkBack reads each metric as one swipe stop instead of two.

## 3. Lint accessibility triage

Ran `./gradlew :app:lintGithubDebug` (full report generated despite the task exiting non-zero on pre-existing, unrelated errors — see Notes). 24 `ContentDescription` findings triaged:

**Fixed (cheap, in this PR):**
- `AdapterAccess.java` (`access.xml` `ivBlock`) — per-connection blocked/allowed icon now gets a `contentDescription` (mirrors the pattern already used for the access-log adapter in #634).
- `ActivityMain.java` (`actionmain.xml` `ivQueue` / `ivMetered`) — "busy" and "metered network" header icons now get a `contentDescription` built from their existing toast strings (`msg_queue`, `msg_metered`).
- `WidgetMain.java` (`widgetmain.xml` `ivEnabled`) — home-screen widget toggle now gets a state-aware `contentDescription` via new strings `widget_toggle_enable_description` / `widget_toggle_disable_description`.
- 13 purely decorative icons marked `importantForAccessibility="no"` (each already has an adjacent text label conveying the same information): 12 icons in `legend.xml`, plus the onboarding illustrations in `item_onboarding.xml` / `item_onboarding_blocking_mode.xml`, and the insights "no data" empty-state icon in `activity_insights.xml`.

**Remaining (listed, not fixed here):**
- `actionmain.xml` `ivIcon` (master rocket logo / long-press "about" trigger) — ambiguous purpose (branding + hidden gesture), needs a product decision on wording rather than a mechanical fix.
- `log.xml` `ivConnection` / `ivInteractive` — lint false positive; these already get a dynamic `contentDescription` set in `AdapterLog.java` from #634, just not statically declared in XML.
- `traffic.xml` `ivTraffic` — a live-drawn traffic-rate graph with no static text equivalent; needs a proper dynamic/summary description, out of scope for a "cheap fix".
- All other lint categories (`RtlHardcoded`, `UseCompoundDrawables`, `HardcodedText`, etc.) are non-accessibility or pre-existing and out of scope for this issue.

## Not in this PR (per issue, left for follow-up)

- On-device TalkBack pass for #625 / #634.
- Live-region / dynamic state-change announcements.
- Focus/traversal order review on main and details screens.

## Notes

- New strings (`widget_toggle_enable_description`, `widget_toggle_disable_description`) added to base English `strings.xml` only, matching the #625/#634 pattern; translations follow via the normal localization process.
- `./gradlew :app:lintGithubDebug` currently fails to *exit* 0 due to pre-existing, unrelated resource-linking/format errors in translated strings (e.g. a mistranslated `@string/...` reference in `values-uk-rUA`, and a `%` formatting issue in `values-da-rDK`) — these predate this PR and are a known symptom of the Crowdin string-recreation issue tracked separately. The lint *report* itself still generates correctly and was used for the triage above.
- `./gradlew :app:compileGithubDebugJavaWithJavac` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
