### PR TITLE
Fix StringFormatInvalid lint errors in translated strings

### DIFF
--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_description">TrackerControl lader brugere overvåge og kontrollere den udbredte, løbende, og skjulte dataindsamling i mobilapps om brugeradfærd (\'tracking\').</string>
     <string name="app_android">TrackerControl kræver Android 5.1 eller nyere</string>
     <string name="app_xposed">Xposed forårsager for mange nedbrud, hvilket kan medføre, at TrackerControl fjernes fra Google Play Butik. Derfor understøttes TrackerControl ikke, mens Xposed er installeret</string>
-    <string name="app_eula">Brugen af denne app er på eget ansvar. Ingen app kan tilbyde 100% beskyttelse mod sporing.</string>
+    <string name="app_eula">Brugen af denne app er på eget ansvar. Ingen app kan tilbyde 100%% beskyttelse mod sporing.</string>
     <string name="app_privacy"><a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice">Privatlivspolitik</a> <a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy">Cookie-politik</a></string>
     <string name="channel_foreground">Kørende tjenester</string>
     <string name="channel_notify">Generelle notifikationer</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_description">TrackerControl-ek aplikazioek egiten duten erabilpenaren jarraipenaren datuak era ezkutuan jasotzeko egiten duten lana monitorizatu eta kontrolatzeko aukera eskaintzen die erabiltzaileei (\'tracking\' bezala ezaguna).</string>
     <string name="app_android">TrackerControlek Android 5.1 edo berriagoa behar du</string>
     <string name="app_xposed">Xposedek arazo asko sortzen ditu eta horregatik agian TrackerControl Google Play Storetik ezabatu dezakete, beraz TrackerControl ezin da instalatu Xposed instalatuta dagoen artean</string>
-    <string name="app_eula">Aplikazio honen erabilera zure ardurapean dago. Aplikazio batek ezin du 100% babesa eskaini jarraipenaren aurka.</string>
+    <string name="app_eula">Aplikazio honen erabilera zure ardurapean dago. Aplikazio batek ezin du 100%% babesa eskaini jarraipenaren aurka.</string>
     <string name="app_privacy"><a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice">Pribatutasun politika</a> <a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy">Cookie Politika</a></string>
     <string name="channel_foreground">Martxan dauden zerbitzuak</string>
     <string name="channel_notify">Jakinarazpen orokorrak</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_copyright">Copyright \u00A9 2019–2025 Konrad Kollnig\n\nTrackerControl perustuu Marcel Bokhorstin (M66B) kehittämään NetGuardiin.</string>
     <string name="app_android">TrackerControl vaatii Android 5,1 tai uudemman</string>
     <string name="app_xposed">Xposed aiheuttaa liikaa kaatumisia, mikä voi johtaa TrackerControlin poistamiseen Google Play kaupasta, joten TrackerControlia ei tueta, kun Xposed on asennettu</string>
-    <string name="app_eula">Tämän sovelluksen käyttö on omalla vastuullasi. Mikään sovellus ei voi tarjota 100% suojaa seurantaa vastaan.</string>
+    <string name="app_eula">Tämän sovelluksen käyttö on omalla vastuullasi. Mikään sovellus ei voi tarjota 100%% suojaa seurantaa vastaan.</string>
     <string name="app_privacy"><a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice">Yksityisyydensuoja</a> <a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy">Evästekäytäntö</a></string>
     <string name="channel_foreground">Käynnissä olevat palvelut</string>
     <string name="channel_notify">Yleiset ilmoitukset</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -4,7 +4,7 @@
     <string name="app_copyright">Copyright \u00A9 2019–2022 Konrad Kollnig\n\nTrackerControl is gebaseerd op NetGuard, ontwikkeld door Marcel Bokhorst (M66B).</string>
     <string name="app_android">TrackerControl vereist Android 5.1 of nieuwer</string>
     <string name="app_xposed">Xposed veroorzaakt te veel crashes, wat ertoe kan leiden dat TrackerControl uit de Google Play Store wordt verwijderd, daarom wordt TrackerControl niet ondersteund zolang Xposed is geïnstalleerd.</string>
