### PR TITLE
Speed up builds across worktrees

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,7 @@
 apply plugin: 'com.android.application'
 
+def ccacheLauncher = file("$projectDir/gradle/ccache-launcher.sh").absolutePath
+
 // WireGuard bridge (Rust/cargo-ndk) build logic. Defines the wgbridgeBuild
 // task and exposes ext.wgbridgeNdkVersion (reused for defaultConfig.ndkVersion).
 apply from: "$projectDir/gradle/wgbridge.gradle"
@@ -36,7 +38,9 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags ""
-                arguments "-DANDROID_PLATFORM=android-22"
+                arguments "-DANDROID_PLATFORM=android-22",
+                        "-DCMAKE_C_COMPILER_LAUNCHER=${ccacheLauncher}",
+                        "-DCMAKE_CXX_COMPILER_LAUNCHER=${ccacheLauncher}"
                 // https://developer.android.com/ndk/guides/cmake.html
             }
         }

--- a/app/gradle/ccache-launcher.sh
+++ b/app/gradle/ccache-launcher.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Normalize checkout/worktree paths so equivalent native compiler invocations
+# share cache entries across repositories rooted at different absolute paths.
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export CCACHE_BASEDIR=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
+
+if command -v ccache >/dev/null 2>&1; then
+    exec ccache "$@"
+fi
+
+# Ccache remains an optional local acceleration; CI and reproducible release
+# builds continue to work on machines where it is not installed.
+exec "$@"

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,6 +14,9 @@
 #org.gradle.jvmargs=-Xmx500m
 org.gradle.jvmargs=-Xmx4608m
 
+# Reuse relocatable Gradle task outputs between checkouts and worktrees.
+org.gradle.caching=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## What changed

- enable Gradle's local build cache so relocatable task outputs can be reused between checkouts and worktrees
- route CMake C and C++ compiler invocations through a portable `ccache` launcher
- normalize the repository root with `CCACHE_BASEDIR` so equivalent native builds at different worktree paths share cache entries
- fall back to direct compiler execution when `ccache` is unavailable, keeping CI and reproducible release builds portable

## Why

AGP stores CMake intermediates under each checkout and embeds absolute paths in the generated native build metadata. A fresh worktree therefore recompiles unchanged C sources. The shared Gradle cache covers cacheable Gradle tasks, while `ccache` reuses native compiler outputs across those differing paths.

## Validation

- `git diff --check`
- `sh -n app/gradle/ccache-launcher.sh`
- `./gradlew ':app:buildCMakeDebug[arm64-v8a]-2' --console=plain`
- confirmed CMake records the launcher for both `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER`
- unchanged native rebuild completed successfully in approximately 0.6 seconds
