### PR TITLE
Improve Android test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,8 +110,10 @@ jobs:
       - name: Prefetch Gradle dependencies
         run: |
           ./gradlew :app:dependencies
-          # Warm the cache for the androidTest classpath (androidx.test.*)
-          # so the offline emulator run below doesn't need network access.
+          # Warm the cache for the androidTest classpath (androidx.test.*).
+          # Running the tests themselves still needs network access: the
+          # Unified Test Platform runner classpath (UTP, dagger, protobuf,
+          # etc.) is only resolved once a device is actually connected.
           ./gradlew :app:assembleFdroidDebugAndroidTest
 
       - name: Enable KVM
@@ -129,4 +131,4 @@ jobs:
           arch: x86_64
           ndk: 27.2.12479018
           profile: pixel_7
-          script: ./gradlew connectedFdroidDebugAndroidTest --offline
+          script: ./gradlew connectedFdroidDebugAndroidTest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,11 @@ jobs:
         run: |
           ./gradlew :app:dependencies
           ./gradlew :app:prefetchAndroidLintDependencies
+          # :app:dependencies only resolves dependency metadata, not the
+          # actual test-variant classpath artifacts (e.g. mockwebserver3).
+          # Compile the unit tests online once so their classpath is cached
+          # before the offline run below.
+          ./gradlew :app:assembleFdroidDebugUnitTest
 
       - name: Run Rust unit tests
         run: cargo test --manifest-path wgbridge-rs/Cargo.toml --locked --offline
@@ -105,6 +110,9 @@ jobs:
       - name: Prefetch Gradle dependencies
         run: |
           ./gradlew :app:dependencies
+          # Warm the cache for the androidTest classpath (androidx.test.*)
+          # so the offline emulator run below doesn't need network access.
+          ./gradlew :app:assembleFdroidDebugAndroidTest
 
       - name: Enable KVM
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,3 +47,50 @@ jobs:
 
       - name: Build debug APK
         run: ./gradlew assembleGithubDebug
+
+  instrumentation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Set up Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup target add armv7-linux-androideabi aarch64-linux-android i686-linux-android x86_64-linux-android
+          cargo install cargo-ndk
+
+      - name: Cache cargo registry and build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            wgbridge-rs/target
+          key: cargo-android-${{ runner.os }}-${{ hashFiles('wgbridge-rs/Cargo.lock') }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Run instrumentation tests
+        uses: reactivecircus/android-emulator-runner@v2.38.0
+        with:
+          api-level: 37
+          arch: x86_64
+          ndk: 27.2.12479018
+          profile: pixel_7
+          script: ./gradlew connectedGithubDebugAndroidTest

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -156,10 +156,12 @@ tasks.register('wgbridgeBuild') {
     }
 }
 
