### PR TITLE
Consolidate system-app settings into one "Monitor system apps" toggle

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -981,11 +981,13 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         if (!showingApps)
             return super.onPrepareOptionsMenu(menu);
 
+        Menu submenu = menu.findItem(R.id.menu_filter).getSubMenu();
         if (prefs.getBoolean("manage_system", false)) {
             menu.findItem(R.id.menu_app_user).setChecked(prefs.getBoolean("show_user", true));
-            menu.findItem(R.id.menu_app_system).setChecked(prefs.getBoolean("show_system", false));
+            // Visibility follows the single "Monitor system apps" setting.
+            // Do not leave a second control here that can desynchronise it.
+            submenu.removeItem(R.id.menu_app_system);
         } else {
-            Menu submenu = menu.findItem(R.id.menu_filter).getSubMenu();
             submenu.removeItem(R.id.menu_app_user);
             submenu.removeItem(R.id.menu_app_system);
         }
@@ -1019,10 +1021,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         if (itemId == R.id.menu_app_user) {
             item.setChecked(!item.isChecked());
             prefs.edit().putBoolean("show_user", item.isChecked()).apply();
-            return true;
-        } else if (itemId == R.id.menu_app_system) {
-            item.setChecked(!item.isChecked());
-            prefs.edit().putBoolean("show_system", item.isChecked()).apply();
             return true;
         } else if (itemId == R.id.menu_app_nointernet) {
             item.setChecked(!item.isChecked());

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -685,17 +685,15 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             ServiceSinkhole.reload("changed " + name, this, false);
 
         else if ("include_system_vpn".equals(name)) {
-            boolean includeSystem = prefs.getBoolean(name, false);
-            if (!includeSystem) {
-                // When disabling include_system_vpn, also disable manage_system and show_system
-                prefs.edit().putBoolean("manage_system", false).apply();
-                prefs.edit().putBoolean("show_system", false).apply();
-                // Update the UI toggle
-                TwoStatePreference pref_manage_system = (TwoStatePreference) getPreferenceScreen()
-                        .findPreference("manage_system");
-                if (pref_manage_system != null)
-                    pref_manage_system.setChecked(false);
-            }
+            // Single user-facing "Monitor system apps" toggle. It drives three
+            // internal prefs kept in lock-step: include_system_vpn (VPN routing),
+            // manage_system (tracker detection/blocking for system apps), and
+            // show_system (visibility in the app list / insights).
+            boolean monitorSystem = prefs.getBoolean(name, false);
+            prefs.edit().putBoolean("manage_system", monitorSystem).apply();
+            prefs.edit().putBoolean("show_system", monitorSystem).apply();
+            if (!monitorSystem)
+                prefs.edit().putBoolean("show_user", true).apply();
             ServiceSinkhole.reload("changed " + name, this, false);
 
         } else if ("wifi_only".equals(name) ||

--- a/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
@@ -121,12 +121,18 @@ public class ReceiverAutostart extends BroadcastReceiver {
 
                 if (oldVersion < 2026071202) {
                     // Collapse the three system-app prefs into one "Monitor system
-                    // apps" toggle backed by include_system_vpn. Preserve the
-                    // existing VPN-routing choice exactly and derive the other two
-                    // internal prefs (tracker detection + list visibility) from it,
-                    // so a user who routed system apps now also monitors them.
-                    boolean monitorSystem = prefs.getBoolean("include_system_vpn", false);
+                    // apps" toggle. Do not silently enable tracker blocking for a
+                    // user who previously routed system apps but opted out of
+                    // managing them. Very old installs need the preceding
+                    // manage_system -> include_system_vpn migration reflected here
+                    // before the editor is applied.
+                    boolean managedSystem = prefs.getBoolean("manage_system", false);
+                    boolean includedSystem = prefs.getBoolean("include_system_vpn", false);
+                    if (oldVersion < 2026010401 && managedSystem)
+                        includedSystem = true;
+                    boolean monitorSystem = includedSystem && managedSystem;
                     Log.i(TAG, "Migrating system-app prefs to single toggle=" + monitorSystem);
+                    editor.putBoolean("include_system_vpn", monitorSystem);
                     editor.putBoolean("manage_system", monitorSystem);
                     editor.putBoolean("show_system", monitorSystem);
                     if (!monitorSystem)

--- a/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
@@ -119,6 +119,20 @@ public class ReceiverAutostart extends BroadcastReceiver {
                     }
                 }
 
+                if (oldVersion < 2026071202) {
+                    // Collapse the three system-app prefs into one "Monitor system
+                    // apps" toggle backed by include_system_vpn. Preserve the
+                    // existing VPN-routing choice exactly and derive the other two
+                    // internal prefs (tracker detection + list visibility) from it,
+                    // so a user who routed system apps now also monitors them.
+                    boolean monitorSystem = prefs.getBoolean("include_system_vpn", false);
+                    Log.i(TAG, "Migrating system-app prefs to single toggle=" + monitorSystem);
+                    editor.putBoolean("manage_system", monitorSystem);
+                    editor.putBoolean("show_system", monitorSystem);
+                    if (!monitorSystem)
+                        editor.putBoolean("show_user", true);
+                }
+
             } else {
                 Log.i(TAG, "Initializing sdk=" + Build.VERSION.SDK_INT);
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -687,8 +687,8 @@ Sincerely,\n\n]]></string>
     <string name="failed_loading_cached_analysis">Loading cached tracker results failed. Please report this to the developer at hello@trackercontrol.org</string>
     <string name="msg_notifications">Tap to grant notification permissions (for error messages, etc.)</string>
 
-    <string name="setting_include_system_vpn">Include system apps</string>
-    <string name="summary_include_system_vpn">Include all system apps in the VPN and DoH.\n\nNote: \"Block connections without VPN\" in the Android VPN settings must be DISABLED.</string>
+    <string name="setting_monitor_system">Monitor system apps</string>
+    <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>
 
     <!-- Onboarding -->
     <string name="title_next">Next</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -92,14 +92,8 @@
             <eu.faircode.netguard.SwitchPreference
                 android:defaultValue="false"
                 android:key="include_system_vpn"
-                android:summary="@string/summary_include_system_vpn"
-                android:title="@string/setting_include_system_vpn" />
-            <eu.faircode.netguard.SwitchPreference
-                android:defaultValue="false"
-                android:dependency="include_system_vpn"
-                android:key="manage_system"
-                android:summary="@string/summary_system"
-                android:title="@string/setting_system" />
+                android:summary="@string/summary_monitor_system"
+                android:title="@string/setting_monitor_system" />
             <Preference
                 android:key="exclude_all_tracking"
                 android:summary="@string/summary_exclude_all_tracking"


### PR DESCRIPTION
Part of #653

## UX simplification

System-app handling was spread across three interacting preferences:

| Pref | Meaning | Read at |
|------|---------|---------|
| `include_system_vpn` | Route system apps through the VPN tun | `ServiceSinkhole.getBuilder` / `getBlockingBuilder` (`addDisallowedApplication` when `!includeSystem && rule.system`) |
| `manage_system` | Apply tracker detection/blocking to system apps; gate the app-list filter menu + hint | `ServiceSinkhole.shouldTrackApp` (via `cachedManageSystem`), `ActivityMain` (menu/hint), `ActivitySettings` |
| `show_system` | Show system apps in the app list and Insights | `Rule.getRules`, `ActivityMain` filter menu, `InsightsDataProvider` |

The user saw **two switches** in Settings (`include_system_vpn` + its dependent `manage_system`) plus a separate overflow-menu filter that flipped `show_system`. The three were already partly cascaded, but the model was hard to reason about.

This PR presents **one user-facing toggle, "Monitor system apps"**, backed by `include_system_vpn`. When it changes, `ActivitySettings` writes `manage_system` and `show_system` to match, so routing, detection and visibility always move together. All existing read sites are untouched — they keep reading the derived prefs, which minimizes risk. The `manage_system` switch is removed from `preferences.xml`. The Apps overflow menu's separate **"system apps" filter item is also removed** (in `ActivityMain`), since visibility now follows the single toggle and a second control there could desynchronise `show_system`; the "user apps" filter item remains.

The toggle summary preserves and documents the trade-off: **off is battery-friendly** (system-app background traffic no longer wakes the VPN packet threads), **on conflicts with Android's "Block connections without VPN"**, which must be disabled.

### Migration rule

`ReceiverAutostart.upgrade` gains a block for `oldVersion < 2026071202` that collapses the three prefs into the single toggle **without silently enabling blocking**:

- The toggle turns on **only when the user previously both routed _and_ managed** system apps: `monitorSystem = include_system_vpn && manage_system`. A user who routed system apps but had deliberately left `manage_system` off is **not** opted into tracker detection/blocking.
- All three prefs (`include_system_vpn`, `manage_system`, `show_system`) are then written to `monitorSystem`, so routing, detection and visibility stay coherent; `show_user` is forced back on when the toggle ends up off.
- **Very old installs** (`oldVersion < 2026010401`) are handled before the batched `editor` is committed: the earlier `manage_system → include_system_vpn` migration only writes to the *pending* editor, so this block re-derives `include_system_vpn` from `manage_system` directly to avoid reading a stale committed value.

Net effect: installs that both routed and managed system apps keep monitoring them; every other install ends up with the toggle **off**. A user who routed-*without*-managing loses system-app routing — that is the intended coherent semantics of a single toggle (routing without detection is no longer expressible), and is the only behavior change, documented here rather than applied silently.

Base `values/strings.xml` only (`setting_monitor_system` / `summary_monitor_system`); translation dirs left to Crowdin. No per-flavour `preferences.xml` overrides exist (`github`/`fdroid`/`play` share the main one). Orphaned `setting_system`/`summary_system` strings are left in place to avoid churn.

## Measurement plan (wakeups, not throughput)

The battery cost of including system apps is **wakeup frequency**, not tun MB/s: background traffic from Play Services/Store/carrier apps traverses the tun and wakes the packet threads (with WG egress up, TC absorbs radio-wakeup blame roughly every ~2.5 min). Measure it as follows, holding everything else fixed (same device, same WG/DoH state, screen off, same duration):

1. **Wakeup attribution via batterystats.** Reset, then run each arm for a fixed window with the screen off:
   ```
   adb shell dumpsys batterystats --reset
   # ... fixed idle window, screen off ...
   adb shell dumpsys batterystats --history | grep -c "wakeupap=.*net.kollnig"   # TC uid wake-up-by count
   adb shell dumpsys batterystats <TC-package>                                    # per-uid wakelock/CPU summary
   ```
   Compare **Monitor system apps ON vs OFF**. Primary metric = `wakeupap` events attributed to the TC uid per hour, plus wakelock time; MB/s is explicitly *not* the metric.
2. **Time-in-packet-loop (optional native counter).** A cheap, low-risk counter in the native engine's per-thread receive loop — count wakeups (returns from the blocking `read()` on the tun fd) and accumulate loop time, logged through the existing stats/log path — gives a device-independent signal that isolates system-app traffic. Not added in this PR to keep it Java-only and low-risk; specified here so it can land separately if the batterystats signal is noisy.
3. **Confounders to hold constant:** WireGuard egress on/off, DoH on/off, blocking mode, and the set of installed system apps. Run each arm at least twice.

Expected result: ON shows materially more TC-attributed wakeups/wakelock time per hour than OFF, confirming routing frequency (not tunnel volume) as the cost — which is exactly why the toggle defaults off and the summary flags the battery/"Block connections without VPN" trade-off.

## Verification

- `./gradlew :app:compileGithubDebugJavaWithJavac -q` — passes
- `./gradlew :app:testGithubDebugUnitTest` — BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