-    <string name="app_eula">Het gebruik van deze app is op eigen risico. Geen enkele app kan 100% bescherming bieden tegen tracking.</string>
+    <string name="app_eula">Het gebruik van deze app is op eigen risico. Geen enkele app kan 100%% bescherming bieden tegen tracking.</string>
     <string name="app_privacy">&lt;a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice"&gt;&lt;a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice"&gt;Privacybeleid&lt;/a&gt; &lt;a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy"&gt;Cookiebeleid&lt;/a&gt;</string>
     <string name="channel_foreground">Actieve services</string>
     <string name="channel_notify">Algemene meldingen</string>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -3,7 +3,7 @@
     <string name="app_description">TrackerControl lar brukere overvåke og kontrollere den utbredte, pågående og skjulte innsamlingen av bruksdata i mobilapplikasjoner (\"sporing\").</string>
     <string name="app_android">TrackerControl krever Android 5.1 eller nyere</string>
     <string name="app_xposed">Xposed forårsaker for mange krasjer, noe som kan føre til at TrackerControl blir fjernet fra Google Play. TrackerControl støttes derfor ikke mens Xposed er installert</string>
-    <string name="app_eula">Bruken av denne appen er på eget ansvar. Ingen app kan tilby 100% beskyttelse mot sporing.</string>
+    <string name="app_eula">Bruken av denne appen er på eget ansvar. Ingen app kan tilby 100%% beskyttelse mot sporing.</string>
     <string name="app_privacy"><a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice">Personvernerklæring</a> <a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy">Om informasjonskapsler</a></string>
     <string name="channel_foreground">Kjørende tjenester</string>
     <string name="channel_notify">Generelle varsler</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -204,7 +204,7 @@
     <string name="msg_wg_mullvad_note">TrackerControl ustvari WireGuardov profil Mulvad.  Številka računa se shrani krajevno za bodoče profile Mulvad.  Žetoni se ne shranjujejo in in izbrisa tukajšnjega profila ne odstrani naprave iz Mullvada.</string>
     <string name="msg_wg_mullvad_generating">Ustvarjanje profila WireGuard …</string>
     <string name="msg_wg_mullvad_failed">Nastavitev Mullvada je spodletela: %s</string>
-    <string name="msg_wg_mullvad_countries_failed"></string>
+    <string name="msg_wg_mullvad_countries_failed">Nalaganje držav Mullvada ni uspelo: %s</string>
     <string name="vpn_status_connected">%s</string>
     <string name="vpn_status_mullvad_connected">Mullvad - %s</string>
     <string name="vpn_status_mullvad">Mullvad</string>


### PR DESCRIPTION
## Summary
- `:app:lintGithubDebug` was failing with 6 `StringFormatInvalid` errors, all pre-existing in translated `strings.xml` files, unrelated to any in-flight changes.
- Five `app_eula` translations (da, eu, fi, nl, no) contain a literal `100%` immediately followed by a letter (e.g. `b`, `s`) that lint's Java `Formatter` parser reads as a conversion character, producing an invalid format spec like `% b`. Escaped the `%` as `%%` in each so it's treated as a literal percent sign.
- The Slovenian `msg_wg_mullvad_countries_failed` string was empty, silently dropping the `%s` placeholder required by the code that calls `getString(R.string.msg_wg_mullvad_countries_failed, ex.getMessage())` (`ActivityWireGuardProfiles.java:187`). Added a translation with the placeholder restored, following the phrasing of the neighboring `msg_wg_mullvad_failed` string.

## Test plan
- [x] `./gradlew :app:lintGithubDebug` — 0 errors (was 6), 512 warnings (unchanged)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01M5uW2XvYGhBTBE19Nsod6z

---
_Generated by [Claude Code](https://claude.ai/code/session_01M5uW2XvYGhBTBE19Nsod6z)_