### PR TITLE
Notify about missing local network access, and stop misdiagnosing it

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -230,6 +230,7 @@ public class ServiceSinkhole extends VpnService {
     public static final int NOTIFY_EXTERNAL = 9;
     private static final int NOTIFY_DOH_ERROR = 11;
     private static final int NOTIFY_WG_ERROR = 12;
+    private static final int NOTIFY_LOCAL_NETWORK = 13;
 
     public static final String EXTRA_COMMAND = "Command";
     private static final String EXTRA_REASON = "Reason";
@@ -1663,9 +1664,15 @@ public class ServiceSinkhole extends VpnService {
         // Android 17 refuses local network traffic without ACCESS_LOCAL_NETWORK:
         // TCP times out, UDP fails with EPERM. A LAN resolver routed into the tun
         // above is re-sent from our own socket, so it goes silent (#701).
-        if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(ServiceSinkhole.this))
+        // The symptom is "nothing resolves", which no one attributes to a
+        // permission — and the banner only reaches someone who opens the app.
+        // Notify, so the reason meets the user where the failure appears.
+        if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(ServiceSinkhole.this)) {
             Log.w(TAG, "Local network access not granted: configured LAN destinations" +
-                    " (custom DNS, Secure DNS resolver, WireGuard peer) are unreachable");
+                    " (custom DNS, Secure DNS resolver, WireGuard peer, proxy) are unreachable");
+            showLocalNetworkNotification();
+        } else
+            clearLocalNetworkNotification();
 
         // Dynamically exclude carrier ePDG IPs so Wi-Fi calling works globally.
         // ePDG domains follow 3GPP standard: epdg.epc.mnc{MNC}.mcc{MCC}.pub.3gppnetwork.org
@@ -3662,6 +3669,14 @@ public class ServiceSinkhole extends VpnService {
     }
 
     private void showDohErrorNotification() {
+        // A local resolver we are not allowed to reach is not a DoH problem,
+        // and "consider disabling Secure DNS" is the wrong advice for it: the
+        // fix is one permission away. Say so instead (#701).
+        if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(this)) {
+            showLocalNetworkNotification();
+            return;
+        }
+
         Intent main = new Intent(this, ActivityMain.class);
         PendingIntent pi = PendingIntentCompat.getActivity(this, 0, main, PendingIntent.FLAG_UPDATE_CURRENT);
 
@@ -3686,6 +3701,14 @@ public class ServiceSinkhole extends VpnService {
     }
 
     private void showWireGuardErrorNotification(String message) {
+        // Same as the DoH case: a peer on the LAN that we may not talk to is a
+        // permission problem, not a tunnel problem, and sending the user to the
+        // WireGuard settings only wastes their time (#701).
+        if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(this)) {
+            showLocalNetworkNotification();
+            return;
+        }
+
         Intent main = new Intent(this, ActivitySettings.class);
         PendingIntent pi = PendingIntentCompat.getActivity(this, NOTIFY_WG_ERROR, main,
                 PendingIntent.FLAG_UPDATE_CURRENT);
@@ -3715,6 +3738,42 @@ public class ServiceSinkhole extends VpnService {
 
     private void clearWireGuardErrorNotification() {
         NotificationManagerCompat.from(this).cancel(NOTIFY_WG_ERROR);
+    }
+
+    /**
+     * Local network access is missing and something the user configured needs
+     * it. Opens the main screen, where the warning row requests the permission.
+     */
+    private void showLocalNetworkNotification() {
+        Intent main = new Intent(this, ActivityMain.class);
+        PendingIntent pi = PendingIntentCompat.getActivity(this, NOTIFY_LOCAL_NETWORK, main,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String detail = getString(R.string.msg_local_network_notify);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "notify");
+        builder.setSmallIcon(R.drawable.ic_error_white_24dp)
+                .setContentTitle(getString(R.string.msg_local_network_title))
+                .setContentText(detail)
+                .setContentIntent(pi)
+                .setColor(getResources().getColor(R.color.colorTrackerControl))
+                .setOngoing(false)
+                .setAutoCancel(true)
+                // Rebuilt on every network change; alert once, then sit quietly.
+                .setOnlyAlertOnce(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+
+        NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
+        notification.bigText(detail);
+
+        Util.notify(this, NOTIFY_LOCAL_NETWORK, notification.build());
+    }
+
+    private void clearLocalNetworkNotification() {
+        NotificationManagerCompat.from(this).cancel(NOTIFY_LOCAL_NETWORK);
     }
 
     private void showUpdateNotification(String name, String url) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,6 +694,8 @@ Sincerely,\n\n]]></string>
     <string name="failed_loading_cached_analysis">Loading cached tracker results failed. Please report this to the developer at hello@trackercontrol.org</string>
     <string name="msg_notifications">Tap to grant notification permissions (for error messages, etc.)</string>
     <string name="msg_local_network">Tap to allow local network access, which Android asks about as \"nearby devices\". Android 17 blocks it by default, so your own DNS server, Secure DNS resolver, WireGuard peer or proxy cannot be reached.</string>
