### PR TITLE
Fix SecurityException crash resolving cross-profile UIDs on Android 16

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1293,7 +1293,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     for (String uidStr : set) {
                         try {
                             int uid = Integer.parseInt(uidStr);
-                            String[] packages = pm.getPackagesForUid(uid);
+                            String[] packages = Util.getPackagesForUid(pm, uid);
                             if (packages != null) {
                                 Collections.addAll(packageNames, packages);
                             }
@@ -1315,7 +1315,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     for (String uidStr : set) {
                         try {
                             int uid = Integer.parseInt(uidStr);
-                            String[] packages = pm.getPackagesForUid(uid);
+                            String[] packages = Util.getPackagesForUid(pm, uid);
                             if (packages != null) {
                                 for (String pkg : packages) {
                                     packageNames.add(pkg);
@@ -1391,7 +1391,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         else if (uid == 9999)
             return new String[] { "nobody" };
         else {
-            String pkgs[] = getPackageManager().getPackagesForUid(uid);
+            String pkgs[] = Util.getPackagesForUid(getPackageManager(), uid);
             if (pkgs == null)
                 return new String[0];
             else

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -246,20 +246,7 @@ public class AdapterLog extends CursorAdapter {
         // Application icon
         ApplicationInfo info = null;
         PackageManager pm = context.getPackageManager();
-        String[] pkg = null;
-
-        try {
-            pkg = pm.getPackagesForUid(uid);
-        } catch (SecurityException ignored) {
-            // STACK_TRACE=java.lang.SecurityException: getPackagesForUid: UID 1010154 requires android.permission.INTERACT_ACROSS_USERS_FULL or android.permission.INTERACT_ACROSS_USERS to access user 0.
-            //   at android.os.Parcel.createExceptionOrNull(Parcel.java:3240)
-            //   at android.os.Parcel.createException(Parcel.java:3224)
-            //   at android.os.Parcel.readException(Parcel.java:3200)
-            //   at android.os.Parcel.readException(Parcel.java:3142)
-            //   at android.content.pm.IPackageManager$Stub$Proxy.getPackagesForUid(IPackageManager.java:5176)
-            //   at android.app.ApplicationPackageManager$3.recompute(ApplicationPackageManager.java:1148)
-            //   at android.app.ApplicationPackageManager$3.recompute(ApplicationPackageManager.java:1142)
-        }
+        String[] pkg = Util.getPackagesForUid(pm, uid);
 
         if (pkg != null && pkg.length > 0)
             try {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2869,7 +2869,7 @@ public class ServiceSinkhole extends VpnService {
 
             // Get application info
             PackageManager pm = getPackageManager();
-            String[] packages = pm.getPackagesForUid(uid);
+            String[] packages = Util.getPackagesForUid(pm, uid);
             if (packages == null || packages.length < 1)
                 throw new PackageManager.NameNotFoundException(Integer.toString(uid));
             boolean internet = Util.hasInternet(uid, this);

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -381,9 +381,21 @@ public class Util {
         return (pm.checkPermission("android.permission.INTERNET", packageName) == PackageManager.PERMISSION_GRANTED);
     }
 
+    // On Android 16+, getPackagesForUid throws SecurityException for UIDs of
+    // other users/profiles (work profile, private space, cloned apps) instead
+    // of returning null (requires INTERACT_ACROSS_USERS). Treat those as unknown.
+    public static String[] getPackagesForUid(PackageManager pm, int uid) {
+        try {
+            return pm.getPackagesForUid(uid);
+        } catch (SecurityException ex) {
+            Log.w(TAG, "getPackagesForUid uid=" + uid + ": " + ex.getMessage());
+            return null;
+        }
+    }
+
     public static boolean hasInternet(int uid, Context context) {
         PackageManager pm = context.getPackageManager();
-        String[] pkgs = pm.getPackagesForUid(uid);
+        String[] pkgs = getPackagesForUid(pm, uid);
         if (pkgs != null)
             for (String pkg : pkgs)
                 if (hasInternet(pkg, context))
@@ -416,7 +428,7 @@ public class Util {
             listResult.add(context.getString(R.string.title_nobody));
         else {
             PackageManager pm = context.getPackageManager();
-            String[] pkgs = pm.getPackagesForUid(uid);
+            String[] pkgs = getPackagesForUid(pm, uid);
             if (pkgs == null)
                 listResult.add(Integer.toString(uid));
             else

--- a/app/src/main/java/net/kollnig/missioncontrol/Common.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/Common.kt
@@ -26,6 +26,7 @@ import android.net.Uri
 import android.view.View
 import androidx.core.content.ContextCompat
 import com.google.android.material.snackbar.Snackbar
+import eu.faircode.netguard.Util
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -172,7 +173,7 @@ object Common {
         if (uid == 0) return "System"
 
         // Get packages for this UID and return the app label (not package name)
-        val packages = pm.getPackagesForUid(uid)
+        val packages = Util.getPackagesForUid(pm, uid)
         if (packages != null && packages.isNotEmpty()) {
             try {
                 val appInfo = pm.getApplicationInfo(packages[0], 0)

--- a/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import eu.faircode.netguard.DatabaseHelper;
+import eu.faircode.netguard.Util;
 
 public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntryClickListener {
 
@@ -232,7 +233,7 @@ public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntr
                 if (!uidAppInfo.containsKey(uid)) {
                     String appName = Integer.toString(uid);
                     String packageName = null;
-                    String[] packages = pm.getPackagesForUid(uid);
+                    String[] packages = Util.getPackagesForUid(pm, uid);
                     if (packages != null && packages.length > 0) {
                         packageName = packages[0];
                         try {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
@@ -23,6 +23,7 @@ import android.content.pm.PackageManager
 import android.util.Pair
 import androidx.preference.PreferenceManager
 import eu.faircode.netguard.DatabaseHelper
+import eu.faircode.netguard.Util
 import net.kollnig.missioncontrol.Common
 import java.util.Locale
 
@@ -216,7 +217,7 @@ class InsightsDataProvider(context: Context) {
      */
     private fun getPackageNameForUid(uid: Int): String? {
         if (uid == 0) return "android"
-        val packages = packageManager.getPackagesForUid(uid)
+        val packages = Util.getPackagesForUid(packageManager, uid)
         return packages?.firstOrNull()
     }
 
@@ -225,7 +226,7 @@ class InsightsDataProvider(context: Context) {
      */
     private fun isSystemApp(uid: Int): Boolean {
         if (uid == 0) return true
-        val packages = packageManager.getPackagesForUid(uid) ?: return false
+        val packages = Util.getPackagesForUid(packageManager, uid) ?: return false
         return packages.any { pkg ->
             try {
                 val appInfo = packageManager.getApplicationInfo(pkg, 0)


### PR DESCRIPTION
Fixes #664

## Problem

On Android 16, `PackageManager.getPackagesForUid()` throws a `SecurityException` (requires `INTERACT_ACROSS_USERS[_FULL]`/`INTERACT_ACROSS_PROFILES`) instead of returning `null` when the queried UID belongs to another user or profile — a work profile, the private space, or OEM app-clone features. Since the traffic/DNS logs record UIDs from all profiles routed through the VPN, opening the Insights screen crashed the app (`InsightsDataProvider.getPackageNameForUid`), and the same latent crash existed in the Timeline, log adapter fallbacks, settings export, and the new-app notification path.

This is the same failure NetGuard hit in M66B/NetGuard#442; TrackerControl already guarded two call sites (`AdapterLog`, `ServiceSinkhole.shouldTrackApp`) but not the rest.

## Fix

- Add `Util.getPackagesForUid(pm, uid)`, which catches the `SecurityException` and returns `null` (the pre-Android-16 behavior for unknown UIDs), so callers fall back to their existing "unknown app" handling.
- Use it at every call site that resolves UIDs originating from the logs: `InsightsDataProvider` (the reported crash), `TimelineFragment`, `Common.getAppName`, `Util.hasInternet`/`getApplicationNames`, `ActivitySettings` export, and the `ServiceSinkhole` new-app notification.
- Fold `AdapterLog`'s existing ad-hoc guard into the helper. `shouldTrackApp` keeps its own catch because it must default to *tracking* rather than to null.

Verified with `./gradlew :app:compileGithubDebugJavaWithJavac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)