### PR TITLE
Fix ANR when handling package add/remove broadcasts

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2796,67 +2796,83 @@ public class ServiceSinkhole extends VpnService {
 
     private BroadcastReceiver packageChangedReceiver = new BroadcastReceiver() {
         @Override
-        public void onReceive(Context context, Intent intent) {
+        public void onReceive(final Context context, final Intent intent) {
             Log.i(TAG, "Received " + intent);
             Util.logExtras(intent);
 
-            try {
-                if (Intent.ACTION_PACKAGE_ADDED.equals(intent.getAction())) {
-                    // Application added
-                    Rule.clearCache(context);
-
-                    if (!intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
-                        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
-                        int uid = intent.getIntExtra(Intent.EXTRA_UID, -1);
-                        if (uid > -1) {
-                            // Set tracker defaults based on blocking mode
-                            TrackerBlocklist b = TrackerBlocklist.getInstance(context);
-                            if (b.ensureDefaults(uid, BlockingMode.isStrictMode(context)))
-                                b.saveSettings(context);
-
-                            // Show install notification
-                            if (prefs.getBoolean("installed", true))
-                                notifyNewApplication(uid, this);
-                        }
+            // Handle off the main thread: Rule.clearCache() synchronizes on the
+            // application context, a lock the command thread can hold for several
+            // seconds while building rules via slow PackageManager IPC. Doing this
+            // work on the main thread blocks input dispatching and causes an ANR.
+            final BroadcastReceiver.PendingResult result = goAsync();
+            executor.submit(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        handlePackageChanged(context, intent);
+                    } catch (Throwable ex) {
+                        Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                    } finally {
+                        result.finish();
                     }
-
-                    reload("package added", context, false);
-
-                } else if (Intent.ACTION_PACKAGE_REMOVED.equals(intent.getAction())) {
-                    // Application removed
-                    Rule.clearCache(context);
-
-                    if (intent.getBooleanExtra(Intent.EXTRA_DATA_REMOVED, false)) {
-                        // Remove settings
-                        String packageName = intent.getData().getSchemeSpecificPart();
-                        Log.i(TAG, "Deleting settings package=" + packageName);
-                        context.getSharedPreferences("apply", Context.MODE_PRIVATE).edit().remove(packageName).apply();
-                        BlockingMode.clearAutoExcludedApp(context, packageName);
-                        context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE).edit().remove(packageName).apply();
-                        context.getSharedPreferences("notify", Context.MODE_PRIVATE).edit().remove(packageName).apply();
-
-                        int uid = intent.getIntExtra(Intent.EXTRA_UID, 0);
-                        if (uid > 0) {
-                            DatabaseHelper dh = DatabaseHelper.getInstance(context);
-                            dh.clearLog(uid);
-                            dh.clearAccess(uid, false);
-                            uidToApp.remove(uid);
-                            uidToPackage.remove(uid);
-
-                            NotificationManagerCompat.from(context).cancel(uid); // installed notification
-                            NotificationManagerCompat.from(context).cancel(uid + 10000); // access notification
-                        }
-                    }
-
-                    reload("package deleted", context, false);
                 }
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-            }
+            });
         }
     };
 
-    public void notifyNewApplication(int uid, BroadcastReceiver br) {
+    private void handlePackageChanged(Context context, Intent intent) {
+        if (Intent.ACTION_PACKAGE_ADDED.equals(intent.getAction())) {
+            // Application added
+            Rule.clearCache(context);
+
+            if (!intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
+                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+                int uid = intent.getIntExtra(Intent.EXTRA_UID, -1);
+                if (uid > -1) {
+                    // Set tracker defaults based on blocking mode
+                    TrackerBlocklist b = TrackerBlocklist.getInstance(context);
+                    if (b.ensureDefaults(uid, BlockingMode.isStrictMode(context)))
+                        b.saveSettings(context);
+
+                    // Show install notification
+                    if (prefs.getBoolean("installed", true))
+                        notifyNewApplication(uid, true);
+                }
+            }
+
+            reload("package added", context, false);
+
+        } else if (Intent.ACTION_PACKAGE_REMOVED.equals(intent.getAction())) {
+            // Application removed
+            Rule.clearCache(context);
+
+            if (intent.getBooleanExtra(Intent.EXTRA_DATA_REMOVED, false)) {
+                // Remove settings
+                String packageName = intent.getData().getSchemeSpecificPart();
+                Log.i(TAG, "Deleting settings package=" + packageName);
+                context.getSharedPreferences("apply", Context.MODE_PRIVATE).edit().remove(packageName).apply();
+                BlockingMode.clearAutoExcludedApp(context, packageName);
+                context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE).edit().remove(packageName).apply();
+                context.getSharedPreferences("notify", Context.MODE_PRIVATE).edit().remove(packageName).apply();
+
+                int uid = intent.getIntExtra(Intent.EXTRA_UID, 0);
+                if (uid > 0) {
+                    DatabaseHelper dh = DatabaseHelper.getInstance(context);
+                    dh.clearLog(uid);
+                    dh.clearAccess(uid, false);
+                    uidToApp.remove(uid);
+                    uidToPackage.remove(uid);
+
+                    NotificationManagerCompat.from(context).cancel(uid); // installed notification
+                    NotificationManagerCompat.from(context).cancel(uid + 10000); // access notification
+                }
+            }
+
+            reload("package deleted", context, false);
+        }
+    }
+
+    public void notifyNewApplication(int uid, boolean checkTrackerLibraries) {
         if (uid < 0 || !Util.hasInternet(uid, this))
             return;
         if (uid == Process.myUid())
@@ -2908,8 +2924,8 @@ public class ServiceSinkhole extends VpnService {
                     NotificationManagerCompat.from(this).notify(uid, builder.build());
 
                 // Check tracker libraries in app
-                if (br != null)
-                    checkTrackers(packageName, uid, name, br, builder);
+                if (checkTrackerLibraries)
+                    checkTrackers(packageName, uid, name, builder);
             }
 
         } catch (PackageManager.NameNotFoundException ex) {
@@ -2920,33 +2936,28 @@ public class ServiceSinkhole extends VpnService {
         }
     }
 