+    <string name="msg_local_network_title">Local network access needed</string>
+    <string name="msg_local_network_notify">TrackerControl cannot reach your own DNS server, Secure DNS resolver, WireGuard peer or proxy, so name resolution may fail. Android 17 requires permission for this, which Android asks about as \"nearby devices\". Tap to open TrackerControl and allow it.</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>


### PR DESCRIPTION
**Stacked on #707**, which is stacked on #704. Review those first; each retargets automatically as the one below it merges.

## The problem

After #704 and #707, everything that tells the user about missing local network access requires them to already be in the app:

| Surface | Reaches the user when… |
|---|---|
| Warning row on the main screen | they open the app |
| Settings prompt | they happen to be changing `dns`, `doh_*`, `wg_*`, `socks5_*` or tethering mode |
| `Log.w` in `ServiceSinkhole` | someone reads a bug report |

But the symptom is *"nothing resolves"*, and nobody attributes that to a permission. The likely responses are to turn the VPN off or uninstall — neither of which the app ever hears about.

Worse, the notifications that *do* fire today point at the wrong thing. A LAN resolver we are not allowed to reach raises the DoH one:

> Secure DNS (DoH) cannot be reached even though you have an active internet connection. If this happens repeatedly, consider disabling it in the Network settings.

That blames DoH and recommends disabling a feature that works fine. A WireGuard peer on the LAN likewise sends the user into the WireGuard settings for a problem that is not there.

## The change

* A `NOTIFY_LOCAL_NETWORK` notification, raised from the same place as the existing `Log.w` — where the tunnel is built — and cleared as soon as the permission is granted. `setOnlyAlertOnce`, since the tunnel is rebuilt on every network change. Tapping it opens the main screen, where the warning row requests the permission.
* `showDohErrorNotification()` and `showWireGuardErrorNotification()` check `isMissing()` first and defer to it, so the user gets the actual cause and a one-tap fix instead of misleading advice.

Follows the established pattern of `NOTIFY_DOH_ERROR` / `NOTIFY_WG_ERROR`: same channel, same category, same `VISIBILITY_SECRET`.

The notification is an additional channel, not a replacement for the warning row — `POST_NOTIFICATIONS` may itself be denied, which is what the other row exists for.

## Testing

On a Pixel 8 (Android 17, API 37), notification permission granted:

* **Custom DNS at `192.168.178.50`, permission denied, VPN enabled** — notification posted, title `Local network access needed`, body naming the cause and what to tap.
* **Permission then granted and the tunnel rebuilt** — notification gone.
* **DoH at `https://192.168.178.128:8443/dns-query`, permission denied** — the user gets `Local network access needed`; the misleading "Secure DNS cannot be reached … consider disabling it" is **not** posted.
* **Negative control: DoH at `https://192.0.2.1/dns-query` with the permission granted** — the DoH notification posts as before, once the proxy's failure threshold trips. The substitution has not swallowed the genuine DoH case.

One honest limit: in the third scenario both the tunnel-build path and the `showDohErrorNotification()` guard have the same trigger condition and post the same notification, so which of the two posted it is not distinguishable from outside. What is verified is the user-visible property — the correct message appears and the misleading one does not.