### PR TITLE
Support Android 17 local network protections (#701)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,14 @@
     <!-- http://developer.android.com/guide/topics/security/permissions.html#normal-dangerous -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <!--
+        Android 17 local network protections: reaching a DNS server, Secure DNS
+        resolver or WireGuard peer on the user's own network needs this runtime
+        permission once the app targets API 37. Only requested when a setting
+        actually points TrackerControl at the local network (see
+        net.kollnig.missioncontrol.LocalNetworkAccess).
+    -->
+    <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
     <!-- https://developer.android.com/preview/privacy/package-visibility -->
     <uses-permission

--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -198,7 +198,7 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
             popup.getMenu().findItem(R.id.menu_protocol).setTitle(Util.getProtocolName(protocol, version, false));
 
             // Whois
-            final Intent lookupIP = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.dnslytics.com/whois-lookup/" + ip));
+            final Intent lookupIP = new Intent(Intent.ACTION_VIEW, Uri.parse("https://search.dnslytics.com/ip/" + ip));
             if (pm.resolveActivity(lookupIP, 0) == null)
                 popup.getMenu().removeItem(R.id.menu_whois);
             else

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -87,6 +87,7 @@ import com.opencsv.CSVWriter;
 
 import net.kollnig.missioncontrol.ActivityOnboarding;
 import net.kollnig.missioncontrol.Common;
+import net.kollnig.missioncontrol.LocalNetworkAccess;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.TimelineFragment;
 import net.kollnig.missioncontrol.data.Tracker;
@@ -140,6 +141,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
     public static final int REQUEST_DETAILS_UPDATED = 4;
 
     private static final int REQUEST_NOTIFICATIONS = 5;
+    private static final int REQUEST_LOCAL_NETWORK = 6;
 
     private static final int REQUEST_EXPORT = 10;
 
@@ -453,6 +455,18 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 }
             });
 
+        // Local network permission (Android 17+), shown when the configuration
+        // needs it: without it, a LAN DNS server or WireGuard peer is
+        // unreachable and the user is left without working name resolution.
+        TextView tvLocalNetwork = findViewById(R.id.tvLocalNetwork);
+        tvLocalNetwork.setVisibility(View.GONE);
+        tvLocalNetwork.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                requestPermissions(new String[] { LocalNetworkAccess.PERMISSION }, REQUEST_LOCAL_NETWORK);
+            }
+        });
+
         // Application list
         RecyclerView rvApplication = findViewById(R.id.rvApplication);
         rvApplication.setHasFixedSize(false);
@@ -547,6 +561,11 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         TextView tvNotifications = findViewById(R.id.tvNotifications);
         if (tvNotifications != null)
             tvNotifications.setVisibility(canNotify ? View.GONE : View.VISIBLE);
+
+        TextView tvLocalNetwork = findViewById(R.id.tvLocalNetwork);
+        if (tvLocalNetwork != null)
+            tvLocalNetwork.setVisibility(
+                    LocalNetworkAccess.isMissing(this) ? View.VISIBLE : View.GONE);
 
         super.onResume();
     }
@@ -766,6 +785,28 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             if (grantResults.length > 0 && grantResults[0] != PackageManager.PERMISSION_GRANTED &&
                     !ActivityCompat.shouldShowRequestPermissionRationale(this,
                             Manifest.permission.POST_NOTIFICATIONS))
+                try {
+                    Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                    Uri uri = Uri.fromParts("package", getPackageName(), null);
+                    intent.setData(uri);
+                    startActivity(intent);
+                } catch (Throwable ex) {
+                    Log.e(TAG, ex + "\n" + ex.getStackTrace());
+                }
+        } else if (requestCode == REQUEST_LOCAL_NETWORK) {
+            boolean granted = (grantResults.length > 0 &&
+                    grantResults[0] == PackageManager.PERMISSION_GRANTED);
+            TextView tvLocalNetwork = findViewById(R.id.tvLocalNetwork);
+            if (tvLocalNetwork != null)
+                tvLocalNetwork.setVisibility(granted ? View.GONE : View.VISIBLE);
+            if (granted)
+                // The tunnel keeps its sockets across a reload, but the native
+                // engine reopens them, so LAN destinations become reachable.
+                ServiceSinkhole.reload("permission granted", this, false);
+            else if (!ActivityCompat.shouldShowRequestPermissionRationale(this,
+                    LocalNetworkAccess.PERMISSION))
+                // Permanently denied: the prompt no longer appears, so send the
+                // user to the permission screen instead.
                 try {
                     Intent intent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
                     Uri uri = Uri.fromParts("package", getPackageName(), null);

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -798,7 +798,10 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                     grantResults[0] == PackageManager.PERMISSION_GRANTED);
             TextView tvLocalNetwork = findViewById(R.id.tvLocalNetwork);
             if (tvLocalNetwork != null)
-                tvLocalNetwork.setVisibility(granted ? View.GONE : View.VISIBLE);
+                // Derived, not inferred from the grant result: the row is about
+                // the configuration needing access, which onResume decides too.
+                tvLocalNetwork.setVisibility(
+                        LocalNetworkAccess.isMissing(this) ? View.VISIBLE : View.GONE);
             if (granted)
                 // The tunnel keeps its sockets across a reload, but the native
                 // engine reopens them, so LAN destinations become reachable.

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -74,6 +74,7 @@ import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
 import net.kollnig.missioncontrol.BuildConfig;
+import net.kollnig.missioncontrol.LocalNetworkAccess;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
@@ -127,6 +128,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
     private static final int REQUEST_EXPORT = 1;
     private static final int REQUEST_IMPORT = 2;
     private static final int REQUEST_CALL = 5;
+    private static final int REQUEST_LOCAL_NETWORK = 6;
+
+    private boolean requestedLocalNetwork = false;
 
     private static final Intent INTENT_VPN_SETTINGS = new Intent("android.net.vpn.SETTINGS");
 
@@ -966,6 +970,19 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             TrackerList.reloadTrackerData(this);
         }
 