-    private void checkTrackers(String packageName, int uid, String appName, BroadcastReceiver br,
+    // Callers must invoke this off the main thread (e.g. the package receiver's
+    // executor or the command handler thread), as it performs blocking work.
+    private void checkTrackers(String packageName, int uid, String appName,
             NotificationCompat.Builder builder) {
-        BroadcastReceiver.PendingResult result = br.goAsync();
-        new Thread() {
-            public void run() {
-                try {
-                    Context c = getApplicationContext();
-                    TrackerAnalysisManager manager = TrackerAnalysisManager.getInstance(c);
+        try {
+            Context c = getApplicationContext();
+            TrackerAnalysisManager manager = TrackerAnalysisManager.getInstance(c);
 
-                    // Check cache first
-                    String cachedResult = manager.getCachedResult(packageName);
-                    if (cachedResult != null && !manager.isCacheStale(packageName)) {
-                        // Use cached result
-                        int trackerCount = TrackerAnalysisManager.countTrackers(cachedResult);
-                        builder.setContentText(getString(R.string.msg_installed_tracker_libraries_found, trackerCount));
-                        NotificationManagerCompat.from(c).notify(uid, builder.build());
-                    } else {
-                        // Schedule analysis for later; the worker updates this notification when done.
-                        manager.startAnalysis(packageName, uid, appName);
-                    }
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-                result.setResultCode(RESULT_OK);
-                result.finish();
+            // Check cache first
+            String cachedResult = manager.getCachedResult(packageName);
+            if (cachedResult != null && !manager.isCacheStale(packageName)) {
+                // Use cached result
+                int trackerCount = TrackerAnalysisManager.countTrackers(cachedResult);
+                builder.setContentText(getString(R.string.msg_installed_tracker_libraries_found, trackerCount));
+                NotificationManagerCompat.from(c).notify(uid, builder.build());
+            } else {
+                // Schedule analysis for later; the worker updates this notification when done.
+                manager.startAnalysis(packageName, uid, appName);
             }
-        }.start();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     @Override
@@ -3306,7 +3317,7 @@ public class ServiceSinkhole extends VpnService {
         ServiceSinkhole.reload("notification", ServiceSinkhole.this, false);
 
         // Update notification
-        notifyNewApplication(uid, null);
+        notifyNewApplication(uid, false);
 
         // Update UI
         Intent ruleset = new Intent(ActivityMain.ACTION_RULES_CHANGED);


### PR DESCRIPTION
## Problem

An ANR was reported in `DetailsActivity` (`Input dispatching timed out … Waited 5000ms`). The captured thread dump shows a lock-contention stall, not a hang in the activity itself:

- **main thread** — blocked in `Rule.clearCache()` (`Rule.java:201`), called synchronously from `packageChangedReceiver.onReceive()` (`ServiceSinkhole.java:2827`), *waiting to lock* the `ApplicationEx` monitor.
- **"TrackerControl command" thread** — *holds* that monitor inside `Rule.getRules()` and is parked in a slow `PackageManager.getPackageInfo()` binder IPC (via `Util.isSystem` → `Rule.<init>` while building the rule list).
- **AsyncTask #1** — also waiting on the same monitor in `Rule.getRules()`.

Both `Rule.getRules()` and `Rule.clearCache()` synchronize on `context.getApplicationContext()`. `getRules()` makes per-package `PackageManager` IPC *while holding the lock*; when that IPC is slow, the command thread keeps the monitor for several seconds. Because the package-changed broadcast receiver ran `clearCache()` directly on the **main thread**, the main thread blocked on that monitor, input dispatch stalled, and the system raised an ANR.

## Fix

`ServiceSinkhole.java` only:

- The `packageChangedReceiver` now hands its work to the existing `executor` via `goAsync()`, so waiting on the application-context monitor happens on a background thread and never blocks the UI. The receiver body was extracted into `handlePackageChanged(context, intent)`.
- Both callers of `notifyNewApplication()` now run off the main thread, so the nested `goAsync()`/`new Thread()` inside the tracker-library check (`checkTrackers`) is no longer needed — it runs inline on the caller's background thread. Calling `goAsync()` twice would have returned `null` on the second call, so this also keeps the async handoff correct.
- `notifyNewApplication(int, BroadcastReceiver)` became `notifyNewApplication(int, boolean)` — the `BroadcastReceiver` argument existed only to feed that nested `goAsync()`. The notification-only caller in `set()` passes `false`; the install path passes `true`.

No behavioral change to what work happens on package install/removal — only which thread it runs on.

## Testing

The full Gradle build could not run in this environment: the pinned Gradle 9.6.1 distribution and AGP 9.3.0 are blocked by the sandbox egress policy (GitHub returns 403 and nothing is cached for offline mode). The change is a localized, self-contained refactor within `ServiceSinkhole.java`; a `./gradlew :app:compileGithubDebugJavaWithJavac` on a networked checkout is recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018yc5s4aH1mWrYw4gpsHRrZ

---
_Generated by [Claude Code](https://claude.ai/code/session_018yc5s4aH1mWrYw4gpsHRrZ)_