### PR TITLE
Restore the system-app display filter

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -984,9 +984,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Menu submenu = menu.findItem(R.id.menu_filter).getSubMenu();
         if (prefs.getBoolean("manage_system", false)) {
             menu.findItem(R.id.menu_app_user).setChecked(prefs.getBoolean("show_user", true));
-            // Visibility follows the single "Monitor system apps" setting.
-            // Do not leave a second control here that can desynchronise it.
-            submenu.removeItem(R.id.menu_app_system);
+            menu.findItem(R.id.menu_app_system).setChecked(prefs.getBoolean("show_system", false));
         } else {
             submenu.removeItem(R.id.menu_app_user);
             submenu.removeItem(R.id.menu_app_system);
@@ -1021,6 +1019,10 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         if (itemId == R.id.menu_app_user) {
             item.setChecked(!item.isChecked());
             prefs.edit().putBoolean("show_user", item.isChecked()).apply();
+            return true;
+        } else if (itemId == R.id.menu_app_system) {
+            item.setChecked(!item.isChecked());
+            prefs.edit().putBoolean("show_system", item.isChecked()).apply();
             return true;
         } else if (itemId == R.id.menu_app_nointernet) {
             item.setChecked(!item.isChecked());


### PR DESCRIPTION
## Summary

- restore the **Show system apps** entry in the Apps filter when system-app monitoring is enabled
- restore its handler so it changes only the existing `show_system` visibility preference
- keep **Monitor system apps** as the single control for VPN routing and tracker blocking

## Root cause

PR #656 intentionally removed the display filter while consolidating system-app routing, monitoring, and visibility into one setting. This meant users could no longer monitor system apps while hiding them from the app list, causing the regression reported in #696.

The underlying list and Insights filtering already continue to respect `show_system`, so this restores the previous UI path without changing VPN membership, tracker detection, or battery behaviour.

Fixes #696.

## Validation

- `./gradlew :app:compileGithubDebugJavaWithJavac -q :app:testGithubDebugUnitTest`
- `git diff --check`
