### PR TITLE
Key tracker-verdict cache by (uid, destination IP) — partial #655

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2207,8 +2207,7 @@ public class ServiceSinkhole extends VpnService {
             prepareUidIPFilters(rr.QName);
 
             if (Util.isNumericAddress(rr.Resource)) { // make sure correct format
-                ipToHost.remove(rr.Resource);
-                ipToTracker.remove(rr.Resource);
+                invalidateTrackerCachesForIp(rr.Resource);
             }
         }
     }
@@ -2257,8 +2256,35 @@ public class ServiceSinkhole extends VpnService {
 
     static ConcurrentHashMap<Integer, String> uidToApp = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<Integer, String> uidToPackage = new ConcurrentHashMap<>();
+    // The tracker-verdict caches are keyed by (uid, destination IP) via
+    // trackerCacheKey(), not destination IP alone (see #655, Option 1). These
+    // caches sit directly on the per-app blocking path
+    // (blockKnownTracker(daddr, uid)); an IP-only key lets one app's cached
+    // verdict be reused for a different app that reaches the same shared IP.
+    // Per-app keying keeps cache reuse conservative and blocks cross-app bleed
+    // the moment any uid-specific state (per-app access rules, or a future
+    // uid-aware DNS lookup) feeds the cached value. Cost: cache cardinality
+    // scales with IPs x active apps instead of IPs; entries still expire on the
+    // DNS TTL (or NEGATIVE_TRACKER_CACHE_TTL_MS for misses), so the working set
+    // stays bounded by live traffic.
     static ConcurrentHashMap<String, Expiring<String>> ipToHost = new ConcurrentHashMap<>();
     static ConcurrentHashMap<String, Expiring<Tracker>> ipToTracker = new ConcurrentHashMap<>();
+
+    // Composite (uid, destination IP) key for the tracker-verdict caches. The
+    // '#' separator never appears in an IPv4/IPv6 literal, so the IP prefix
+    // stays unambiguous for invalidateTrackerCachesForIp().
+    static String trackerCacheKey(int uid, String daddr) {
+        return daddr + '#' + uid;
+    }
+
+    // A freshly resolved DNS answer for an IP invalidates every app's cached
+    // verdict for that IP, so drop all (uid, IP) entries sharing this IP.
+    static void invalidateTrackerCachesForIp(String daddr) {
+        String prefix = daddr + '#';
+        ipToHost.keySet().removeIf(k -> k.startsWith(prefix));
+        ipToTracker.keySet().removeIf(k -> k.startsWith(prefix));
+    }
+
     static String NO_DNAME = "null"; // use a String, unequal the real null
     static Tracker NO_TRACKER = new Tracker(null, null, 0);
     // Negative results (no tracker / no dname for an IP) are cached only
@@ -2409,23 +2435,24 @@ public class ServiceSinkhole extends VpnService {
         String blockingMode = BlockingMode.getMode(this);
         boolean blockAmbiguousTrackers = BlockingModeLogic.blocksAmbiguousTrackerIp(blockingMode);
         Tracker tracker = null;
-        Expiring<Tracker> expiringTracker = ipToTracker.get(daddr);
+        String cacheKey = trackerCacheKey(uid, daddr);
+        Expiring<Tracker> expiringTracker = ipToTracker.get(cacheKey);
         if (expiringTracker != null) {
             tracker = expiringTracker.getOrExpired();
 
             if (tracker == null) // expired
-                ipToTracker.remove(daddr);
+                ipToTracker.remove(cacheKey);
         }
 
         if (tracker == null) {
             // Check if IP known
             String dname = null;
-            Expiring<String> expiringHost = ipToHost.get(daddr);
+            Expiring<String> expiringHost = ipToHost.get(cacheKey);
             if (expiringHost != null) {
                 dname = expiringHost.getOrExpired();
 
                 if (dname == null) // expired
-                    ipToHost.remove(daddr);
+                    ipToHost.remove(cacheKey);
             }
 
             if (dname == null) { // TODO: Note that this does not implement any SNI code
@@ -2527,8 +2554,8 @@ public class ServiceSinkhole extends VpnService {
                 }
 
                 // Save dname and tracker
-                ipToHost.put(daddr, new Expiring<>(dname, expiry));
-                ipToTracker.put(daddr, new Expiring<>(tracker, expiry));
+                ipToHost.put(cacheKey, new Expiring<>(dname, expiry));
+                ipToTracker.put(cacheKey, new Expiring<>(tracker, expiry));
             }
 
             // Do not block based on IP-only tracker evidence.
@@ -2548,7 +2575,7 @@ public class ServiceSinkhole extends VpnService {
             // null on an ipToTracker cache hit (the ipToHost.put(...) block is
             // skipped). Guard both so log_logcat never NPEs the packet path.
             if (tracker != null) {
-                Expiring<String> expiringHost = ipToHost.get(daddr);
+                Expiring<String> expiringHost = ipToHost.get(cacheKey);
                 String host = (expiringHost == null ? null : expiringHost.getOrExpired());
                 Log.i("TC-Log", app + " " + daddr + " " + host + " " + tracker.getName());
             }
@@ -3859,7 +3886,7 @@ public class ServiceSinkhole extends VpnService {
         }
     }
 
-    private class Expiring<T> {
+    static class Expiring<T> {
         private T t;
         private long expires;
 

--- a/app/src/test/java/eu/faircode/netguard/TrackerCacheKeyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/TrackerCacheKeyTest.java
@@ -1,0 +1,78 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Verifies the (uid, destination IP) keying of the in-memory tracker-verdict
+ * caches (#655, Option 1): the same IP resolves to different cache slots for
+ * different apps, so one app's cached verdict is never reused for another, and
+ * a fresh DNS answer invalidates every app's slot for that IP.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class TrackerCacheKeyTest {
+
+    @After
+    public void tearDown() {
+        ServiceSinkhole.clearTrackerCaches();
+    }
+
+    @Test
+    public void keyIsStablePerUidAndIp() {
+        assertEquals(ServiceSinkhole.trackerCacheKey(10001, "1.2.3.4"),
+                ServiceSinkhole.trackerCacheKey(10001, "1.2.3.4"));
+    }
+
+    @Test
+    public void keyDiffersAcrossUidsForSameIp() {
+        // The whole point of Option 1: same shared IP, different apps must not
+        // collide in the cache.
+        assertNotEquals(ServiceSinkhole.trackerCacheKey(10001, "1.2.3.4"),
+                ServiceSinkhole.trackerCacheKey(10002, "1.2.3.4"));
+    }
+
+    @Test
+    public void keyDiffersAcrossIpsForSameUid() {
+        assertNotEquals(ServiceSinkhole.trackerCacheKey(10001, "1.2.3.4"),
+                ServiceSinkhole.trackerCacheKey(10001, "1.2.3.5"));
+    }
+
+    @Test
+    public void keyExposesIpAsInvalidationPrefix() {
+        // invalidateTrackerCachesForIp() relies on every per-app key starting
+        // with "<ip>#"; '#' cannot appear in an IP literal so the prefix is
+        // unambiguous.
+        assertTrue(ServiceSinkhole.trackerCacheKey(12345, "10.0.0.7").startsWith("10.0.0.7#"));
+    }
+
+    @Test
+    public void invalidationDropsAllAppsForThatIpOnly() {
+        long soon = System.currentTimeMillis() + 60_000L;
+        String ip = "1.2.3.4";
+        String otherIp = "5.6.7.8";
+
+        ServiceSinkhole.ipToTracker.put(ServiceSinkhole.trackerCacheKey(10001, ip),
+                new ServiceSinkhole.Expiring<>(ServiceSinkhole.NO_TRACKER, soon));
+        ServiceSinkhole.ipToTracker.put(ServiceSinkhole.trackerCacheKey(10002, ip),
+                new ServiceSinkhole.Expiring<>(ServiceSinkhole.NO_TRACKER, soon));
+        ServiceSinkhole.ipToHost.put(ServiceSinkhole.trackerCacheKey(10001, ip),
+                new ServiceSinkhole.Expiring<>("host-a", soon));
+        // A different IP must survive invalidation of `ip`.
+        ServiceSinkhole.ipToTracker.put(ServiceSinkhole.trackerCacheKey(10001, otherIp),
+                new ServiceSinkhole.Expiring<>(ServiceSinkhole.NO_TRACKER, soon));
+
+        ServiceSinkhole.invalidateTrackerCachesForIp(ip);
+
+        assertFalse(ServiceSinkhole.ipToTracker.containsKey(ServiceSinkhole.trackerCacheKey(10001, ip)));
+        assertFalse(ServiceSinkhole.ipToTracker.containsKey(ServiceSinkhole.trackerCacheKey(10002, ip)));
+        assertFalse(ServiceSinkhole.ipToHost.containsKey(ServiceSinkhole.trackerCacheKey(10001, ip)));
+        assertTrue(ServiceSinkhole.ipToTracker.containsKey(ServiceSinkhole.trackerCacheKey(10001, otherIp)));
+    }
+}


### PR DESCRIPTION
Part of #655.

## What this does

Implements **Option 1** from #655: the in-memory tracker-verdict caches in `ServiceSinkhole` (`ipToHost`, `ipToTracker`) are now keyed by a composite **(uid, destination IP)** via `trackerCacheKey()` instead of destination IP alone.

These caches sit directly on the per-app blocking path (`blockKnownTracker(daddr, uid)`). With an IP-only key, the first app to reach a shared IP populated a single cache slot whose verdict was then reused for every other app hitting that IP. Per-app keying makes cache reuse conservative and removes that cross-app cache bleed.

A freshly resolved DNS answer for an IP must drop **all** apps' cached verdicts for that IP, so `dnsResolved()` now calls `invalidateTrackerCachesForIp()`, which prefix-scans the maps on `"<ip>#"` (`#` never appears in an IP literal).

`Expiring<T>` is promoted from a private inner class to a package-private `static` nested class (it uses no outer state) so the new keying and invalidation can be unit-tested.

### Caches reviewed

| Cache | Key before | Change | Why |
|---|---|---|---|
| `ServiceSinkhole.ipToTracker` / `ipToHost` | destination IP | **now (uid, IP)** | On the per-app blocking path; must not bleed across apps. |
| `ServiceSinkhole.mapUidIPFilters` | `IPKey(version, protocol, dport, uid)` | left as-is | Already uid-keyed. |
| `TrackerList.hostnameToTracker` | hostname | left global | A hostname belongs to a tracker regardless of app — genuinely uid-independent. |
| `get_uid` cache in native `ip.c` | 5-tuple | left as-is | Resolves the uid itself; not a verdict cache. |

Note: the native `wg_flow_cache` referenced in the issue-triage notes does **not** exist in the current tree (WireGuard-mode passive DNS in `wgbridge-rs` never caches a block/allow verdict), so there was nothing to fix there.

### Cost

Cache cardinality scales with **IPs × active apps** instead of IPs. Entries still expire on the DNS TTL (or the 60 s negative-cache TTL for misses), and the maps are fully cleared on the periodic mapping refresh, so the working set stays bounded by live traffic rather than growing unbounded.

### Honest scope note

Because `getQAName(uid, ip, ...)` still ignores `uid`, the *value* derived for a given IP is currently the same for every app, so this change has no immediate effect on which apps get blocked today. Its purpose is structural: it removes cache-level cross-app reuse and guarantees no cross-app bleed the moment any uid-specific state (per-app access-table verdicts, or a future uid-aware DNS lookup) feeds the cached value. That is exactly the "more-conservative cache reuse, not app-specific evidence" framing of Option 1.

## Verification

- `./gradlew :app:compileGithubDebugJavaWithJavac -q` — passes.
- `./gradlew :app:testGithubDebugUnitTest` — **141 tests, 0 failures**, including the new `TrackerCacheKeyTest` (per-uid key distinctness, IP-prefix invalidation, and that invalidating one IP drops all apps for that IP while sparing other IPs).
- No native C touched, so no `assembleGithubDebug` needed.

## Decision input for #655

**Recommendation: ship Option 1 now (this PR); do not pursue full Option 2 yet — instead make Standard mode's ambiguous-IP handling explicit, and only revisit per-app DNS attribution if real reports show it is needed.**

### What Option 2 would require

Option 2 ("genuine per-app DNS evidence") means persisting DNS observations with a UID and linking DNS evidence to access observations. Concretely:

1. **Schema + migration.** Add a `uid` column to the `dns` table and re-key/re-index it. The `dns` table is high-churn and can be large; an online migration that rewrites it (plus its `resource` index) is a non-trivial, risky one-off on-device cost. Historical rows have no uid and would need a sentinel (`-1`/global), so queries must handle mixed uid/global rows indefinitely.
2. **Collection path.** DNS is parsed in native C (`dns.c`) / the Rust bridge and recorded via `dnsResolved()` / `wireGuardDnsResolved()`, none of which currently carry a reliable uid at DNS-record time. The querying app for a DNS response is frequently a shared resolver/system UID, not the app that will later use the IP — so attributing the answer to a uid at capture time is often wrong. This is the core reason DNS was left uid-global in the first place.
3. **Query logic + `uncertain` semantics.** `getQAName`, the `log()` path, and `blockKnownTracker` would all need uid-aware variants, and the meaning of `ACCESS_UNCERTAIN_SHARED_IP` / `MIXED` / `MULTIPLE_TRACKERS` would change: today "uncertain" captures *shared-IP-across-apps* ambiguity; under per-app evidence it would need to distinguish "this app resolved a tracker hostname for this IP" from "some app did". That is a semantic redesign of the insights/blocking contract, not a localized change.
4. **Attribution model mismatch.** Per AGENTS.md §4, attribution is deliberately **global, not per-app** — a known, deferred limitation. Option 2 reverses a standing design decision and would need product sign-off, not just an engineering change.

### Why not now

- **Cost/benefit.** Option 2 touches schema, migration, native + Rust collection, query logic, and UI semantics for a gain that is only real when an IP is genuinely shared by a tracker host and a non-tracker host used by *different* apps — a narrow slice already partly mitigated by the Minimal/Standard/Strict ambiguous-IP handling.
- **Correctness risk.** The capture-time uid is often the wrong uid (shared resolver UIDs), so naive Option 2 could make attribution *less* accurate while looking more precise.
- **Reversibility.** Option 1 is additive and reversible; Option 2's schema/migration is not.

### The real product decision the issue asks for

The issue also asks "how conservative Standard blocking should be when evidence is global and ambiguous." That is orthogonal to Option 2 and cheaper to get right: it is already expressed by `BlockingModeLogic.blocksAmbiguousTrackerIp()` (Standard allows ambiguous shared-IP hosts, Strict blocks them). If cross-app ambiguity is causing real breakage or leakage reports, the low-cost lever is to tune that policy (and document it), not to rebuild DNS attribution. I'd recommend treating that policy tuning as the primary follow-up, and keeping full per-app DNS attribution (Option 2) deferred behind a concrete, reported need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