+        // Android 17 blocks traffic to local network addresses unless the user
+        // grants ACCESS_LOCAL_NETWORK. Ask as soon as a setting starts pointing
+        // TrackerControl at the LAN — a custom DNS server, a local Secure DNS
+        // resolver, a WireGuard peer at home, or the full-tunnel tethering
+        // mode — rather than letting name resolution fail silently (#701).
+        // Asked at most once per visit: writing back a trimmed value re-enters
+        // this listener, and a second request while the dialog is up is dropped
+        // by the framework.
+        if (!requestedLocalNetwork && LocalNetworkAccess.isRelevantSetting(name)
+                && LocalNetworkAccess.isMissing(this)) {
+            requestedLocalNetwork = true;
+            requestPermissions(new String[] { LocalNetworkAccess.PERMISSION }, REQUEST_LOCAL_NETWORK);
+        }
     }
 
     private CharSequence getWireGuardStatusSummary(SharedPreferences prefs) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1660,6 +1660,13 @@ public class ServiceSinkhole extends VpnService {
                     Log.e(TAG, "addRoute DNS " + dns + ": " + ex);
                 }
 
+        // Android 17 refuses local network traffic without ACCESS_LOCAL_NETWORK:
+        // TCP times out, UDP fails with EPERM. A LAN resolver routed into the tun
+        // above is re-sent from our own socket, so it goes silent (#701).
+        if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(ServiceSinkhole.this))
+            Log.w(TAG, "Local network access not granted: configured LAN destinations" +
+                    " (custom DNS, Secure DNS resolver, WireGuard peer) are unreachable");
+
         // Dynamically exclude carrier ePDG IPs so Wi-Fi calling works globally.
         // ePDG domains follow 3GPP standard: epdg.epc.mnc{MNC}.mcc{MCC}.pub.3gppnetwork.org
         // TC excludes itself from the VPN (addDisallowedApplication), so this DNS resolution

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -69,6 +69,9 @@ import java.net.URI;
  * never need it.
  */
 public class LocalNetworkAccess {
+    private LocalNetworkAccess() {
+    }
+
     private static final String TAG = "TrackerControl.LocalNet";
 
     /**
@@ -122,11 +125,11 @@ public class LocalNetworkAccess {
     }
 
     /** Whether the current configuration makes TrackerControl talk to the LAN. */
-    public static boolean isConfigured(Context context) {
+    private static boolean isConfigured(Context context) {
         return isConfigured(PreferenceManager.getDefaultSharedPreferences(context));
     }
 
-    public static boolean isConfigured(SharedPreferences prefs) {
+    static boolean isConfigured(SharedPreferences prefs) {
         if (isLocalAddress(prefs.getString("dns", null)) ||
                 isLocalAddress(prefs.getString("dns2", null)))
             return true;

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -1,0 +1,265 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.text.TextUtils;
+import android.util.Log;
+
+import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
+
+import net.kollnig.missioncontrol.wg.WgConfig;
+import net.kollnig.missioncontrol.wg.WgConfigParser;
+import net.kollnig.missioncontrol.wg.WgPeer;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+
+/**
+ * Android 17 (API 37) "local network protections": traffic to and from local
+ * network addresses requires the {@code ACCESS_LOCAL_NETWORK} runtime
+ * permission for apps targeting API 37 or higher. Without it, TCP connections
+ * time out and UDP fails with {@code EPERM}.
+ *
+ * <p>Traffic other apps send to the LAN is unaffected by TrackerControl's
+ * permission state: those are their own sockets, and TrackerControl keeps RFC
+ * 1918 ranges out of its routes (see {@link eu.faircode.netguard.VpnRoutes}),
+ * so that traffic never enters the tun. What does depend on this permission is
+ * traffic TrackerControl itself sends to the local network:
+ *
+ * <ul>
+ *   <li>a custom VPN DNS server on the LAN (Pi-hole, AdGuard Home, the router).
+ *       Such resolvers get a host route into the tun, so the queries are
+ *       re-sent from TrackerControl's own socket (#701);</li>
+ *   <li>Secure DNS (DoH) pointed at a local resolver — an ordinary HTTPS
+ *       connection, with no DNS exemption to fall back on;</li>
+ *   <li>tethering compatibility mode, which installs a full-tunnel default
+ *       route, so LAN traffic no longer bypasses the VPN;</li>
+ *   <li>a WireGuard peer hosted on the LAN, whose endpoint socket is local.</li>
+ * </ul>
+ *
+ * <p>The system's own resolvers are deliberately not treated as needing the
+ * permission: Android exempts port 53 traffic to the network's DNS servers, so
+ * the common "router is the DNS server" setup keeps working untouched. Only
+ * configuration that points TrackerControl somewhere else on the LAN triggers
+ * the prompt, which keeps the permission request off the path of users who
+ * never need it.
+ */
+public class LocalNetworkAccess {
+    private static final String TAG = "TrackerControl.LocalNet";
+
+    /**
+     * Runtime permission guarding local network access. Referenced by name
+     * because {@code Manifest.permission.ACCESS_LOCAL_NETWORK} only exists in
+     * API 36+ SDKs, and the manifest declares the same string.
+     */
+    public static final String PERMISSION = "android.permission.ACCESS_LOCAL_NETWORK";
+
+    /** Android 17. Enforcement applies to apps targeting this level or higher. */
+    private static final int SDK_LOCAL_NETWORK_PROTECTION = 37;
+
+    /** Preferences that can point TrackerControl at the local network. */
+    private static final String[] SETTINGS = {
+            "dns", "dns2",                      // custom VPN DNS servers
+            "doh_enabled", "doh_endpoint",      // Secure DNS
+            "tcp_mss_clamp",                    // tethering compatibility mode
+            "wg_enabled", "wg_config",          // WireGuard remote egress
+    };
+
+    /** Whether the running Android version enforces local network protections. */
+    public static boolean isEnforced() {
+        return Build.VERSION.SDK_INT >= SDK_LOCAL_NETWORK_PROTECTION;
+    }
+
+    /** Whether changing {@code name} can change {@link #isMissing(Context)}. */
+    public static boolean isRelevantSetting(String name) {
+        for (String setting : SETTINGS)
+            if (setting.equals(name))
+                return true;
+        return false;
+    }
+
+    public static boolean isGranted(Context context) {
+        if (!isEnforced())
+            return true;
+        return ContextCompat.checkSelfPermission(context, PERMISSION)
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Whether local network access is both needed by the current configuration
+     * and not granted — i.e. whether something the user configured is about to
+     * break, or has already broken.
+     */
+    public static boolean isMissing(Context context) {
+        // Cheapest checks first: nothing to do below Android 17, and parsing the
+        // WireGuard config is pointless once the permission is granted.
+        return isEnforced() && !isGranted(context) && isConfigured(context);
+    }
+
+    /** Whether the current configuration makes TrackerControl talk to the LAN. */
+    public static boolean isConfigured(Context context) {
+        return isConfigured(PreferenceManager.getDefaultSharedPreferences(context));
+    }
+
+    public static boolean isConfigured(SharedPreferences prefs) {
+        if (isLocalAddress(prefs.getString("dns", null)) ||
+                isLocalAddress(prefs.getString("dns2", null)))
+            return true;
+
+        if (prefs.getBoolean("doh_enabled", false) &&
+                isLocalUrlHost(prefs.getString("doh_endpoint", null)))
+            return true;
+
+        if (prefs.getBoolean("tcp_mss_clamp", false))
+            return true;
+
+        return prefs.getBoolean("wg_enabled", false) &&
+                hasLocalWireGuardEndpoint(prefs.getString("wg_config", null));
+    }
+
+    /**
+     * Whether {@code address} is a numeric address on the local network: an RFC
+     * 1918 range, the RFC 6598 range some routers use on their LAN side, a
+     * link-local address, or an IPv6 unique local address. Only literals are
+     * considered — resolving a hostname here would mean a network lookup on the
+     * caller's (often main) thread.
+     */
+    static boolean isLocalAddress(String address) {
+        if (TextUtils.isEmpty(address))
+            return false;
+
+        InetAddress addr = parseNumeric(address.trim());
+        if (addr == null)
+            return false;
+
+        if (addr.isLoopbackAddress() || addr.isAnyLocalAddress())
+            return false; // The device itself, not the local network
+        if (addr.isLinkLocalAddress() || addr.isSiteLocalAddress())
+            return true;
+        if (addr instanceof Inet6Address) {
+            // Unique local addresses (fc00::/7) — isSiteLocalAddress() only
+            // covers the deprecated fec0::/10 range.
+            byte[] bytes = addr.getAddress();
+            return (bytes[0] & 0xFE) == 0xFC;
+        }
+        return isCarrierGradeNat(addr);
+    }
+
+    /**
+     * Parses a numeric IPv4/IPv6 address, returning null for anything else.
+     * Deliberately does not fall back to {@link InetAddress#getByName(String)}
+     * for names, which would resolve them over the network.
+     */
+    private static InetAddress parseNumeric(String value) {
+        try {
+            if (value.indexOf(':') >= 0) {
+                // IPv6 literal; drop any zone index (fe80::1%wlan0).
+                int zone = value.indexOf('%');
+                String literal = (zone < 0 ? value : value.substring(0, zone));
+                // Colons cannot appear in host names, so this never resolves.
+                return InetAddress.getByName(literal);
+            }
+
+            String[] parts = value.split("\\.", -1);
+            if (parts.length != 4)
+                return null;
+            byte[] bytes = new byte[4];
+            for (int i = 0; i < 4; i++) {
+                if (parts[i].isEmpty() || parts[i].length() > 3)
+                    return null;
+                for (int c = 0; c < parts[i].length(); c++)
+                    if (parts[i].charAt(c) < '0' || parts[i].charAt(c) > '9')
+                        return null;
+                int octet = Integer.parseInt(parts[i]);
+                if (octet > 255)
+                    return null;
+                bytes[i] = (byte) octet;
+            }
+            return InetAddress.getByAddress(bytes);
+        } catch (Throwable ex) {
+            Log.w(TAG, "Cannot parse address: " + ex);
+            return null;
+        }
+    }
+
+    /** 100.64.0.0/10 (RFC 6598), used by some routers for their LAN side. */
+    private static boolean isCarrierGradeNat(InetAddress addr) {
+        if (!(addr instanceof Inet4Address))
+            return false;
+        byte[] bytes = addr.getAddress();
+        return (bytes[0] & 0xFF) == 100 && (bytes[1] & 0xC0) == 0x40;
+    }
+
+    /** Whether {@code url}'s host is a local network address literal. */
+    static boolean isLocalUrlHost(String url) {
+        if (TextUtils.isEmpty(url))
+            return false;
+        try {
+            String host = URI.create(url.trim()).getHost();
+            if (host == null)
+                return false;
+            // URI keeps the brackets around IPv6 literals.
+            if (host.startsWith("[") && host.endsWith("]"))
+                host = host.substring(1, host.length() - 1);
+            return isLocalAddress(host);
+        } catch (Throwable ex) {
+            Log.w(TAG, "Cannot parse URL: " + ex);
+            return false;
+        }
+    }
+
+    /** Whether any peer of {@code config} has an endpoint on the local network. */
+    static boolean hasLocalWireGuardEndpoint(String config) {
+        if (TextUtils.isEmpty(config))
+            return false;
+        try {
+            WgConfig parsed = WgConfigParser.INSTANCE.parse(config);
+            for (WgPeer peer : parsed.getPeers()) {
+                String endpoint = peer.getEndpoint();
+                if (endpoint == null)
+                    continue;
+                if (isLocalAddress(hostOfEndpoint(endpoint)))
+                    return true;
+            }
+        } catch (Throwable ex) {
+            Log.w(TAG, "Cannot parse WireGuard config: " + ex);
+        }
+        return false;
+    }
+
+    /** Strips the port from a WireGuard {@code host:port} endpoint. */
+    private static String hostOfEndpoint(String endpoint) {
+        String value = endpoint.trim();
+        if (value.startsWith("[")) { // [fd00::1]:51820
+            int end = value.indexOf(']');
+            return end < 0 ? value : value.substring(1, end);
+        }
+        int colon = value.lastIndexOf(':');
+        // A bare IPv6 literal has several colons and no port.
+        if (colon < 0 || value.indexOf(':') != colon)
+            return value;
+        return value.substring(0, colon);
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -56,7 +56,9 @@ import java.net.URI;
  *       connection, with no DNS exemption to fall back on;</li>
  *   <li>tethering compatibility mode, which installs a full-tunnel default
  *       route, so LAN traffic no longer bypasses the VPN;</li>
- *   <li>a WireGuard peer hosted on the LAN, whose endpoint socket is local.</li>
+ *   <li>a WireGuard peer hosted on the LAN, whose endpoint socket is local;</li>
+ *   <li>a SOCKS5 proxy on the LAN, which the native engine dials from our own
+ *       socket in the same way.</li>
  * </ul>
  *
  * <p>The system's own resolvers are deliberately not treated as needing the
@@ -85,6 +87,7 @@ public class LocalNetworkAccess {
             "doh_enabled", "doh_endpoint",      // Secure DNS
             "tcp_mss_clamp",                    // tethering compatibility mode
             "wg_enabled", "wg_config",          // WireGuard remote egress
+            "socks5_enabled", "socks5_addr",    // SOCKS5 egress
     };
 
     /** Whether the running Android version enforces local network protections. */
@@ -135,6 +138,12 @@ public class LocalNetworkAccess {
         if (prefs.getBoolean("tcp_mss_clamp", false))
             return true;
 
+        // The native engine dials the SOCKS5 proxy from our own socket, exactly
+        // like the WireGuard endpoint below (see ServiceSinkhole.jni_socks5).
+        if (prefs.getBoolean("socks5_enabled", false) &&
+                isLocalAddress(prefs.getString("socks5_addr", null)))
+            return true;
+
         return prefs.getBoolean("wg_enabled", false) &&
                 hasLocalWireGuardEndpoint(prefs.getString("wg_config", null));
     }
@@ -178,7 +187,12 @@ public class LocalNetworkAccess {
                 // IPv6 literal; drop any zone index (fe80::1%wlan0).
                 int zone = value.indexOf('%');
                 String literal = (zone < 0 ? value : value.substring(0, zone));
-                // Colons cannot appear in host names, so this never resolves.
+                // getByName() falls back to a name lookup for anything it cannot
+                // parse numerically — a blocking resolve on the caller's thread.
+                // Only hand it strings that can be IPv6 literals in the first
+                // place; everything else is not an address we care about.
+                if (!isIpv6Literal(literal))
+                    return null;
                 return InetAddress.getByName(literal);
             }
 
@@ -202,6 +216,25 @@ public class LocalNetworkAccess {
             Log.w(TAG, "Cannot parse address: " + ex);
             return null;
         }
+    }
+
+    /**
+     * Whether {@code value} consists only of characters an IPv6 literal can be
+     * made of. A cheap gate in front of {@link InetAddress#getByName(String)},
+     * which would otherwise resolve whatever it cannot parse.
+     */
+    private static boolean isIpv6Literal(String value) {
+        if (value.isEmpty())
+            return false;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            boolean allowed = (c >= '0' && c <= '9') ||
+                    (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F') ||
+                    c == ':' || c == '.'; // '.' for IPv4-mapped (::ffff:10.0.0.1)
+            if (!allowed)
+                return false;
+        }
+        return true;
     }
 
     /** 100.64.0.0/10 (RFC 6598), used by some routers for their LAN side. */

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -44,6 +44,26 @@
         android:textColor="?attr/colorOff"
         android:visibility="gone" />
 
+    <!--
+        Outside llApps on purpose: that container is hidden on the Timeline and
+        VPN tabs, and Timeline is where the app lands. A warning about a broken
+        configuration has to be visible whichever tab the user is on.
+    -->
+    <TextView
+        android:id="@+id/tvLocalNetwork"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_warning_amber"
+        android:drawablePadding="8dp"
+        android:drawableTint="?attr/colorError"
+        android:padding="8dp"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/msg_local_network"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="?attr/colorOff"
+        android:visibility="gone" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -693,7 +693,7 @@ Sincerely,\n\n]]></string>
     <string name="static_analysis">Detect trackers in app code</string>
     <string name="failed_loading_cached_analysis">Loading cached tracker results failed. Please report this to the developer at hello@trackercontrol.org</string>
     <string name="msg_notifications">Tap to grant notification permissions (for error messages, etc.)</string>
-    <string name="msg_local_network">Tap to allow local network access, which Android asks about as \"nearby devices\". Android 17 blocks it by default, so your own DNS server, Secure DNS resolver or WireGuard peer cannot be reached.</string>
+    <string name="msg_local_network">Tap to allow local network access, which Android asks about as \"nearby devices\". Android 17 blocks it by default, so your own DNS server, Secure DNS resolver, WireGuard peer or proxy cannot be reached.</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -693,7 +693,7 @@ Sincerely,\n\n]]></string>
     <string name="static_analysis">Detect trackers in app code</string>
     <string name="failed_loading_cached_analysis">Loading cached tracker results failed. Please report this to the developer at hello@trackercontrol.org</string>
     <string name="msg_notifications">Tap to grant notification permissions (for error messages, etc.)</string>
-    <string name="msg_local_network">Tap to allow local network access. Android 17 blocks it by default, so your own DNS server, Secure DNS resolver or WireGuard peer cannot be reached.</string>
+    <string name="msg_local_network">Tap to allow local network access, which Android asks about as \"nearby devices\". Android 17 blocks it by default, so your own DNS server, Secure DNS resolver or WireGuard peer cannot be reached.</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -693,6 +693,7 @@ Sincerely,\n\n]]></string>
     <string name="static_analysis">Detect trackers in app code</string>
     <string name="failed_loading_cached_analysis">Loading cached tracker results failed. Please report this to the developer at hello@trackercontrol.org</string>
     <string name="msg_notifications">Tap to grant notification permissions (for error messages, etc.)</string>
+    <string name="msg_local_network">Tap to allow local network access. Android 17 blocks it by default, so your own DNS server, Secure DNS resolver or WireGuard peer cannot be reached.</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>

--- a/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
@@ -1,0 +1,192 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package net.kollnig.missioncontrol;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Which configurations make TrackerControl talk to the local network, and thus
+ * need the Android 17 {@code ACCESS_LOCAL_NETWORK} permission (#701). The SDK
+ * gating itself is not covered: Robolectric runs on API 36, below the level
+ * where local network protections are enforced.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class LocalNetworkAccessTest {
+    private static final String KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    private static final String WG_CONFIG_TEMPLATE =
+            "[Interface]\n" +
+                    "PrivateKey = " + KEY + "\n" +
+                    "Address = 10.64.0.2/32\n" +
+                    "\n" +
+                    "[Peer]\n" +
+                    "PublicKey = " + KEY + "\n" +
+                    "AllowedIPs = 0.0.0.0/0\n" +
+                    "Endpoint = %s\n";
+
+    private SharedPreferences prefs;
+
+    @Before
+    public void setUp() {
+        prefs = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.getApplication());
+        prefs.edit().clear().commit();
+    }
+
+    @Test
+    public void defaultConfigurationDoesNotNeedLocalNetworkAccess() {
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void publicCustomDnsDoesNotNeedLocalNetworkAccess() {
+        prefs.edit().putString("dns", "9.9.9.9").commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void privateCustomDnsNeedsLocalNetworkAccess() {
+        prefs.edit().putString("dns", "192.168.1.10").commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void privateSecondaryDnsNeedsLocalNetworkAccess() {
+        prefs.edit().putString("dns", "9.9.9.9").putString("dns2", " 10.0.0.53 ").commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void uniqueLocalIpv6DnsNeedsLocalNetworkAccess() {
+        prefs.edit().putString("dns", "fd12:3456:789a::1").commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void loopbackDnsDoesNotNeedLocalNetworkAccess() {
+        // The device itself is not the local network.
+        prefs.edit().putString("dns", "127.0.0.1").commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void localDohEndpointNeedsLocalNetworkAccessOnlyWhenEnabled() {
+        prefs.edit().putString("doh_endpoint", "https://192.168.1.10/dns-query").commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+
+        prefs.edit().putBoolean("doh_enabled", true).commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void bracketedIpv6DohEndpointNeedsLocalNetworkAccess() {
+        prefs.edit()
+                .putBoolean("doh_enabled", true)
+                .putString("doh_endpoint", "https://[fd00::1]:8443/dns-query")
+                .commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void publicDohEndpointDoesNotNeedLocalNetworkAccess() {
+        prefs.edit()
+                .putBoolean("doh_enabled", true)
+                .putString("doh_endpoint", "https://dns.quad9.net/dns-query")
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void tetheringCompatibilityModeNeedsLocalNetworkAccess() {
+        // Full-tunnel routes put LAN traffic back inside the tun.
+        prefs.edit().putBoolean("tcp_mss_clamp", true).commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void remoteWireGuardEndpointDoesNotNeedLocalNetworkAccess() {
+        prefs.edit()
+                .putBoolean("wg_enabled", true)
+                .putString("wg_config", String.format(WG_CONFIG_TEMPLATE, "185.65.135.72:51820"))
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void selfHostedWireGuardEndpointNeedsLocalNetworkAccessOnlyWhenEnabled() {
+        prefs.edit()
+                .putString("wg_config", String.format(WG_CONFIG_TEMPLATE, "192.168.1.5:51820"))
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+
+        prefs.edit().putBoolean("wg_enabled", true).commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void ipv6WireGuardEndpointNeedsLocalNetworkAccess() {
+        prefs.edit()
+                .putBoolean("wg_enabled", true)
+                .putString("wg_config", String.format(WG_CONFIG_TEMPLATE, "[fd00::5]:51820"))
+                .commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void hostnameEndpointsAreNotTreatedAsLocal() {
+        // Hostnames are never resolved here — that would be a network lookup on
+        // the caller's thread.
+        prefs.edit()
+                .putBoolean("wg_enabled", true)
+                .putString("wg_config", String.format(WG_CONFIG_TEMPLATE, "vpn.example.org:51820"))
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void malformedValuesAreIgnored() {
+        prefs.edit()
+                .putString("dns", "not-an-address")
+                .putString("dns2", "999.1.1.1")
+                .putBoolean("doh_enabled", true)
+                .putString("doh_endpoint", "not a url")
+                .putBoolean("wg_enabled", true)
+                .putString("wg_config", "garbage")
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void relevantSettingsAreRecognised() {
+        assertTrue(LocalNetworkAccess.isRelevantSetting("dns"));
+        assertTrue(LocalNetworkAccess.isRelevantSetting("doh_endpoint"));
+        assertTrue(LocalNetworkAccess.isRelevantSetting("tcp_mss_clamp"));
+        assertTrue(LocalNetworkAccess.isRelevantSetting("wg_config"));
+        assertFalse(LocalNetworkAccess.isRelevantSetting("blocking_mode"));
+        assertFalse(LocalNetworkAccess.isRelevantSetting(null));
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
@@ -181,11 +181,78 @@ public class LocalNetworkAccessTest {
     }
 
     @Test
+    public void localSocks5ProxyNeedsLocalNetworkAccessOnlyWhenEnabled() {
+        prefs.edit().putString("socks5_addr", "192.168.1.2").commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+
+        prefs.edit().putBoolean("socks5_enabled", true).commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void remoteSocks5ProxyDoesNotNeedLocalNetworkAccess() {
+        prefs.edit()
+                .putBoolean("socks5_enabled", true)
+                .putString("socks5_addr", "203.0.113.5")
+                .commit();
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void privateRangesAreRecognised() {
+        assertTrue(LocalNetworkAccess.isLocalAddress("10.0.0.1"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("172.16.0.1"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("172.31.255.254"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("192.168.0.1"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("169.254.1.1")); // link-local
+        assertTrue(LocalNetworkAccess.isLocalAddress("fe80::1"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("fe80::1%wlan0")); // zone index
+        assertTrue(LocalNetworkAccess.isLocalAddress("fdff:ffff::1"));
+    }
+
+    @Test
+    public void publicRangesAreNotRecognisedAsLocal() {
+        assertFalse(LocalNetworkAccess.isLocalAddress("172.15.0.1")); // just below 172.16/12
+        assertFalse(LocalNetworkAccess.isLocalAddress("172.32.0.1")); // just above
+        assertFalse(LocalNetworkAccess.isLocalAddress("192.169.0.1"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("2606:4700:4700::1111"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("::1")); // the device itself
+    }
+
+    @Test
+    public void carrierGradeNatRangeIsRecognised() {
+        // 100.64.0.0/10 (RFC 6598): some routers use it on their LAN side.
+        assertTrue(LocalNetworkAccess.isLocalAddress("100.64.0.1"));
+        assertTrue(LocalNetworkAccess.isLocalAddress("100.127.255.254"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("100.63.255.255"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("100.128.0.1"));
+    }
+
+    @Test
+    public void hostnamesAreNeverResolved() {
+        // A blocking lookup here would run on the caller's thread.
+        assertFalse(LocalNetworkAccess.isLocalAddress("pi.hole"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("localhost"));
+        assertFalse(LocalNetworkAccess.isLocalAddress("not:a:literal"));
+        assertFalse(LocalNetworkAccess.isLocalUrlHost("https://pi.hole/dns-query"));
+    }
+
+    @Test
+    public void wireGuardEndpointWithoutPortIsRecognised() {
+        prefs.edit()
+                .putBoolean("wg_enabled", true)
+                .putString("wg_config", String.format(WG_CONFIG_TEMPLATE, "192.168.1.5"))
+                .commit();
+        assertTrue(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
     public void relevantSettingsAreRecognised() {
         assertTrue(LocalNetworkAccess.isRelevantSetting("dns"));
         assertTrue(LocalNetworkAccess.isRelevantSetting("doh_endpoint"));
         assertTrue(LocalNetworkAccess.isRelevantSetting("tcp_mss_clamp"));
         assertTrue(LocalNetworkAccess.isRelevantSetting("wg_config"));
+        assertTrue(LocalNetworkAccess.isRelevantSetting("socks5_addr"));
         assertFalse(LocalNetworkAccess.isRelevantSetting("blocking_mode"));
         assertFalse(LocalNetworkAccess.isRelevantSetting(null));
     }


### PR DESCRIPTION
Fixes #701.

## The problem

Android 17 makes [local network protections](https://developer.android.com/privacy-and-security/local-network-permission) mandatory for apps targeting API 37 — which TrackerControl does (`targetSdk 37`). Traffic to local network addresses now needs the `ACCESS_LOCAL_NETWORK` runtime permission (`NEARBY_DEVICES` group); without it TCP connections time out and UDP fails with `EPERM`.

Traffic *other apps* send to the LAN is unaffected by our permission state: those are their own sockets, and `VpnRoutes` keeps RFC 1918 ranges out of the tun, so that traffic never reaches us. What breaks is traffic **TrackerControl itself** sends to the local network:

* **A custom VPN DNS server on the LAN** (the reported case). `getConfig()` deliberately adds a `/32` host route for site-local resolvers so they stay inside the tunnel and pass through the filtering path — which means the query is re-sent from TrackerControl's own socket. With the permission missing that socket is blocked, and the device ends up with no working name resolution at all.
* **Secure DNS pointed at a local resolver** — an ordinary HTTPS connection on port 443, with no DNS exemption to fall back on.
* **Tethering compatibility mode** — its full-tunnel `0.0.0.0/0` route puts LAN traffic back inside the tun.
* **A WireGuard peer hosted on the LAN** — the tunnel's endpoint socket is local.

## The change

* Declare `android.permission.ACCESS_LOCAL_NETWORK` in the manifest.
* New `net.kollnig.missioncontrol.LocalNetworkAccess`: is enforcement active (API ≥ 37), is the permission granted, and does the current configuration actually point TrackerControl at the LAN (the four cases above, address literals only — resolving a hostname here would mean a lookup on the main thread).
* Request the permission where it is needed:
  * **In settings**, as soon as a relevant preference changes (`dns`, `dns2`, `doh_enabled`, `doh_endpoint`, `tcp_mss_clamp`, `wg_enabled`, `wg_config`), so the user grants it at the moment they configure the thing that needs it. Asked at most once per visit — writing back a trimmed value re-enters the listener, and a second request while the dialog is up is dropped by the framework.
  * **On the main screen**, a tappable warning row (same pattern as the existing notification-permission row) while the permission is missing and the configuration needs it. Permanent denial opens the app's permission screen, as the notification row already does.
* `ServiceSinkhole` logs a warning when the tunnel comes up in that state, so the failure is visible in a bug report.

Deliberately **not** treated as needing the permission: the system's own resolvers. Android exempts port 53 traffic to the network's DNS servers, so the very common "router is the DNS server" setup keeps working, and users who never point TrackerControl at the LAN are never prompted. Below Android 17, `isEnforced()` short-circuits — no checks, no banner, no config parsing.

This is a breakage-recovery fix rather than a new knob: no preference is added, and the permission is only ever requested for a configuration the user already chose.

## NetGuard upstream

Checked NetGuard (M66B/NetGuard) for the same fix and for anything else worth merging since our last sync:

* **Local network protections: not implemented upstream.** NetGuard's manifest has no `ACCESS_LOCAL_NETWORK` and it still targets SDK 36 (`Updated to SDK 36`, 31 Jul 2026), so it gets the implicit legacy grant and the enforcement never bites. Nothing to merge — the work here is ours.
* **Merged:** `Updated whois link` (552ef140) — dnslytics moved its lookup to `search.dnslytics.com/ip/<ip>`; our `ActivityLog` still used the old `/whois-lookup/` URL (second commit).
* **Already in TrackerControl:** `Added AP state receiver` (761450e1), `Buffered settings output` (8a60a7b3).
* **Not applicable:** `Allow dynamic tethering network interface` (b1d598ce) adds dynamic `ap_br_wlan*` exclusions to NetGuard's route list; our `VpnRoutes` already excludes all of RFC 1918 by default, and tethering downstreams are handled by the tethering compatibility mode added in #700. The SDK 36 / insets / action-bar-height work (0a95c6ea, f2ccd1df, 7b152b49, ce67398e and the accompanying refactors) is NetGuard's route to edge-to-edge on API 36; we already target 37 with our own per-activity insets handling, so adopting it would be churn against a codebase that has moved past it.

## Testing

`LocalNetworkAccessTest` (Robolectric) covers the configuration detection: public vs. private custom DNS, IPv6 ULA and loopback, DoH endpoint gated on `doh_enabled` including a bracketed IPv6 literal, tethering compatibility mode, local vs. remote vs. hostname WireGuard endpoints, and malformed input. The SDK gate itself is not covered — Robolectric runs on API 36, below the enforcement level.

Not verified on a device: this environment has no Android SDK, so the build and the Robolectric run are left to CI. The permission prompt and banner flow on an Android 17 device have not been exercised, and I would like the reporter to confirm that granting the permission restores their LAN DNS setup before this leaves draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsAkkinA9Jfjt9khTKvBma)_