### PR TITLE
ci: warm unit-test runtime classpath before offline test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,11 @@ jobs:
           # Compile the unit tests online once so their classpath is cached
           # before the offline run below.
           ./gradlew :app:assembleFdroidDebugUnitTest
+          # assembleFdroidDebugUnitTest doesn't resolve the unit test
+          # *runtime* classpath (e.g. espresso-idling-resource, pulled in
+          # via Robolectric/androidx.test), which mergeFdroidDebugUnitTestManifest
+          # needs. Warm that too, or the offline test run below fails.
+          ./gradlew :app:mergeFdroidDebugUnitTestManifest
 
       - name: Run Rust unit tests
         run: cargo test --manifest-path wgbridge-rs/Cargo.toml --locked --offline


### PR DESCRIPTION
## Summary

Fixes a reproducible CI failure in the `test` job, first observed on #702 (a dependabot bump of `constraintlayout` unrelated to the actual cause).

The `Prefetch Gradle dependencies` step only runs `./gradlew :app:assembleFdroidDebugUnitTest` online to warm the Gradle cache before the offline test run. That task never resolves the unit test **runtime** classpath (`fdroidDebugUnitTestRuntimeClasspath`), which is needed by `:app:mergeFdroidDebugUnitTestManifest` — a task that only runs as part of `testFdroidDebugUnitTest`. Since that classpath includes `espresso-idling-resource:3.7.0` (pulled in transitively via Robolectric/androidx.test), the later `./gradlew testFdroidDebugUnitTest --offline` step fails with:

```
Could not resolve all files for configuration ':app:fdroidDebugUnitTestRuntimeClasspath'.
Failed to transform espresso-idling-resource-3.7.0.aar ...
Could not download espresso-idling-resource-3.7.0.aar: No cached version available for offline mode
```

This isn't dependency-bump-specific or flaky — it's a straightforward gap in what the prefetch step warms.

## Fix

Add `./gradlew :app:mergeFdroidDebugUnitTestManifest` to the online prefetch step, so the runtime classpath (including `espresso-idling-resource`) gets resolved and cached before the offline `testFdroidDebugUnitTest` run.

## Test plan

- [ ] CI `test` job passes on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01FUrFJHUU716XNNWRdxHQet)_