### PR TITLE
Add tracker:<company> app-list search (#447)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -911,6 +911,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         });
 
         final SearchView searchView = (SearchView) menuSearch.getActionView();
+        // Hint at the "tracker:<company>" search prefix (#447), which filters apps
+        // by the tracker companies they have been observed contacting.
+        searchView.setQueryHint(getString(R.string.menu_search_hint));
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -60,9 +60,12 @@ import net.kollnig.missioncontrol.DetailsActivity;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
+import net.kollnig.missioncontrol.data.TrackerList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> implements Filterable {
     private static final String TAG = "TrackerControl.Adapter";
@@ -78,6 +81,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
     private boolean wifiActive = true;
     private boolean otherActive = true;
     private boolean live = true;
+    private final Context appContext;
     private List<Rule> listAll = new ArrayList<>();
     private List<Rule> listFiltered = new ArrayList<>();
     private int iconSize;
@@ -106,6 +110,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
     public AdapterRule(Context context, View anchor) {
         this.anchor = anchor;
+        this.appContext = context.getApplicationContext();
         this.inflater = LayoutInflater.from(context);
         this.glideOptions = new RequestOptions().format(DecodeFormat.PREFER_RGB_565);
 
@@ -402,6 +407,11 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         }
     }
 
+    // Prefix that switches the search box from matching app name/package/uid to
+    // matching the tracker companies an app has been observed contacting, e.g.
+    // "tracker:gravy analytics" (#447).
+    private static final String TRACKER_SEARCH_PREFIX = "tracker:";
+
     @Override
     public Filter getFilter() {
         return new Filter() {
@@ -412,17 +422,35 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                     listResult.addAll(listAll);
                 else {
                     String queryStr = query.toString().toLowerCase().trim();
-                    int uid;
-                    try {
-                        uid = Integer.parseInt(queryStr);
-                    } catch (NumberFormatException ignore) {
-                        uid = -1;
+                    if (queryStr.startsWith(TRACKER_SEARCH_PREFIX)) {
+                        String company = queryStr.substring(TRACKER_SEARCH_PREFIX.length()).trim();
+                        // Built once per filter invocation (single DB scan), not per
+                        // row, and runs on this Filter's background thread.
+                        Map<Integer, Set<String>> trackersByUid =
+                                TrackerList.getInstance(appContext).getTrackerNamesByUid();
+                        for (Rule rule : listAll) {
+                            Set<String> companies = trackersByUid.get(rule.uid);
+                            if (companies == null)
+                                continue;
+                            for (String name : companies)
+                                if (name != null && name.toLowerCase().contains(company)) {
+                                    listResult.add(rule);
+                                    break;
+                                }
+                        }
+                    } else {
+                        int uid;
+                        try {
+                            uid = Integer.parseInt(queryStr);
+                        } catch (NumberFormatException ignore) {
+                            uid = -1;
+                        }
+                        for (Rule rule : listAll)
+                            if (rule.uid == uid ||
+                                    rule.packageName.toLowerCase().contains(queryStr) ||
+                                    (rule.name != null && rule.name.toLowerCase().contains(queryStr)))
+                                listResult.add(rule);
                     }
-                    for (Rule rule : listAll)
-                        if (rule.uid == uid ||
-                                rule.packageName.toLowerCase().contains(queryStr) ||
-                                (rule.name != null && rule.name.toLowerCase().contains(queryStr)))
-                            listResult.add(rule);
                 }
 
                 FilterResults result = new FilterResults();

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -64,6 +64,7 @@ import net.kollnig.missioncontrol.data.TrackerList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -421,7 +422,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                 if (query == null)
                     listResult.addAll(listAll);
                 else {
-                    String queryStr = query.toString().toLowerCase().trim();
+                    String queryStr = query.toString().toLowerCase(Locale.ROOT).trim();
                     if (queryStr.startsWith(TRACKER_SEARCH_PREFIX)) {
                         String company = queryStr.substring(TRACKER_SEARCH_PREFIX.length()).trim();
                         // Built once per filter invocation (single DB scan), not per
@@ -433,7 +434,7 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
                             if (companies == null)
                                 continue;
                             for (String name : companies)
-                                if (name != null && name.toLowerCase().contains(company)) {
+                                if (name != null && name.toLowerCase(Locale.ROOT).contains(company)) {
                                     listResult.add(rule);
                                     break;
                                 }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -239,6 +239,32 @@ public class TrackerList {
     }
 
     /**
+     * Retrieves the set of contacted tracker company names, per app UID (#447), so
+     * the app-list search can filter apps by "tracker:<company>". A single DB scan
+     * builds a lookup for every app at once, instead of querying per row; the
+     * caller (AdapterRule's search Filter) already runs on a background thread, so
+     * no caching is needed here.
+     *
+     * @return Map of app UID to the set of tracker company names observed for it
+     */
+    public synchronized Map<Integer, Set<String>> getTrackerNamesByUid() {
+        Map<Integer, Set<String>> trackers = new ArrayMap<>();
+
+        try (Cursor cursor = databaseHelper.getHosts()) {
+            if (cursor.moveToFirst()) {
+                do {
+                    int appUid = cursor.getInt(cursor.getColumnIndexOrThrow("uid"));
+                    String hostname = cursor.getString(cursor.getColumnIndexOrThrow("daddr"));
+                    Tracker tracker = findTracker(hostname);
+                    checkTracker(trackers, appUid, tracker);
+                } while (cursor.moveToNext());
+            }
+        }
+
+        return trackers;
+    }
+
+    /**
      * Helper method to check tracker
      *
      * @param trackers Set of seen trackers

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="channel_access">Access notifications</string>
 
     <string name="menu_search">Search for app</string>
+    <string name="menu_search_hint">Search app, or tracker:company</string>
     <string name="menu_filter">Filter apps</string>
     <string name="menu_app_user">Show user apps</string>
     <string name="menu_app_system">Show system apps</string>


### PR DESCRIPTION
Implements #447: let users search which installed apps have contacted a particular tracker company or SDK.

## What

The existing app-list search box now understands a `tracker:` prefix. A query like

```
tracker:gravy analytics
```

filters the app list to apps whose observed/contacted tracker companies contain the query substring (case-insensitive). Plain queries keep the existing name/package/uid search behaviour unchanged.

## How

- `TrackerList.getTrackerNamesByUid()` — a single scan over the recorded hosts, mapping each app UID to the set of contacted tracker company names (same traversal pattern as the existing `getTrackerCountsAndTotal()`).
- `AdapterRule.getFilter()` — on a `tracker:`-prefixed query, builds that lookup once per filter invocation on the `Filter`'s background thread (no per-row DB queries, no UI-thread work), then keeps apps whose company set has a substring match.
- Discoverability: the SearchView now shows the query hint "Search app, or tracker:company" (new base-English string `menu_search_hint` only; translations left to Crowdin).

No new screens, settings, or dependencies.

## Usage example

1. Open TrackerControl, tap the search icon on the Apps tab.
2. Type `tracker:facebook` — the list shrinks to apps that have contacted Facebook-owned tracker domains.
3. Tap an app to open its details and see/block the trackers.

## Manual verification needed

- On a device with recorded traffic: `tracker:facebook` (or another company seen in app details) returns the expected apps; a nonsense company returns an empty list.
- Plain searches (app name, package, numeric uid) behave exactly as before.
- The new query hint shows in the expanded SearchView and does not truncate awkwardly on narrow screens.
- Search performance with a large host log (lookup is one DB scan per keystroke after the 300 ms debounce — please sanity-check on a long-running install).

Note: like the "contacted N companies" counts, this searches *observed* tracker contacts recorded by TC, not static SDK analysis, and interacts with the hidden-app search stubs from 58a9e0a only in that tracker-search matches are restricted to the visible list (stubs carry no tracker data).

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)