-// Force the native library to be present before packaging; preBuild runs
-// before all variant tasks.
-afterEvaluate {
-    tasks.named('preBuild').configure { dependsOn 'wgbridgeBuild' }
+// Only packaging/installation needs the Android Rust library. Keeping this off
+// preBuild is important: JVM unit tests compile app code but never load the
+// Android .so, and should not cross-compile four release ABIs first.
+tasks.configureEach { task ->
+    if (task.name ==~ /merge.*JniLibFolders/)
+        task.dependsOn 'wgbridgeBuild'
 }
 
 android {
@@ -172,6 +174,7 @@ android {
         //noinspection HighAppVersionCode
         versionCode 2026042701
         versionName "2026.04.27"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Secure DNS (DoH) configuration
         buildConfigField "String", "DEFAULT_DOH_ENDPOINT", "\"https://dns.quad9.net/dns-query\""
@@ -281,6 +284,9 @@ android {
         disable 'MissingTranslation'
         disable 'ExtraTranslation'
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     namespace = 'net.kollnig.missioncontrol'
     buildFeatures {
         buildConfig = true
@@ -303,6 +309,9 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.19.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16.1'
+    testImplementation 'com.squareup.okhttp3:mockwebserver3:5.4.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/app/src/androidTest/java/net/kollnig/missioncontrol/wgbridge/WgbridgeInstrumentedTest.java
+++ b/app/src/androidTest/java/net/kollnig/missioncontrol/wgbridge/WgbridgeInstrumentedTest.java
@@ -1,0 +1,32 @@
+package net.kollnig.missioncontrol.wgbridge;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+/** Exercises the packaged Rust library through its real JNI entry points. */
+@RunWith(AndroidJUnit4.class)
+public class WgbridgeInstrumentedTest {
+    @Test
+    public void generatedKeysRoundTripAcrossJni() {
+        String firstPrivateKey = Wgbridge.generatePrivateKey();
+        String secondPrivateKey = Wgbridge.generatePrivateKey();
+
+        assertNotNull(firstPrivateKey);
+        assertNotNull(secondPrivateKey);
+        assertEquals(44, firstPrivateKey.length());
+        assertEquals(44, Wgbridge.publicKey(firstPrivateKey).length());
+        assertNotEquals(firstPrivateKey, secondPrivateKey);
+        assertNotEquals(Wgbridge.publicKey(firstPrivateKey), Wgbridge.publicKey(secondPrivateKey));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void invalidPrivateKeyIsReportedAsJavaException() {
+        Wgbridge.publicKey("not-a-wireguard-key");
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
@@ -15,6 +15,7 @@ import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 public class WgProfileManager {
     private static final String TAG = "TrackerControl.WgProfiles";
@@ -201,6 +202,7 @@ public class WgProfileManager {
 
     public void deleteProfile(String id) {
         JSONArray profiles = readProfilesJson();
+        String active = getActiveProfileId();
         JSONArray kept = new JSONArray();
         for (int i = 0; i < profiles.length(); i++) {
             JSONObject profile = profiles.optJSONObject(i);
@@ -213,7 +215,7 @@ public class WgProfileManager {
         if (kept.length() == 0) {
             editor.remove(PREF_WG_PROFILE);
             editor.remove(PREF_WG_CONFIG);
-        } else {
+        } else if (id.equals(active) || findJsonProfile(kept, active) == null) {
             JSONObject next = kept.optJSONObject(0);
             if (next != null) {
                 editor.putString(PREF_WG_PROFILE, next.optString("id"));
@@ -578,7 +580,7 @@ public class WgProfileManager {
     }
 
     private String newId() {
-        return "wg-" + System.currentTimeMillis();
+        return "wg-" + UUID.randomUUID();
     }
 
     private static String normalizeCountry(String countryCode) {

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -377,9 +377,9 @@
     <string name="title_log_port">Порт %1$d</string>
     <string name="title_log_copy">Копіювати</string>
     <string-array name="blockingModeNames">
-        <item>@string/режим_блокування_мінімальний</item>
-        <item>@string/режим_блокування_стандартний</item>
-        <item>@string/режим_блокування_суворий</item>
+        <item>@string/blocking_mode_minimal</item>
+        <item>@string/blocking_mode_standard</item>
+        <item>@string/blocking_mode_strict</item>
     </string-array>
     <!-- App Overview -->
     <string name="tracked_app_icon">Вимкнути доступ до Інтернету для цієї програми</string>

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
@@ -1,0 +1,129 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseHelperMigrationTest {
+    private DatabaseHelper helper;
+    private SQLiteDatabase database;
+
+    @Before
+    public void setUp() {
+        helper = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        database = SQLiteDatabase.create(null);
+    }
+
+    @After
+    public void tearDown() {
+        database.close();
+    }
+
+    @Test
+    public void upgradeFrom21AddsUncertainWithoutLosingAccessRows() {
+        createVersion16AccessTable(database);
+        database.execSQL("ALTER TABLE access ADD COLUMN sent INTEGER");
+        database.execSQL("ALTER TABLE access ADD COLUMN received INTEGER");
+        database.execSQL("ALTER TABLE access ADD COLUMN connections INTEGER");
+        database.execSQL("INSERT INTO access "
+                + "(uid, version, protocol, daddr, dport, time, allowed, block, sent, received, connections) "
+                + "VALUES (1001, 4, 6, 'tracker.example', 443, 123456, 0, 1, 10, 20, 3)");
+        database.setVersion(21);
+
+        helper.onUpgrade(database, 21, 22);
+
+        assertEquals(22, database.getVersion());
+        assertTrue(columnExists("access", "uncertain"));
+        try (Cursor cursor = database.rawQuery("SELECT * FROM access WHERE uid = 1001", null)) {
+            assertTrue(cursor.moveToFirst());
+            assertEquals("tracker.example", cursor.getString(cursor.getColumnIndexOrThrow("daddr")));
+            assertEquals(10, cursor.getInt(cursor.getColumnIndexOrThrow("sent")));
+            assertEquals(20, cursor.getInt(cursor.getColumnIndexOrThrow("received")));
+            assertEquals(3, cursor.getInt(cursor.getColumnIndexOrThrow("connections")));
+            assertTrue(cursor.isNull(cursor.getColumnIndexOrThrow("uncertain")));
+        }
+    }
+
+    @Test
+    public void upgradeFrom16PreservesDataAndBuildsCurrentSchema() {
+        createVersion16AccessTable(database);
+        database.execSQL("CREATE UNIQUE INDEX idx_access "
+                + "ON access(uid, version, protocol, daddr, dport)");
+        database.execSQL("CREATE TABLE dns ("
+                + "ID INTEGER PRIMARY KEY AUTOINCREMENT, time INTEGER NOT NULL, "
+                + "qname TEXT NOT NULL, aname TEXT NOT NULL, resource TEXT NOT NULL, ttl INTEGER)");
+        database.execSQL("CREATE UNIQUE INDEX idx_dns ON dns(qname, resource)");
+        database.execSQL("INSERT INTO access "
+                + "(uid, version, protocol, daddr, dport, time, allowed, block) "
+                + "VALUES (2002, 4, 17, '1.2.3.4', 53, 654321, 1, 0)");
+        database.execSQL("INSERT INTO dns (time, qname, aname, resource, ttl) "
+                + "VALUES (654321, 'example.org', 'alias.example.org', '1.2.3.4', 60)");
+        database.setVersion(16);
+
+        helper.onUpgrade(database, 16, 22);
+
+        assertEquals(22, database.getVersion());
+        assertTrue(columnExists("access", "sent"));
+        assertTrue(columnExists("access", "received"));
+        assertTrue(columnExists("access", "connections"));
+        assertTrue(columnExists("access", "uncertain"));
+        assertTrue(tableExists("app"));
+        assertTrue(indexExists("idx_access_block"));
+        assertTrue(indexExists("idx_access_daddr"));
+        assertTrue(indexExists("idx_dns_resource"));
+
+        try (Cursor cursor = database.rawQuery("SELECT uid, daddr, block FROM access", null)) {
+            assertTrue(cursor.moveToFirst());
+            assertEquals(2002, cursor.getInt(0));
+            assertEquals("1.2.3.4", cursor.getString(1));
+            assertEquals(0, cursor.getInt(2));
+        }
+        try (Cursor cursor = database.rawQuery("SELECT qname, aname, resource FROM dns", null)) {
+            assertTrue(cursor.moveToFirst());
+            assertEquals("example.org", cursor.getString(0));
+            assertEquals("alias.example.org", cursor.getString(1));
+            assertEquals("1.2.3.4", cursor.getString(2));
+        }
+    }
+
+    private static void createVersion16AccessTable(SQLiteDatabase db) {
+        db.execSQL("CREATE TABLE access ("
+                + "ID INTEGER PRIMARY KEY AUTOINCREMENT, uid INTEGER NOT NULL, "
+                + "version INTEGER NOT NULL, protocol INTEGER NOT NULL, daddr TEXT NOT NULL, "
+                + "dport INTEGER NOT NULL, time INTEGER NOT NULL, allowed INTEGER, block INTEGER NOT NULL)");
+    }
+
+    private boolean columnExists(String table, String column) {
+        try (Cursor cursor = database.rawQuery("PRAGMA table_info(" + table + ")", null)) {
+            while (cursor.moveToNext())
+                if (column.equals(cursor.getString(cursor.getColumnIndexOrThrow("name"))))
+                    return true;
+        }
+        return false;
+    }
+
+    private boolean tableExists(String table) {
+        return schemaObjectExists("table", table);
+    }
+
+    private boolean indexExists(String index) {
+        return schemaObjectExists("index", index);
+    }
+
+    private boolean schemaObjectExists(String type, String name) {
+        try (Cursor cursor = database.rawQuery(
+                "SELECT 1 FROM sqlite_master WHERE type = ? AND name = ?", new String[] { type, name })) {
+            return cursor.moveToFirst();
+        }
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -1,0 +1,111 @@
+package net.kollnig.missioncontrol.dns;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.RecordedRequest;
+import okio.Buffer;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 36)
+public class DnsOverHttpsClientTest {
+    private static final byte[] QUERY = new byte[] {
+            0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    private static final byte[] RESPONSE = new byte[] {
+            0x12, 0x34, (byte) 0x81, (byte) 0x80, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+    };
+
+    private MockWebServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        DnsOverHttpsClient.resetInstance();
+        server = new MockWebServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        DnsOverHttpsClient.resetInstance();
+        server.close();
+    }
+
+    @Test
+    public void resolvePostsDnsWireMessageAndReturnsResponse() throws Exception {
+        server.enqueue(dnsResponse(200, RESPONSE));
+
+        byte[] result = client().resolve(QUERY);
+
+        assertArrayEquals(RESPONSE, result);
+        RecordedRequest request = server.takeRequest(1, TimeUnit.SECONDS);
+        assertEquals("POST", request.getMethod());
+        assertEquals("application/dns-message", request.getHeaders().get("Accept"));
+        assertEquals("application/dns-message", request.getHeaders().get("Content-Type"));
+        assertArrayEquals(QUERY, request.getBody().toByteArray());
+    }
+
+    @Test
+    public void resolveRejectsEmptyQueryWithoutNetworkRequest() throws Exception {
+        assertNull(client().resolve(new byte[0]));
+
+        assertNull(server.takeRequest(100, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void resolveDoesNotRetryClientError() {
+        server.enqueue(dnsResponse(400, new byte[0]));
+
+        assertNull(client().resolve(QUERY));
+
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    public void resolveRetriesServerErrorsThenGivesUp() {
+        server.enqueue(dnsResponse(503, new byte[0]));
+        server.enqueue(dnsResponse(503, new byte[0]));
+        server.enqueue(dnsResponse(503, new byte[0]));
+
+        assertNull(client().resolve(QUERY));
+
+        assertEquals(3, server.getRequestCount());
+    }
+
+    @Test
+    public void resolveRetriesInvalidShortDnsResponse() {
+        server.enqueue(dnsResponse(200, new byte[] { 1, 2, 3 }));
+        server.enqueue(dnsResponse(200, RESPONSE));
+
+        assertArrayEquals(RESPONSE, client().resolve(QUERY));
+
+        assertEquals(2, server.getRequestCount());
+    }
+
+    private DnsOverHttpsClient client() {
+        return DnsOverHttpsClient.getInstance(server.url("/dns-query").toString());
+    }
+
+    private static MockResponse dnsResponse(int status, byte[] body) {
+        return new MockResponse.Builder()
+                .code(status)
+                .addHeader("Content-Type", "application/dns-message")
+                .body(new Buffer().write(body))
+                .build();
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
@@ -1,0 +1,203 @@
+package net.kollnig.missioncontrol.wg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import net.kollnig.missioncontrol.R;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 36, qualifiers = "en")
+public class WgProfileManagerTest {
+    private Context context;
+    private SharedPreferences prefs;
+    private WgProfileManager manager;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.edit().clear().commit();
+        manager = new WgProfileManager(context);
+    }
+
+    @Test
+    public void migratesLegacyConfigAndMakesItActive() {
+        prefs.edit().putString(WgProfileManager.PREF_WG_CONFIG, "legacy-config").commit();
+
+        manager.migrateIfNeeded();
+
+        List<WgProfileManager.Profile> profiles = manager.getProfiles();
+        assertEquals(1, profiles.size());
+        assertEquals(context.getString(R.string.msg_wg_profile_default_name), profiles.get(0).name);
+        assertEquals("legacy-config", profiles.get(0).config);
+        assertEquals(profiles.get(0).id, manager.getActiveProfileId());
+    }
+
+    @Test
+    public void migrationRepairsMissingActiveProfileAndConfig() throws Exception {
+        JSONArray profiles = new JSONArray()
+                .put(profile("first", "First", "first-config", "", "", "", ""))
+                .put(profile("second", "Second", "second-config", "", "", "", ""));
+        prefs.edit()
+                .putString(WgProfileManager.PREF_WG_PROFILES, profiles.toString())
+                .putString(WgProfileManager.PREF_WG_PROFILE, "missing")
+                .putString(WgProfileManager.PREF_WG_CONFIG, "stale")
+                .commit();
+
+        manager.migrateIfNeeded();
+
+        assertEquals("first", manager.getActiveProfileId());
+        assertEquals("first-config", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void saveUpdateAndSelectProfilesKeepLegacyConfigInSync() throws Exception {
+        manager.saveProfile("", "One", "config-1", "mullvad", " acct ", "NL", "Netherlands");
+        String first = manager.getActiveProfileId();
+        manager.saveProfile("", "Two", "config-2", "ivpn", "ivpn-account", "DE", "Germany");
+        String second = manager.getActiveProfileId();
+
+        assertFalse(first.equals(second));
+        manager.saveProfile(first, "Renamed", "config-1b", "mullvad", "acct", "us", "USA");
+        assertEquals(first, manager.getActiveProfileId());
+        assertEquals("Renamed", manager.getProfile(first).name);
+        assertEquals("us", manager.getProfile(first).countryCode);
+        assertEquals("config-1b", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+
+        manager.setActiveProfile(second);
+        assertEquals(second, manager.getActiveProfileId());
+        assertEquals("config-2", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+        manager.setActiveProfile("does-not-exist");
+        assertEquals(second, manager.getActiveProfileId());
+    }
+
+    @Test
+    public void deletingInactiveProfilePreservesActiveSelection() throws Exception {
+        manager.saveProfile("", "One", "config-1");
+        String first = manager.getActiveProfileId();
+        manager.saveProfile("", "Two", "config-2");
+        String second = manager.getActiveProfileId();
+
+        manager.deleteProfile(first);
+
+        assertEquals(second, manager.getActiveProfileId());
+        assertEquals("config-2", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void deletingActiveSelectsFirstRemainingThenClearsLast() throws Exception {
+        manager.saveProfile("", "One", "config-1");
+        String first = manager.getActiveProfileId();
+        manager.saveProfile("", "Two", "config-2");
+        String second = manager.getActiveProfileId();
+
+        manager.deleteProfile(second);
+        assertEquals(first, manager.getActiveProfileId());
+        assertEquals("config-1", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+
+        manager.deleteProfile(first);
+        assertTrue(manager.getProfiles().isEmpty());
+        assertFalse(prefs.contains(WgProfileManager.PREF_WG_PROFILE));
+        assertFalse(prefs.contains(WgProfileManager.PREF_WG_CONFIG));
+    }
+
+    @Test
+    public void providerAndCountryLookupPreferActiveAndNormalizeCountry() throws Exception {
+        manager.saveProfile("", "Mullvad NL", "m-nl", "mullvad", "m-account", " NL ", "Netherlands");
+        String mullvad = manager.getActiveProfileId();
+        manager.saveProfile("", "IVPN NL", "i-nl", "ivpn", "i-account", "Nl", "Netherlands");
+
+        assertEquals(mullvad, manager.findMullvadProfileForCountry("nL").id);
+        assertEquals("i-nl", manager.findIvpnProfileForCountry(" NL ").config);
+        assertNull(manager.findMullvadProfileForCountry(""));
+        assertEquals("i-nl", manager.getProviderConfig("ivpn", "i-account"));
+        assertTrue(manager.hasProviderProfiles("mullvad", "m-account"));
+        assertFalse(manager.hasProviderProfiles("mullvad", "wrong"));
+    }
+
+    @Test
+    public void providerAccountsAreRecoveredAndAccountChangesClearCredentials() throws Exception {
+        manager.saveProfile("", "Mullvad", "config", "mullvad", "m-account");
+        manager.saveProfile("", "IVPN", "config", "ivpn", "i-account");
+        assertEquals("i-account", manager.getLastIvpnAccount());
+        assertEquals("m-account", manager.getLastMullvadAccount());
+
+        manager.saveMullvadDeviceId(" device ");
+        manager.saveMullvadAccount("another");
+        assertEquals("", manager.getMullvadDeviceId());
+
+        manager.saveIvpnSession(new WgProfileManager.IvpnSession("token", "private", "public", "10.0.0.1/32"));
+        assertNotNull(manager.getIvpnSession("i-account"));
+        manager.saveIvpnAccount("different");
+        assertNull(manager.getIvpnSession("i-account"));
+        assertFalse(prefs.contains(WgProfileManager.PREF_IVPN_SESSION_TOKEN));
+    }
+
+    @Test
+    public void rewriteProviderInterfaceUpdatesMatchingProfilesAndActiveConfig() throws Exception {
+        String config = "[Interface]\nPrivateKey = old\nAddress = 10.0.0.1/32\n" +
+                "# keep me\n[Peer]\nPublicKey = peer\nEndpoint = example:51820\n";
+        manager.saveProfile("", "Mullvad", config, "mullvad", "account");
+
+        assertTrue(manager.rewriteProviderInterface("mullvad", " account ", "new", "10.0.0.2/32"));
+        String updated = manager.getActiveProfile().config;
+        assertTrue(updated.contains("PrivateKey = new"));
+        assertTrue(updated.contains("Address = 10.0.0.2/32"));
+        assertTrue(updated.contains("# keep me"));
+        assertEquals(updated, prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+        assertFalse(manager.rewriteProviderInterface("mullvad", "account", "new", "10.0.0.2/32"));
+    }
+
+    @Test
+    public void rewriteAddsMissingInterfaceLinesWithoutChangingNonMatchingProfiles() throws Exception {
+        manager.saveProfile("", "Other", "[Interface]\nDNS = 1.1.1.1\n[Peer]\nPublicKey = p", "ivpn", "other");
+        String other = manager.getActiveProfileId();
+        manager.saveProfile("", "Target", "[Interface]\nDNS = 9.9.9.9\n[Peer]\nPublicKey = p", "ivpn", "target");
+        manager.setActiveProfile(other);
+
+        assertFalse(manager.rewriteProviderInterface("ivpn", "target", "private", "10.0.0.3/32"));
+        String target = manager.getProviderConfig("ivpn", "target");
+        assertTrue(target.contains("[Interface]\nAddress = 10.0.0.3/32\nPrivateKey = private\nDNS = 9.9.9.9"));
+        assertEquals("[Interface]\nDNS = 1.1.1.1\n[Peer]\nPublicKey = p", manager.getActiveProfile().config);
+    }
+
+    @Test
+    public void malformedStoredProfilesAreIgnoredAndCanBeReplacedByLegacyMigration() {
+        prefs.edit()
+                .putString(WgProfileManager.PREF_WG_PROFILES, "not json")
+                .putString(WgProfileManager.PREF_WG_CONFIG, "legacy")
+                .commit();
+
+        manager.migrateIfNeeded();
+
+        assertEquals(1, manager.getProfiles().size());
+        assertEquals("legacy", manager.getActiveProfile().config);
+    }
+
+    private static JSONObject profile(String id, String name, String config, String provider,
+                                      String account, String countryCode, String countryName) throws Exception {
+        return new JSONObject()
+                .put("id", id).put("name", name).put("config", config)
+                .put("provider", provider).put("account", account)
+                .put("countryCode", countryCode).put("countryName", countryName);
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,3 @@
+# Robolectric 4.16 supports Android through API 36. Keep framework-backed unit
+# tests on that SDK while the production app targets preview/final API 37.
+sdk=36


### PR DESCRIPTION
## Summary

- add database migration coverage for representative version 16→22 and 21→22 upgrades, including schema and data preservation
- add deterministic DNS-over-HTTPS tests for request formatting, retries, invalid responses, and client errors
- add WireGuard profile persistence, migration, selection, deletion, provider, credential, and rewrite coverage
- add API 37 instrumentation coverage for the Rust/JNI key boundary
- keep JVM unit tests independent of the four-ABI Rust build while preserving the native packaging dependency

## Fixes discovered while adding coverage

- preserve the active WireGuard profile when deleting an inactive profile
- generate profile IDs with UUIDs to avoid timestamp collisions
- correct broken Ukrainian blocking-mode string references
- configure Robolectric to run at its supported API 36 while the app targets API 37

## Validation

- `./gradlew testGithubDebugUnitTest compileGithubDebugAndroidTestJavaWithJavac --no-daemon` — 153 JVM tests passed and instrumentation sources compiled
- `cargo test --manifest-path wgbridge-rs/Cargo.toml` — 21 Rust tests passed
- `ANDROID_SERIAL=emulator-5554 ./gradlew connectedGithubDebugAndroidTest --no-daemon` — 2 JNI instrumentation tests passed on the API 37 Small_Phone emulator
- `./gradlew assembleGithubDebug --dry-run --no-daemon` — confirms `wgbridgeBuild` remains upstream of `mergeGithubDebugJniLibFolders`
- `git diff --check`
