### PR TITLE
Clarify SNI research-mode IP-leak warning accounts for remote routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,7 +166,12 @@ The non-negotiables that decide most changes:
    made when a control directly helps a user *recover from breakage*.
 2. **Privacy-preserving by construction.** No SSL/TLS interception, ever. Detection
    works off DNS metadata; SNI/TLS parsing is confined to an opt-in research mode
-   because acting on it would leak the user's IP to the tracker first.
+   because acting on it would leak the user's IP to the tracker first. This SNI
+   parsing happens in the native `handle_ip()` block/allow decision (`ip.c`)
+   before traffic is dispatched to any egress path, so it runs the same way
+   whether remote routing (WireGuard) is on or off — when it is on, the
+   subsequent connection to the tracker goes out through the tunnel, so only
+   the VPN provider's IP leaks, not the device's real IP.
 3. **Battery is a first-class constraint.** Anything periodic must be gated off
    idle/screen-off. Do not make DoH a stronger default until its screen-off cost is
    profiled and fixed. Battery is also frequently mis-attributed to the

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ TrackerControl combines two analysis techniques: network traffic analysis and tr
 
 Mobile trackers send personal data over the internet, so tracking can be detected from network traffic. This is TrackerControl's core functionality. The advantage over library analysis is that *actual* evidence of data sharing is gathered — libraries present in app code may never be activated at runtime.
 
-TrackerControl analyses traffic locally using DNS-based detection. TLS Server Name Indication (SNI) extraction is disabled by default because it requires connecting to tracker servers, which would leak the user's IP address. SNI is enabled only when Research mode is turned on, for measurement purposes.
+TrackerControl analyses traffic locally using DNS-based detection. TLS Server Name Indication (SNI) extraction is disabled by default because it requires connecting to tracker servers, which would leak the user's IP address. SNI is enabled only when Research mode is turned on, for measurement purposes. The SNI itself is read locally, from the same traffic TrackerControl already inspects — no separate connection is made to read it — so if remote routing (WireGuard) is also enabled, the connection to the tracker goes out through the VPN tunnel and the tracker sees the VPN provider's IP rather than the device's real IP.
 
 Follow the in-app steps to enable the VPN, then interact with the apps you want to inspect (apps must actually run to share data with tracking companies). Results can be exported via the menu ("Export as CSV"); exporting from the main screen produces data compatible with the visualisation tools by [Hestia Labs](https://digipower.academy/experience/tracker-control).
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -605,7 +605,7 @@ Sincerely,\n\n]]></string>
     <string name="summary_block_ambiguous_trackers">When an IP has both tracker and non-tracker hostname evidence, still block it. Disable this to reduce app breakage.</string>
 
     <string name="setting_sni_enabled">SNI extraction (research)</string>
-    <string name="summary_sni_enabled">Extract hostnames from TLS connections for more accurate tracker detection. Warning: this leaks your IP address to tracker servers. Only enable for research.</string>
+    <string name="summary_sni_enabled">Extract hostnames from TLS connections for more accurate tracker detection. Warning: this leaks your IP address to tracker servers (or, if remote routing is enabled, the VPN provider\'s IP). Only enable for research.</string>
 
     <string name="setting_blocking_mode">Blocking Mode</string>
     <string name="summary_blocking_mode_minimal">Minimal: Only blocks trackers from the DuckDuckGo list that are safe to block. Browsers stay routed through the VPN, but tracker protection is off by default. Known incompatible apps are excluded. Limited app breakage.</string>


### PR DESCRIPTION
## Summary

Follow-up to #685. Verified in the native packet path (`app/src/main/jni/netguard/ip.c`, `handle_ip()`) that SNI research-mode extraction runs as part of the same local block/allow decision applied to every packet, *before* that packet is dispatched to any egress path (direct, SOCKS5, or the WireGuard bridge). This means the existing "leaks your IP address to tracker servers" warnings were correct for direct routing but overstated for the case where remote routing (WireGuard) is also enabled — in that case only the VPN provider's IP is exposed to the tracker, not the device's real IP.

This PR is documentation/strings only, no behavior change:
- `README.md`: clarify the SNI paragraph in "Example Use" to note the local-parsing + remote-routing interaction.
- `app/src/main/res/values/strings.xml`: add a short parenthetical to `summary_sni_enabled` (the in-app settings toggle description).
- `AGENTS.md`: expand the privacy-preserving-by-construction rationale (§4.2) with the `handle_ip()` ordering detail, so future triage doesn't repeat the "SNI isn't supported with WireGuard" assumption from #685.

## Test plan

- [x] Docs/strings only — no code paths changed.
- [x] Re-read edited files to confirm accuracy against `ip.c` behavior.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzsRyRx9BGPisrtRkJRBNF)_