### PR TITLE
Route the full tunnel in tethering compatibility mode (#699)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1623,9 +1623,21 @@ public class ServiceSinkhole extends VpnService {
 
         // WireGuard AllowedIPs can opt RFC 1918 ranges into the VPN routes;
         // without WireGuard, private and reserved ranges remain excluded.
-        List<IPUtil.CIDR> routes = (wgEnabled && !wgAllowedIps.isEmpty())
-                ? VpnRoutes.getRoutes(wgAllowedIps)
-                : VpnRoutes.getRoutes();
+        // Tethering compatibility mode instead installs a plain default route,
+        // which some devices need before they forward tethered traffic into the
+        // tun at all (#699). WireGuard keeps precedence: a full tunnel would
+        // hand LAN and reserved traffic to the peer, which drops it.
+        boolean tetheringCompat = prefs.getBoolean("tcp_mss_clamp", false);
+        List<IPUtil.CIDR> routes;
+        if (wgEnabled && !wgAllowedIps.isEmpty()) {
+            if (tetheringCompat)
+                Log.i(TAG, "Tethering compatibility routes skipped: WireGuard AllowedIPs apply");
+            routes = VpnRoutes.getRoutes(wgAllowedIps);
+        } else if (tetheringCompat) {
+            Log.i(TAG, "Using tethering compatibility routes (full tunnel)");
+            routes = VpnRoutes.getTetheringRoutes();
+        } else
+            routes = VpnRoutes.getRoutes();
         for (IPUtil.CIDR route : routes)
             try {
                 builder.addRoute(route.address, route.prefix);

--- a/app/src/main/java/eu/faircode/netguard/VpnRoutes.java
+++ b/app/src/main/java/eu/faircode/netguard/VpnRoutes.java
@@ -92,6 +92,27 @@ public class VpnRoutes {
     }
 
     /**
+     * Returns the full-tunnel route list (a single 0.0.0.0/0 default route)
+     * used by tethering compatibility mode.
+     *
+     * <p>Some devices only forward tethered traffic into the tun while the VPN
+     * carries a real default route; with the split-tunnel route set above they
+     * fall back to the device's own tethering path, which on such devices is
+     * broken (#699). This also puts the tethering downstream subnets
+     * (192.168.42/43/44/49) and the 255.255.255.255 DHCP broadcast back inside
+     * the tunnel, matching the behaviour TrackerControl had before the static
+     * route set was introduced.
+     *
+     * <p>The cost is that LAN traffic and reserved ranges no longer bypass the
+     * tunnel, which is why this is opt-in. Carrier ePDG addresses are still
+     * excluded on Android 13+, where {@code excludeRoute()} applies on top of
+     * this route.
+     */
+    public static List<IPUtil.CIDR> getTetheringRoutes() {
+        return Collections.singletonList(new IPUtil.CIDR("0.0.0.0", 0));
+    }
+
+    /**
      * Returns the route list for an active WireGuard remote-egress tunnel,
      * making the profile's AllowedIPs authoritative over the RFC 1918
      * exclusions. Any part of an RFC 1918 range covered by {@code wgAllowedIps}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -120,7 +120,7 @@
     <string name="setting_call">Disable on call</string>
     <string name="setting_reload_onconnectivity">Reload on every connectivity change</string>
     <string name="setting_tcp_mss_clamp">Tethering compatibility mode</string>
-    <string name="summary_tcp_mss_clamp">Limit TCP segment size to avoid stalled connections on some tethered networks. May reduce performance.</string>
+    <string name="summary_tcp_mss_clamp">Route all traffic through TrackerControl and limit TCP segment size, to fix tethered connections that stall or get no internet access. Local network access bypasses TrackerControl no longer, and performance may be reduced.</string>
 
     <string name="setting_advanced_options">Advanced options (for experts)</string>
     <string name="setting_system">Show system apps</string>

--- a/app/src/test/java/eu/faircode/netguard/VpnRoutesTest.java
+++ b/app/src/test/java/eu/faircode/netguard/VpnRoutesTest.java
@@ -17,6 +17,7 @@
 
 package eu.faircode.netguard;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -85,6 +86,37 @@ public class VpnRoutesTest {
 
         assertFalse(isRouted(viaEmpty, "192.168.1.10"));
         assertFalse(isRouted(viaV6, "192.168.1.10"));
+    }
+
+    // --- tethering compatibility mode ---------------------------------------
+
+    @Test
+    public void tetheringRoutesAreASingleDefaultRoute() throws Exception {
+        List<IPUtil.CIDR> routes = VpnRoutes.getTetheringRoutes();
+
+        assertEquals(1, routes.size());
+        assertEquals(0, routes.get(0).prefix);
+
+        // Everything is inside the tunnel, including the ranges the default
+        // route set excludes: the tethering downstream subnets and the DHCP
+        // broadcast the tethered client uses to get a lease (#699).
+        assertTrue(isRouted(routes, "8.8.8.8"));
+        assertTrue(isRouted(routes, "192.168.42.129")); // USB tethering
+        assertTrue(isRouted(routes, "192.168.43.1"));   // Wi-Fi tethering
+        assertTrue(isRouted(routes, "192.168.44.1"));   // Bluetooth tethering
+        assertTrue(isRouted(routes, "10.0.0.1"));
+        assertTrue(isRouted(routes, "100.64.0.1"));
+        assertTrue(isRouted(routes, "0.0.0.0"));
+        assertTrue(isRouted(routes, "255.255.255.255")); // DHCP broadcast
+    }
+
+    @Test
+    public void tetheringRoutesDoNotAffectTheDefaultRouteSet() throws Exception {
+        VpnRoutes.getTetheringRoutes();
+        List<IPUtil.CIDR> routes = VpnRoutes.getRoutes();
+
+        assertFalse(isRouted(routes, "192.168.42.129"));
+        assertTrue(isRouted(routes, "8.8.8.8"));
     }
 
     // --- WireGuard active: AllowedIPs authoritative --------------------------


### PR DESCRIPTION
Addresses #699 — tethering worked on 2026.04.03 and stopped on 2026.07.27; downgrading restores it. The reporter's device has a broken tethering path of its own, and TrackerControl was what made tethering work.

## Why it regressed

`68fcd531` (#546, 2026-04-06, first released in 2026.04.27 — three days after the reporter's last working build) replaced the tun's catch-all route with the static split-tunnel route set:

- Before, `subnet` defaulted to `false`, so `getBuilder()` fell through to `builder.addRoute("0.0.0.0", 0)` and the tun captured everything.
- After, `VpnRoutes.getRoutes()` covers public IPv4 only. Permanently excluded are `10/8`, `172.16/12`, `192.168/16` (which contains the tethering downstreams 192.168.42/43/44/49), `100.64/10`, `169.254/16` and `224.0.0.0/3` — the last of which contains the `255.255.255.255` DHCP broadcast that `check_dhcp()` answers for tethered clients.

The same commit also deleted the `subnet`, `tethering` and `lan` preferences, so there is no longer any toggle that restores the old behaviour — which is why downgrading is the reporter's only recourse.

The likely mechanism is that some devices only forward tethered traffic into the tun while the VPN carries a real default route. Without one, tethering falls back to the device's own path, which on such devices is broken.

## What this changes

The opt-in, default-off "Tethering compatibility mode" (added for #478, previously MSS clamp only) now also installs a single `0.0.0.0/0` route, restoring the pre-2026.04.27 behaviour for users who need it. The split-tunnel route set stays the default for everyone else.

- `VpnRoutes.getTetheringRoutes()` — the full-tunnel route list, with the rationale documented.
- `ServiceSinkhole.getBuilder()` — picks it when the mode is on. WireGuard keeps precedence: a full tunnel would hand LAN and reserved ranges to the peer, which drops them, so an active profile's `AllowedIPs` still decide the routes (#593), and the override is logged when it applies.
- On Android 13+, the carrier ePDG `excludeRoute()` calls still apply on top of the default route, so Wi-Fi calling is unaffected.
- Setting summary updated: the mode now costs direct LAN access as well as performance.
- `VpnRoutesTest` covers the new route list and that it does not disturb the cached default one.

No new preference — this reuses the switch that already exists, and it is a breakage-recovery control rather than a general firewall knob.

## Testing

Not built or run: this environment has no Android SDK, so `:app:testGithubDebugUnitTest` could not be executed here. CI should cover compilation and the unit tests.

Still needs on-device confirmation from the reporter that enabling the mode restores tethering on 2026.07.27 — the route mechanism above is inferred from the change history, not yet observed on an affected device.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FhD7ETjNc5qb5hSw9taYtS)_