### PR TITLE
Stop asking about Private DNS during onboarding, notify when it breaks

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -231,6 +231,7 @@ public class ServiceSinkhole extends VpnService {
     private static final int NOTIFY_DOH_ERROR = 11;
     private static final int NOTIFY_WG_ERROR = 12;
     private static final int NOTIFY_LOCAL_NETWORK = 13;
+    private static final int NOTIFY_PRIVATE_DNS = 14;
 
     public static final String EXTRA_COMMAND = "Command";
     private static final String EXTRA_REASON = "Reason";
@@ -706,7 +707,20 @@ public class ServiceSinkhole extends VpnService {
                 net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.stop(
                         () -> { jni_wireguard_stop(); return kotlin.Unit.INSTANCE; });
                 jni_wireguard_required(false);
+                // WgEgress clears its error as it tears the tunnel down, so the
+                // state listener already retracts this one; the call remains for
+                // the case it cannot see, a start that failed without ever
+                // producing a tunnel, where stop() finds nothing to notify about.
                 clearWireGuardErrorNotification();
+                // The other two are config warnings nothing else retracts, and
+                // both describe a tunnel that is no longer running — but leave
+                // them on a temporary stop (a call, say): the VPN is coming
+                // straight back, and re-posting a cancelled notification alerts
+                // again, so the user would be buzzed on every call.
+                if (!temporary) {
+                    clearLocalNetworkNotification();
+                    clearPrivateDnsNotification();
+                }
                 unprepare();
 
                 // Stop DoH proxy
@@ -1673,6 +1687,18 @@ public class ServiceSinkhole extends VpnService {
             showLocalNetworkNotification();
         } else
             clearLocalNetworkNotification();
+
+        // Blocking port 853 is what lets us keep seeing DNS: with Private DNS on
+        // "automatic", Android falls back to plaintext and detection carries on.
+        // In "hostname" mode it does not fall back — the user picked that
+        // resolver explicitly, so DNS simply fails and nothing resolves. That
+        // looks like TC broke the connection, with no hint of why, so say it.
+        if (prefs.getBoolean("block_dot", true) && Util.getPrivateDnsSpecifier(this) != null) {
+            Log.w(TAG, "Private DNS set to a hostname: DoT is blocked and Android will not" +
+                    " fall back to plaintext DNS, so name resolution fails");
+            showPrivateDnsNotification();
+        } else
+            clearPrivateDnsNotification();
 
         // Dynamically exclude carrier ePDG IPs so Wi-Fi calling works globally.
         // ePDG domains follow 3GPP standard: epdg.epc.mnc{MNC}.mcc{MCC}.pub.3gppnetwork.org
@@ -3774,6 +3800,46 @@ public class ServiceSinkhole extends VpnService {
 
     private void clearLocalNetworkNotification() {
         NotificationManagerCompat.from(this).cancel(NOTIFY_LOCAL_NETWORK);
+    }
+
+    /**
+     * Private DNS is pinned to a hostname while we block DoT, which leaves the
+     * device with no working resolver. Opens the network settings, where the
+     * setting lives; naming the resolver makes clear which one is meant.
+     */
+    private void showPrivateDnsNotification() {
+        Intent settings = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
+        if (settings.resolveActivity(getPackageManager()) == null)
+            settings = new Intent(Settings.ACTION_WIFI_SETTINGS);
+        PendingIntent pi = PendingIntentCompat.getActivity(this, NOTIFY_PRIVATE_DNS, settings,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String detail = getString(R.string.msg_private_dns_notify,
+                Util.getPrivateDnsSpecifier(this));
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "notify");
+        builder.setSmallIcon(R.drawable.ic_error_white_24dp)
+                .setContentTitle(getString(R.string.msg_private_dns_title))
+                .setContentText(detail)
+                .setContentIntent(pi)
+                .setColor(getResources().getColor(R.color.colorTrackerControl))
+                .setOngoing(false)
+                .setAutoCancel(true)
+                // Rebuilt on every network change; alert once, then sit quietly.
+                .setOnlyAlertOnce(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+
+        NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
+        notification.bigText(detail);
+
+        Util.notify(this, NOTIFY_PRIVATE_DNS, notification.build());
+    }
+
+    private void clearPrivateDnsNotification() {
+        NotificationManagerCompat.from(this).cancel(NOTIFY_PRIVATE_DNS);
     }
 
     private void showUpdateNotification(String name, String url) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1693,10 +1693,10 @@ public class ServiceSinkhole extends VpnService {
         // In "hostname" mode it does not fall back — the user picked that
         // resolver explicitly, so DNS simply fails and nothing resolves. That
         // looks like TC broke the connection, with no hint of why, so say it.
-        if (prefs.getBoolean("block_dot", true) && Util.getPrivateDnsSpecifier(this) != null) {
+        if (prefs.getBoolean("block_dot", true) && Util.isPrivateDnsHostnameMode(this)) {
             Log.w(TAG, "Private DNS set to a hostname: DoT is blocked and Android will not" +
                     " fall back to plaintext DNS, so name resolution fails");
-            showPrivateDnsNotification();
+            showPrivateDnsNotification(Util.getPrivateDnsSpecifier(this));
         } else
             clearPrivateDnsNotification();
 
@@ -3807,7 +3807,7 @@ public class ServiceSinkhole extends VpnService {
      * device with no working resolver. Opens the network settings, where the
      * setting lives; naming the resolver makes clear which one is meant.
      */
-    private void showPrivateDnsNotification() {
+    private void showPrivateDnsNotification(String specifier) {
         Intent settings = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
         if (settings.resolveActivity(getPackageManager()) == null)
             settings = new Intent(Settings.ACTION_WIFI_SETTINGS);
@@ -3815,7 +3815,7 @@ public class ServiceSinkhole extends VpnService {
                 PendingIntent.FLAG_UPDATE_CURRENT);
 
         String detail = getString(R.string.msg_private_dns_notify,
-                Util.getPrivateDnsSpecifier(this));
+                specifier != null ? specifier : getString(R.string.msg_private_dns_unknown_resolver));
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "notify");
         builder.setSmallIcon(R.drawable.ic_error_white_24dp)

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -260,14 +260,6 @@ public class Util {
         return (country != null && listEU.contains(country.toUpperCase()));
     }
 
-    public static boolean isPrivateDns(Context context) {
-        String dns_mode = Settings.Global.getString(context.getContentResolver(), "private_dns_mode");
-        Log.i(TAG, "Private DNS mode=" + dns_mode);
-        if (dns_mode == null)
-            dns_mode = "off";
-        return (!"off".equals(dns_mode));
-    }
-
     public static String getNetworkGeneration(int networkType) {
         switch (networkType) {
             case TelephonyManager.NETWORK_TYPE_1xRTT:

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -556,12 +556,20 @@ public class Util {
         return ((brief ? b : p) + (version > 0 ? version : ""));
     }
 
-    public static String getPrivateDnsSpecifier(Context context) {
+    /**
+     * Whether Android's Private DNS is pinned to a specific resolver hostname
+     * ("hostname" mode) rather than left on "automatic" or turned off. In this
+     * mode Android does not fall back to plaintext DNS when DoT is blocked.
+     */
+    public static boolean isPrivateDnsHostnameMode(Context context) {
         String dns_mode = Settings.Global.getString(context.getContentResolver(), "private_dns_mode");
-        if ("hostname".equals(dns_mode))
-            return Settings.Global.getString(context.getContentResolver(), "private_dns_specifier");
-        else
+        return "hostname".equals(dns_mode);
+    }
+
+    public static String getPrivateDnsSpecifier(Context context) {
+        if (!isPrivateDnsHostnameMode(context))
             return null;
+        return Settings.Global.getString(context.getContentResolver(), "private_dns_specifier");
     }
 
     public interface DoubtListener {

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
@@ -242,20 +242,8 @@ public class ActivityOnboarding extends AppCompatActivity {
         // }
         // }
 
-        // 7. Private DNS (Mandatory)
-        boolean privateDnsEnabled = Util.isPrivateDns(this);
-        if (privateDnsEnabled) {
-            slides.add(new Slide(
-                    R.string.onboarding_privatedns_title,
-                    getText(R.string.onboarding_privatedns_title),
-                    android.text.TextUtils.concat(getText(R.string.onboarding_privatedns_desc), "\n\n",
-                            android.text.Html
-                                    .fromHtml("<b>" + getString(R.string.onboarding_privatedns_instruction) + "</b>")),
-                    R.drawable.screen,
-                    getString(R.string.onboarding_privatedns_action),
-                    R.string.onboarding_privatedns_skip_msg,
-                    null));
-        }
+        // 7. Private DNS - no longer asked about: DoT (port 853) is blocked by
+        // default, so Android falls back to plaintext DNS on its own.
 
         // 8. Timeline
         slides.add(new Slide(
@@ -393,25 +381,6 @@ public class ActivityOnboarding extends AppCompatActivity {
             // }
             // };
             // }
-
-            // 7. Private DNS
-            if (slide.titleResId == R.string.onboarding_privatedns_title) {
-                boolean privateDnsEnabled = Util.isPrivateDns(this);
-                slide.actionButtonText = privateDnsEnabled ? getString(R.string.onboarding_privatedns_action)
-                        : getString(R.string.onboarding_action_disabled);
-                slide.warningResId = privateDnsEnabled ? R.string.onboarding_privatedns_skip_msg : 0;
-                if (privateDnsEnabled) {
-                    slide.actionListener = v -> {
-                        Intent intent = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
-                        if (intent.resolveActivity(getPackageManager()) == null) {
-                            intent = new Intent(Settings.ACTION_WIFI_SETTINGS);
-                        }
-                        startActivity(intent);
-                    };
-                } else {
-                    slide.actionListener = null;
-                }
-            }
 
             // Lockdown
             if (slide.titleResId == R.string.onboarding_lockdown_title) {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -699,6 +699,11 @@ object WgEgress {
         currentKeepaliveAlwaysOn = false
         lastCheapRecoveryMs = 0
         verificationGeneration++
+        // An error describes a tunnel that no longer exists. Listeners check
+        // lastError before isRunning — deliberately, so a start that fails
+        // without ever producing a tunnel still reports — so leaving it set
+        // here kept a stopped tunnel reporting its final error forever.
+        lastError = null
         if (t != null) {
             try {
                 t.stop()

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -400,12 +400,6 @@ Ystävällisin terveisin,\n\n]]></string>
     <string name="onboarding_notify_desc">Salli ilmoitukset, jotta voit nähdä reaaliaikaiset päivitykset ja hallita suojausta suoraan tilapalkista.</string>
     <string name="onboarding_notify_action">Salli ilmoitukset</string>
     <string name="onboarding_notify_sure">Ilman ilmoituslupaa et voi nähdä reaaliaikaisia päivityksiä tai hallita suojausta tilapalkista. Oletko varma?</string>
-    <string name="onboarding_privatedns_title">Poista yksityinen DNS käytöstä</string>
-    <string name="onboarding_privatedns_desc">Androidin ”Yksityinen DNS” -ominaisuus häiritsee TrackerControlin kykyä estää seurantalaitteita. Tämä asetus <b>on</b> asetettava ”Pois päältä” -tilaan, jotta voit jatkaa.</string>
-    <string name="onboarding_privatedns_instruction">Asetukset -&gt; Verkko &amp; Internet -&gt; Yksityinen DNS -&gt; POIS.</string>
-    <string name="onboarding_privatedns_action">Avaa DNS-asetukset</string>
-    <string name="onboarding_privatedns_skip_title">Ohita yksityisen DNS:n päältä poisto?</string>
-    <string name="onboarding_privatedns_skip_msg">Jatkaessasi yksityisen DNS:n ollessa käytössä TrackerControlin toiminta rajoittuu huomattavasti. Suurin osa seurannasta ei esty, vaan jäljelle jää vain seurantakirjaston analysointi. Lisäksi VPN-suodatin poistetaan käytöstä perusominaisuuksien toimivuuden varmistamiseksi.</string>
     <string name="onboarding_network_title">Rajoittamaton verkko</string>
     <string name="onboarding_network_desc">Tietojen tallennusasetukset voivat estää TrackerControlin toimimasta oikein taustalla. Anna rajoittamaton käyttöoikeus, jotta saat luotettavimman suojan.</string>
     <string name="onboarding_network_action">Myönnä rajoittamaton käyttöoikeus</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -541,8 +541,6 @@ Cordialement,\n\n]]></string>
     <string name="onboarding_battery_sure">Sans désactiver l\'optimisation de la batterie, TrackerControl peut être couper par Android à tout moment. Êtes-vous sûr de vouloir continuer ?</string>
     <string name="onboarding_notify_title">Restez informé</string>
     <string name="onboarding_notify_action">Autoriser les notifications</string>
-    <string name="onboarding_privatedns_title">Désactiver le DNS privé</string>
-    <string name="onboarding_privatedns_action">Ouvrir les paramètres DNS</string>
     <string name="onboarding_lockdown_title">Paramètres de verrouillage VPN</string>
     <string name="onboarding_lockdown_action">Ouvrir les paramètres VPN</string>
     <string name="onboarding_dns_title">DNS sécurisé (fonctionnalité béta ; peut ne pas fonctionner comme prévu)</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -409,12 +409,6 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <string name="onboarding_notify_desc">Permite notificações para ver atualizações em tempo real e controlar a proteção diretamente na barra de status.</string>
     <string name="onboarding_notify_action">Permitir notificações</string>
     <string name="onboarding_notify_sure">Sem permissões de notificação, você não poderá ver atualizações ou proteção de controle em tempo real na barra de status. Tem certeza?</string>
-    <string name="onboarding_privatedns_title">Desabilitar DNS privado</string>
-    <string name="onboarding_privatedns_desc">O recurso \"DNS privado\" do Android interfere com a capacidade do TrackerControl de bloquear rastreadores. Esta configuração <b>deve ser definida como</b> desativada para continuar.</string>
-    <string name="onboarding_privatedns_instruction">Configurações -&gt; Rede &amp; Internet -&gt; DNS privado -&gt; Desligado.</string>
-    <string name="onboarding_privatedns_action">Abrir configurações de DNS</string>
-    <string name="onboarding_privatedns_skip_title">Ignorar o DNS privado desativado?</string>
-    <string name="onboarding_privatedns_skip_msg">Prosseguir com DNS privado habilitado irá restringir fortemente o TrackerControl. A maioria do rastreamento não será bloqueada, deixando apenas a análise da biblioteca de rastreamento. Além disso, o filtro da VPN será desativado para garantir as funcionalidades básicas.</string>
     <string name="onboarding_network_title">Rede irrestrita</string>
     <string name="onboarding_network_desc">A Economia de dados pode impedir que o TrackerControl funcione corretamente em segundo plano. Conceda acesso irrestrito para uma proteção mais confiável.</string>
     <string name="onboarding_network_action">Conceder acesso irrestrito</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -434,12 +434,6 @@
     <string name="onboarding_notify_desc">Разрешить уведомления, чтобы видеть обновления в режиме реального времени и управлять защитой непосредственно из строки состояния.</string>
     <string name="onboarding_notify_action">Разрешить уведомления</string>
     <string name="onboarding_notify_sure">Без разрешения на показ уведомлений вы не сможете видеть обновления или управлять защитой из строки состояния. Вы уверены?</string>
-    <string name="onboarding_privatedns_title">Отключить приватный DNS</string>
-    <string name="onboarding_privatedns_desc">Android-функция \"Private DNS\" препятствует возможности TrackerControl блокировать трекеры. Эта настройка <b>должна быть</b>  \"Выключено\" для продолжения.</string>
-    <string name="onboarding_privatedns_instruction">Настройки -&gt; Сеть &amp; Интернет -&gt; Частный DNS -&gt; Выключить.</string>
-    <string name="onboarding_privatedns_action">Открыть настройки DNS</string>
-    <string name="onboarding_privatedns_skip_title">Пропустить отключение приватного DNS?</string>
-    <string name="onboarding_privatedns_skip_msg">Включение приватного DNS сильно ограничит TrackerControl. Большинство треков не будет блокироваться, оставляя только анализ библиотеки трекеров. Кроме того, фильтр VPN будет отключен для обеспечения базовой функциональности.</string>
     <string name="onboarding_network_title">Не ограничивать сеть</string>
     <string name="onboarding_network_desc">Data Saving может предотвратить корректную работу TrackerControl в фоновом режиме. Предоставьте неограниченный доступ для наиболее надежной защиты.</string>
     <string name="onboarding_network_action">Предоставить неограниченный доступ</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -554,12 +554,6 @@ Vaš internetni promet se ne pošilja na oddaljeni strežnik VPN.</string>
     <string name="onboarding_notify_desc">Dovoli obvestila, da si ogledate posodobitve v resničnem času in nadzirate zaščito neposredno iz vrstice stanja.</string>
     <string name="onboarding_notify_action">Dovoli obvestila</string>
     <string name="onboarding_notify_sure">Brez dovoljenj za obvestila si ne boste mogli ogledati posodobitev v resničnem času ali nadzirati zaščite iz vrstice stanja.  Ali ste prepričani?</string>
-    <string name="onboarding_privatedns_title">Onemogoči zasebni DNS</string>
-    <string name="onboarding_privatedns_desc">Androidova značilnost \"Zasebni DNS\" moti zmožnost blokiranja sledilcev programa TrackerControl.  Če želite nadaljevati,  <b>morate</b> to nastavitev izklopiti.</string>
-    <string name="onboarding_privatedns_instruction">Nastavitve –&gt; Omrežje in internet –&gt; Zasebni DNS –&gt; Izklopi.</string>
-    <string name="onboarding_privatedns_action">Odpri nastavitve DNS</string>
-    <string name="onboarding_privatedns_skip_title">Preskoči onemogočanje zasebnega DNS-a?</string>
-    <string name="onboarding_privatedns_skip_msg">Če nadaljujete z omogočenim zasebnim DNS-om, bo to znatno omejilo TrackerControl.  Večina sledenja ne bo blokirana – program bo zmožen samo preučevanja sledilnih knjižnic.  Poleg tega bo filter VPN onemogočen, da se zagotovi osnovno delovanje.</string>
     <string name="onboarding_timeline_title">Oglejte si, kako se časovnica napolni</string>
     <string name="onboarding_timeline_desc">TrackerControl se zažene po časovnici.  Na začetku je lahko prazna — programi običajno stopijo v stik s sledilci šele med njihovo uporabo.\n\nKo končate z nastavitvijo odprite nekaj programov in se vrnite v TrackerControl, da si ogledate zaznano in blokirano sledilno dejavnost.</string>
     <string name="onboarding_network_title">Neomejeno omrežje</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -585,12 +585,6 @@
     <string name="onboarding_notify_desc">Дозвольте сповіщення, щоб бачити оновлення в режимі реального часу та керувати захистом безпосередньо зі смуги стану.</string>
     <string name="onboarding_notify_action">Дозволити сповіщення</string>
     <string name="onboarding_notify_sure">Без дозволу на отримання сповіщень ви не зможете бачити оновлення в режимі реального часу та керувати захистом із панелі стану. Ви впевнені?</string>
-    <string name="onboarding_privatedns_title">Вимкнути приватний DNS</string>
-    <string name="onboarding_privatedns_desc">Функція «Приватний DNS» в Android заважає TrackerControl блокувати трекери. Щоб продовжити, це налаштування <b>необхідно</b> встановити в положення «Вимкнено».</string>
-    <string name="onboarding_privatedns_instruction">Налаштування -&gt; Мережа &amp; інтернет -&gt; Приватний DNS -&gt; Вимкнено.</string>
-    <string name="onboarding_privatedns_action">Відкрити налаштування DNS</string>
-    <string name="onboarding_privatedns_skip_title">Пропустити вимкнення приватного DNS?</string>
-    <string name="onboarding_privatedns_skip_msg">Продовження роботи з увімкненим приватним DNS значно обмежить роботу TrackerControl. Більшість відстежень не буде заблоковано, залишиться лише аналіз бібліотеки трекерів. Крім того, фільтр VPN буде вимкнено, щоб забезпечити базову функціональність.</string>
     <string name="onboarding_timeline_title">Спостерігайте за заповненням часової шкали</string>
     <string name="onboarding_timeline_desc">TrackerControl запускається на часовій шкалі. Спочатку вона може бути порожньою: зазвичай програми зв’язуються з трекерами лише під час їхнього використання.\n\nПісля завершення налаштування відкрийте кілька програм, а потім поверніться до TrackerControl, щоб переглянути виявлену та заблоковану активність трекерів.</string>
     <string name="onboarding_network_title">Необмежена мережа</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -580,12 +580,6 @@
     <string name="onboarding_notify_desc">允许通知以直接从状态栏查看实时更新并控制保护。</string>
     <string name="onboarding_notify_action">允许通知</string>
     <string name="onboarding_notify_sure">没有通知权限，您将无法从状态栏查看实时更新或控制保护。您确定吗？</string>
-    <string name="onboarding_privatedns_title">禁用私人DNS</string>
-    <string name="onboarding_privatedns_desc">Android 的 Private DNS 功能会妨碍 TrackerControl 拦截跟踪器的能力。要继续此设置 <b>必须</b>设为“关闭”。</string>
-    <string name="onboarding_privatedns_instruction">设置 -&gt; 网络 &amp; 互联网 -&gt; Private DNS -&gt; 关闭。</string>
-    <string name="onboarding_privatedns_action">打开 DNS 设置</string>
-    <string name="onboarding_privatedns_skip_title">跳过私人DNS禁用？</string>
-    <string name="onboarding_privatedns_skip_msg">在开启 Private DNS 情况下继续会极大限制 TrackControl 的运行。多数跟踪不会被拦截，只剩下跟踪库分析。另外， VPN 过滤器会被禁用来确保基础功能。</string>
     <string name="onboarding_timeline_title">观看时间轴填充</string>
     <string name="onboarding_timeline_desc">通过 TrackerControl 时间轴观察跟踪器活动 。时间轴一开始可能是空的：应用程序通常只在您使用时才与跟踪服务器联系。\n\n完成设置后，打开几个应用程序，然后返回到TrackerControl查看检测到和被阻止的跟踪活动。</string>
     <string name="onboarding_network_title">不受限制的网络</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -698,6 +698,7 @@ Sincerely,\n\n]]></string>
     <string name="msg_local_network_notify">TrackerControl cannot reach your own DNS server, Secure DNS resolver, WireGuard peer or proxy, so name resolution may fail. Android 17 requires permission for this, which Android asks about as \"nearby devices\". Tap to open TrackerControl and allow it.</string>
     <string name="msg_private_dns_title">Private DNS blocks name resolution</string>
     <string name="msg_private_dns_notify">Android\'s \"Private DNS\" is set to %1$s, and TrackerControl blocks encrypted DNS so it can detect trackers. Android does not fall back to normal DNS in this mode, so nothing will load. Tap to set Private DNS to \"Automatic\" or \"Off\" — TrackerControl offers its own Secure DNS in Settings.</string>
+    <string name="msg_private_dns_unknown_resolver">a custom resolver</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -696,6 +696,8 @@ Sincerely,\n\n]]></string>
     <string name="msg_local_network">Tap to allow local network access, which Android asks about as \"nearby devices\". Android 17 blocks it by default, so your own DNS server, Secure DNS resolver, WireGuard peer or proxy cannot be reached.</string>
     <string name="msg_local_network_title">Local network access needed</string>
     <string name="msg_local_network_notify">TrackerControl cannot reach your own DNS server, Secure DNS resolver, WireGuard peer or proxy, so name resolution may fail. Android 17 requires permission for this, which Android asks about as \"nearby devices\". Tap to open TrackerControl and allow it.</string>
+    <string name="msg_private_dns_title">Private DNS blocks name resolution</string>
+    <string name="msg_private_dns_notify">Android\'s \"Private DNS\" is set to %1$s, and TrackerControl blocks encrypted DNS so it can detect trackers. Android does not fall back to normal DNS in this mode, so nothing will load. Tap to set Private DNS to \"Automatic\" or \"Off\" — TrackerControl offers its own Secure DNS in Settings.</string>
 
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>
@@ -727,12 +729,6 @@ Sincerely,\n\n]]></string>
     <string name="onboarding_notify_action">Allow Notifications</string>
     <string name="onboarding_notify_sure">Without notification permissions, you will not be able to see real-time updates or control protection from the status bar. Are you sure?</string>
     
-    <string name="onboarding_privatedns_title">Disable Private DNS</string>
-    <string name="onboarding_privatedns_desc">Android\'s \"Private DNS\" feature interferes with TrackerControl\'s ability to block trackers. This setting <b>must</b> be set to \"Off\" to proceed.</string>
-    <string name="onboarding_privatedns_instruction">Settings -> Network &amp; internet -> Private DNS -> Off.</string>
-    <string name="onboarding_privatedns_action">Open DNS Settings</string>
-    <string name="onboarding_privatedns_skip_title">Skip Private DNS Disabling?</string>
-    <string name="onboarding_privatedns_skip_msg">Proceeding with Private DNS enabled will heavily restrict TrackerControl. Most tracking will not be blocked, leaving only the tracker library analysis. Additionally, the VPN filter will be disabled to ensure basic functionality.</string>
 
     <string name="onboarding_timeline_title">Watch the Timeline Fill Up</string>
     <string name="onboarding_timeline_desc">TrackerControl starts on the Timeline. At first it can be empty: apps usually contact trackers only while you use them.\n\nAfter finishing setup, open a few apps, then return to TrackerControl to see detected and blocked tracking activity.</string>


### PR DESCRIPTION
Blocking DoT on port 853 is on by default, so Private DNS on "automatic" now resolves itself: Android falls back to plaintext and tracker detection carries on. The onboarding slide asks the user to go turn a setting off that no longer costs them anything, in the middle of the one flow where attention is scarcest. It goes.

"Hostname" mode is the case that still breaks, and it breaks harder than the slide ever conveyed: Android does not fall back to plaintext for a resolver the user pinned by name, so DNS simply fails and nothing loads. Onboarding is also the wrong place to say so — it fires once, before the user has any traffic to lose, and says nothing to whoever turns Private DNS on next week. So notify from `getBuilder()`, where the tunnel is built, and the reason arrives when the failure does. The text names the configured resolver, and tapping opens the network settings that hold the switch. It re-evaluates on every VPN rebuild, so it clears itself as soon as the setting changes, and it is gated on `block_dot` — research mode, which turns that off, never sees it.

### Notification lifetimes

Clear the Private DNS and local network notifications on VPN stop, but not on a temporary one. Re-posting a cancelled notification alerts again (`setOnlyAlertOnce` only suppresses re-alerts while a notification is still active), and both describe configuration that has not changed, so cancelling on every incoming call would buzz the user each time the VPN returns.

The WireGuard error notification wants the opposite treatment, once it can retract itself. `stopInternal()` never cleared `lastError`, and the state listener checks `lastError` before `isRunning()` — deliberately, so a start that fails without ever producing a tunnel still reports — so a stopped tunnel went on reporting its final error, and the listener's `isRunning` branch could never run. Clearing it there lets the listener retract the notification as the tunnel goes down, which is more accurate than holding a tunnel error over a tunnel that no longer exists. The call in `stop()` stays for the one case the listener cannot see: a failed start with no tunnel to tear down, where `WgEgress.stop()` finds nothing to notify about.

Reordering the listener's two checks would have been the smaller diff and is wrong — a failed `startTunnel()` sets `lastError` while `tunnel` is still null, so checking `isRunning()` first would silently swallow genuine start failures.

### Also

`Util.isPrivateDns()` had no callers left once the slide went, so it is removed. The notification uses `getPrivateDnsSpecifier()`, which is non-null only in the mode that actually breaks.

### Testing

`compileGithubDebugJavaWithJavac`, `lintGithubDebug`, `testGithubDebugUnitTest`, and `cargo test` in `wgbridge-rs` all pass. Not yet exercised on a device — the notification paths in particular are unverified against a real "hostname"-mode resolver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)