### PR TITLE
Show the notification permission prompt on every tab

### DIFF
--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -24,6 +24,26 @@
             app:titleTextColor="@android:color/white" />
     </com.google.android.material.appbar.AppBarLayout>
 
+    <!--
+        Outside llApps on purpose: that container is hidden on the Timeline and
+        VPN tabs, and Timeline is where the app lands. A prompt to grant a
+        permission has to be visible whichever tab the user is on.
+    -->
+    <TextView
+        android:id="@+id/tvNotifications"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/twotone_notifications_24"
+        android:drawablePadding="8dp"
+        android:drawableTint="?attr/colorError"
+        android:padding="8dp"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/msg_notifications"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="?attr/colorOff"
+        android:visibility="gone" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -59,19 +79,6 @@
                     android:textColor="?attr/colorOff"
                     android:visibility="gone" />
             </LinearLayout>
-
-            <TextView
-                android:id="@+id/tvNotifications"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:drawableStart="@drawable/twotone_notifications_24"
-                android:drawablePadding="8dp"
-                android:drawableTint="?attr/colorError"
-                android:padding="8dp"
-                android:text="@string/msg_notifications"
-                android:textAppearance="@style/TextSmall"
-                android:textColor="?attr/colorOff"
-                android:visibility="visible" />
 
             <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
                 android:id="@+id/swipeRefresh"


### PR DESCRIPTION
## The problem

`tvNotifications` — the tappable row prompting the user to grant notification permissions — lives inside `llApps` in `main.xml`. That container is hidden whenever the Timeline or VPN tab is selected, and `ActivityMain` deliberately lands users on Timeline:

> Land new users on Timeline; keep returning users there too — it is the "what's happening now" dashboard. Apps is one tap away.

So a user who has not granted notification permissions never sees the prompt unless they happen to switch to the Apps tab. Confirmed on a Pixel 8 (Android 17): with `POST_NOTIFICATIONS` revoked, the row is absent on Timeline and present on Apps.

This is pre-existing, unrelated to the local network work in #704; it was spotted while testing that branch on a device.

## The change

Move the row out of `llApps`, directly below the app bar, so it renders on every tab. `onCreate` and `onResume` already drive its visibility and are untouched.

The XML default changes from `visible` to `gone` to match: `onCreate` hides it unconditionally regardless, so nothing depended on the old default, and a row in this position should not flash before that runs.

## Testing

Built and installed on a Pixel 8 (Android 17, API 37). With `POST_NOTIFICATIONS` revoked, the prompt now appears on the Timeline tab on launch; granting it hides the row as before.

## Note on merge order

#704 moves `tvLocalNetwork` to the same place. Whichever lands second will need a trivial conflict resolution in `main.xml` — both rows belong outside `llApps`, stacked below the app bar.