### PR TITLE
Version 2026072101

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,8 +24,8 @@ android {
         minSdk 23
         targetSdk 37
         //noinspection HighAppVersionCode
-        versionCode 2026071301
-        versionName "2026.07.13"
+        versionCode 2026072101
+        versionName "2026.07.21"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         // Secure DNS (DoH) configuration

--- a/fastlane/metadata/android/en-US/changelogs/2026072101.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2026072101.txt
@@ -1,0 +1,8 @@
+- New VPN preview: use Mullvad, IVPN, or your own WireGuard profile
+- New Timeline view and refreshed Insights
+- Completed Material 3 redesign with better accessibility
+- More reliable VPN, WireGuard, DNS, pause/resume, and tracker detection
+- Fixed a crash on devices with work profiles
+- Lower memory use, better performance, and less Secure DNS battery drain
+- Updated tracker lists, translations, and dependencies
+- Many bug fixes


### PR DESCRIPTION
Bumps the app to `versionCode 2026072101` / `versionName "2026.07.21"` and adds the fastlane changelog for the release.

Note: the last *published* release is `2026040301` (April 3) — the `Version 2026042701` and `Version 2026071301` bump commits were never tagged or released. This release therefore ships everything since April, and the changelog is written accordingly (WireGuard VPN preview, Timeline, Material 3 completion, reliability/battery work), plus what landed after the July 13 bump:

- Fix `SecurityException` crash resolving cross-profile UIDs on devices with work profiles (#667)
- Improved TLS ClientHello SNI parsing in the opt-in research mode (#669)
- WireGuard engine update: gotatun 0.7.2 → 0.8.1 (#668), getrandom 0.3.4 → 0.4.3 (#666)
- Reproducible release pipeline (#670, #671) — this will be the first release cut with it
- Crowdin translation updates (#659), build/CI improvements (#663, #665, `d95ca36`)

## Release steps after merging

Per `docs/RELEASING.md`: tag `2026072101` on the merge commit, wait for **Build unsigned GitHub release APK** to succeed, then run `./scripts/build_and_sign.sh 2026072101` locally and publish the draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MvJSCTKVbeZYwoGwZXtTaw