### PR TITLE
deps(rust): bump gotatun from 0.7.2 to 0.8.1 in /wgbridge-rs

### DIFF
--- a/wgbridge-rs/Cargo.lock
+++ b/wgbridge-rs/Cargo.lock
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e8590454839d406160792e2c5617e463a0d223f7370687528d0dd6560140b9"
+checksum = "87942cf21be131088380c8b3cb3dc9a8528a7f840a8230bed0e79b2e202d0629"
 dependencies = [
  "aead",
  "base64",
@@ -420,7 +420,6 @@ dependencies = [
  "ip_network_table",
  "ipnetwork",
  "libc",
- "log",
  "nix",
  "parking_lot",
  "rand",
@@ -431,6 +430,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",
+ "tracing",
  "typed-builder",
  "windows-sys 0.61.2",
  "x25519-dalek",
@@ -983,6 +983,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/wgbridge-rs/Cargo.toml
+++ b/wgbridge-rs/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-gotatun = { version = "=0.7.2", default-features = false, features = ["ring", "device"] }
+gotatun = { version = "=0.8.1", default-features = false, features = ["ring", "device"] }
 tokio = { version = "1.43", features = ["rt-multi-thread", "net", "sync", "time", "macros"] }
 base64 = "0.22"
 hex = "0.4"

--- a/wgbridge-rs/src/transport/udp.rs
+++ b/wgbridge-rs/src/transport/udp.rs
@@ -4,7 +4,7 @@
 //! doubles as "rebind the UDP sockets on the new default network".
 
 use std::io;
-use std::os::fd::{AsFd, AsRawFd};
+use std::os::fd::AsRawFd;
 use std::sync::Arc;
 
 use gotatun::udp::socket::{UdpSocket, UdpSocketFactory};
@@ -26,7 +26,9 @@ impl ProtectedUdpFactory {
     }
 
     fn protect(&self, socket: &UdpSocket) -> io::Result<()> {
-        let fd = socket.as_fd().as_raw_fd();
+        // gotatun 0.8.x hides the inner socket behind an enum; socket() exposes
+        // the underlying tokio UdpSocket (0.8.1+) so we can protect its fd.
+        let fd = socket.socket()?.as_raw_fd();
         if !self.protector.protect(fd) {
             // Fail closed: an unprotected socket would loop through the TUN.
             return Err(io::Error::other(format!(


### PR DESCRIPTION
Bumps `gotatun` from 0.7.2 to 0.8.1 in `wgbridge-rs`, unblocking #632.

## Background

#632 (bump to 0.8.0) was deferred because gotatun 0.8.0 made `UdpSocket`'s
inner socket an opaque enum and **removed the public `impl AsFd for UdpSocket`**.
That accessor was how we obtained the outbound UDP socket's fd to hand to
Android's `VpnService.protect()` — our loop-prevention path. A workaround
would have regressed gotatun's optimized `sendmmsg`/`recvmmsg` + GRO datapath
to per-packet I/O, so the bump was deferred pending an upstream public fd
accessor (filed as mullvad/gotatun#165).

## What changed

gotatun **0.8.1** restores a public accessor: `UdpSocket::socket()` returns
`io::Result<&tokio::net::UdpSocket>`, exposing the inner tokio socket. This lets
us obtain the fd through it while keeping gotatun's optimized batched datapath
intact.

- `Cargo.toml` / `Cargo.lock`: `gotatun` pinned to `=0.8.1` (pulls in the
  `tracing` transitive deps that replaced `log` in 0.8.0).
- `transport/udp.rs`: `ProtectedUdpFactory::protect` now derives the fd via
  `socket.socket()?.as_raw_fd()` instead of the removed `AsFd` impl.

## Verification

- `cargo check` — compiles cleanly.
- `cargo test` — all 21 host tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWerf5epj7WPqUHR9p8dL1)_