### PR TITLE
Notice a pinned Private DNS when it happens, and warn in the app too

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -467,6 +467,21 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             }
         });
 
+        // Private DNS pinned to a hostname while we block DoT: name resolution
+        // fails outright, so the user may never see the notification that says
+        // so — nothing they tap can load anything either.
+        TextView tvPrivateDns = findViewById(R.id.tvPrivateDns);
+        tvPrivateDns.setVisibility(View.GONE);
+        tvPrivateDns.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent settings = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
+                if (settings.resolveActivity(getPackageManager()) == null)
+                    settings = new Intent(Settings.ACTION_WIFI_SETTINGS);
+                startActivity(settings);
+            }
+        });
+
         // Application list
         RecyclerView rvApplication = findViewById(R.id.rvApplication);
         rvApplication.setHasFixedSize(false);
@@ -566,6 +581,16 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         if (tvLocalNetwork != null)
             tvLocalNetwork.setVisibility(
                     LocalNetworkAccess.isMissing(this) ? View.VISIBLE : View.GONE);
+
+        // Only while we are actually filtering: with the VPN off, port 853 is
+        // not blocked and a pinned resolver works fine.
+        TextView tvPrivateDns = findViewById(R.id.tvPrivateDns);
+        if (tvPrivateDns != null) {
+            boolean vpnEnabled = PreferenceManager.getDefaultSharedPreferences(this)
+                    .getBoolean("enabled", false);
+            tvPrivateDns.setVisibility(
+                    vpnEnabled && Util.isPrivateDnsBlocked(this) ? View.VISIBLE : View.GONE);
+        }
 
         super.onResume();
     }

--- a/app/src/main/java/eu/faircode/netguard/NetworkReloadPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/NetworkReloadPolicy.java
@@ -70,6 +70,15 @@ final class NetworkReloadPolicy {
                 REASON_CONNECTIVITY_CHANGED.equals(reason);
     }
 
+    /**
+     * The same decision across a coalesced burst of callbacks, which keeps only
+     * the last reason. The need for a rebind is sticky: once any reason in the
+     * burst required one, a later reason that does not must not cancel it.
+     */
+    static boolean shouldRestartWireGuard(boolean pendingRestart, String reason) {
+        return pendingRestart || shouldRestartWireGuard(reason);
+    }
+
     static boolean same(List<?> last, List<?> current) {
         if (last == null || current == null || last.size() != current.size())
             return false;

--- a/app/src/main/java/eu/faircode/netguard/NetworkReloadPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/NetworkReloadPolicy.java
@@ -9,6 +9,7 @@ final class NetworkReloadPolicy {
     static final String REASON_NETWORK_CHANGED = "Network changed";
     static final String REASON_CONNECTED_CHANGED = "Connected state changed";
     static final String REASON_LINK_PROPERTIES_CHANGED = "link properties changed";
+    static final String REASON_PRIVATE_DNS_CHANGED = "private DNS changed";
     static final String REASON_METERED_CHANGED = "Metered state changed";
     static final String REASON_CONNECTIVITY_CHANGED = "connectivity changed";
 
@@ -30,9 +31,16 @@ final class NetworkReloadPolicy {
     }
 
     static String onLinkPropertiesChanged(List<?> lastDns, List<?> currentDns,
-                                          boolean compareDns, boolean reloadOnConnectivity) {
+                                          boolean compareDns, boolean reloadOnConnectivity,
+                                          String lastPrivateDns, String currentPrivateDns) {
         if (compareDns ? !same(lastDns, currentDns) : reloadOnConnectivity)
             return REASON_LINK_PROPERTIES_CHANGED;
+
+        // Pinning Private DNS to a hostname leaves the resolver list alone, so
+        // the comparison above never sees it — yet it decides whether blocking
+        // DoT stops name resolution outright, which the user has to be told.
+        if (!Objects.equals(lastPrivateDns, currentPrivateDns))
+            return REASON_PRIVATE_DNS_CHANGED;
 
         return null;
     }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1693,7 +1693,7 @@ public class ServiceSinkhole extends VpnService {
         // In "hostname" mode it does not fall back — the user picked that
         // resolver explicitly, so DNS simply fails and nothing resolves. That
         // looks like TC broke the connection, with no hint of why, so say it.
-        if (prefs.getBoolean("block_dot", true) && Util.isPrivateDnsHostnameMode(this)) {
+        if (Util.isPrivateDnsBlocked(this)) {
             Log.w(TAG, "Private DNS set to a hostname: DoT is blocked and Android will not" +
                     " fall back to plaintext DNS, so name resolution fails");
             showPrivateDnsNotification(Util.getPrivateDnsSpecifier(this));
@@ -3146,6 +3146,7 @@ public class ServiceSinkhole extends VpnService {
             private Boolean last_connected = null;
             private Boolean last_metered = null;
             private List<InetAddress> last_dns = null;
+            private String last_private_dns = null;
 
             @Override
             public void onAvailable(Network network) {
@@ -3168,17 +3169,26 @@ public class ServiceSinkhole extends VpnService {
 
                 // Make sure the right DNS servers are being used
                 List<InetAddress> dns = linkProperties.getDnsServers();
+                // Non-null only when Private DNS is pinned to a hostname, which
+                // leaves the resolver list untouched — so this is the only part
+                // of the properties that reveals the change.
+                String private_dns = (Build.VERSION.SDK_INT < Build.VERSION_CODES.P
+                        ? null : linkProperties.getPrivateDnsServerName());
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
                 String reason = NetworkReloadPolicy.onLinkPropertiesChanged(
                         last_dns,
                         dns,
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.O,
-                        prefs.getBoolean("reload_onconnectivity", false));
+                        prefs.getBoolean("reload_onconnectivity", false),
+                        last_private_dns,
+                        private_dns);
                 if (reason != null) {
                     Log.i(TAG, "Changed link properties=" + linkProperties +
                             "DNS cur=" + TextUtils.join(",", dns) +
-                            "DNS prv=" + (last_dns == null ? null : TextUtils.join(",", last_dns)));
+                            "DNS prv=" + (last_dns == null ? null : TextUtils.join(",", last_dns)) +
+                            " private DNS cur=" + private_dns + " prv=" + last_private_dns);
                     last_dns = dns;
+                    last_private_dns = private_dns;
                     reloadAfterNetworkChange(reason);
                 }
             }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -119,6 +119,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.zip.GZIPInputStream;
 
@@ -3238,19 +3239,24 @@ public class ServiceSinkhole extends VpnService {
     // ConnectivityManager callbacks within milliseconds of each other. Each
     // reload is a foreground-service update + wakelock + native VPN restart +
     // WireGuard rebind, so bursts are coalesced into a single reload using the
-    // last reason once the burst settles. Every reason string currently in use
-    // maps to the same shouldRestartWireGuard()==true branch, so collapsing to
-    // the latest reason changes no behaviour beyond the log line.
+    // last reason once the burst settles. Not every reason needs the rebind, so
+    // the need for one is accumulated across the burst rather than read off the
+    // surviving reason: a reason that does not need it must not cancel one that
+    // did, or the tunnel keeps a socket bound to a network that is gone.
     private static final long NETWORK_RELOAD_DEBOUNCE_MS = 1500L;
     private static final Object NETWORK_RELOAD_TOKEN = new Object();
     private final Handler networkReloadDebounceHandler = new Handler(Looper.getMainLooper());
+    private final AtomicBoolean pendingWireGuardRestart = new AtomicBoolean(false);
 
     private void reloadAfterNetworkChange(final String reason) {
+        // Callbacks arrive off the main thread; the reload runs on it.
+        if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
+            pendingWireGuardRestart.set(true);
         networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
         networkReloadDebounceHandler.postAtTime(new Runnable() {
             @Override
             public void run() {
-                if (NetworkReloadPolicy.shouldRestartWireGuard(reason))
+                if (pendingWireGuardRestart.getAndSet(false))
                     net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.onUnderlyingNetworkChanged();
                 reload(reason, ServiceSinkhole.this, false);
             }

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -57,6 +57,7 @@ import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.app.ActivityCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.net.ConnectivityManagerCompat;
+import androidx.preference.PreferenceManager;
 
 import net.kollnig.missioncontrol.BuildConfig;
 import net.kollnig.missioncontrol.R;
@@ -570,6 +571,18 @@ public class Util {
         if (!isPrivateDnsHostnameMode(context))
             return null;
         return Settings.Global.getString(context.getContentResolver(), "private_dns_specifier");
+    }
+
+    /**
+     * Whether the device is left with no working resolver: Private DNS pinned
+     * to a hostname while we block DoT. Deliberately keyed on the mode rather
+     * than on the resolver name, which is only decoration for the warning —
+     * a name that reads back empty must not turn the warning off.
+     */
+    public static boolean isPrivateDnsBlocked(Context context) {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean("block_dot", true)
+                && isPrivateDnsHostnameMode(context);
     }
 
     public interface DoubtListener {

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -64,6 +64,26 @@
         android:textColor="?attr/colorOff"
         android:visibility="gone" />
 
+    <!--
+        Same reasoning as the row above, and the one place this reaches a user
+        who declined notification permissions: with Private DNS pinned nothing
+        resolves at all, so the notification alone may never be seen.
+    -->
+    <TextView
+        android:id="@+id/tvPrivateDns"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_warning_amber"
+        android:drawablePadding="8dp"
+        android:drawableTint="?attr/colorError"
+        android:padding="8dp"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/msg_private_dns"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="?attr/colorOff"
+        android:visibility="gone" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/test/java/eu/faircode/netguard/NetworkReloadPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/NetworkReloadPolicyTest.java
@@ -1,6 +1,7 @@
 package eu.faircode.netguard;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -76,7 +77,8 @@ public class NetworkReloadPolicyTest {
                         Collections.singletonList("9.9.9.9"),
                         Collections.singletonList("1.1.1.1"),
                         true,
-                        false));
+                        false,
+                        null, null));
     }
 
     @Test
@@ -85,7 +87,8 @@ public class NetworkReloadPolicyTest {
                 Arrays.asList("9.9.9.9", "149.112.112.112"),
                 Arrays.asList("9.9.9.9", "149.112.112.112"),
                 true,
-                false));
+                false,
+                null, null));
     }
 
     @Test
@@ -95,13 +98,61 @@ public class NetworkReloadPolicyTest {
                         Collections.singletonList("9.9.9.9"),
                         Collections.singletonList("9.9.9.9"),
                         false,
-                        true));
+                        true,
+                        null, null));
 
         assertNull(NetworkReloadPolicy.onLinkPropertiesChanged(
                 Collections.singletonList("9.9.9.9"),
                 Collections.singletonList("1.1.1.1"),
                 false,
-                false));
+                false,
+                null, null));
+    }
+
+    /**
+     * Pinning Private DNS to a hostname leaves the resolver list untouched, so
+     * comparing DNS servers alone never notices it and the warning that DoT is
+     * blocked would not appear until some unrelated network change.
+     */
+    @Test
+    public void privateDnsPinnedReloads() {
+        assertEquals("private DNS changed",
+                NetworkReloadPolicy.onLinkPropertiesChanged(
+                        Collections.singletonList("9.9.9.9"),
+                        Collections.singletonList("9.9.9.9"),
+                        true,
+                        false,
+                        null, "dns.google"));
+    }
+
+    @Test
+    public void privateDnsClearedReloads() {
+        assertEquals("private DNS changed",
+                NetworkReloadPolicy.onLinkPropertiesChanged(
+                        Collections.singletonList("9.9.9.9"),
+                        Collections.singletonList("9.9.9.9"),
+                        true,
+                        false,
+                        "dns.google", null));
+    }
+
+    @Test
+    public void samePrivateDnsDoesNotReload() {
+        assertNull(NetworkReloadPolicy.onLinkPropertiesChanged(
+                Collections.singletonList("9.9.9.9"),
+                Collections.singletonList("9.9.9.9"),
+                true,
+                false,
+                "dns.google", "dns.google"));
+    }
+
+    /**
+     * The tunnel is unaffected by a resolver being pinned, so this reload must
+     * not cost a WireGuard rebind and re-handshake.
+     */
+    @Test
+    public void privateDnsChangeDoesNotRestartWireGuard() {
+        assertFalse(NetworkReloadPolicy.shouldRestartWireGuard("private DNS changed"));
     }
 
     @Test

--- a/app/src/test/java/eu/faircode/netguard/NetworkReloadPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/NetworkReloadPolicyTest.java
@@ -155,6 +155,25 @@ public class NetworkReloadPolicyTest {
         assertFalse(NetworkReloadPolicy.shouldRestartWireGuard("private DNS changed"));
     }
 
+    /**
+     * A burst of callbacks is collapsed to its last reason, but the rebind it
+     * needs is not a property of that reason alone: a private DNS change
+     * landing right after a genuine network change must not cancel the rebind
+     * that change required, or the tunnel keeps a socket bound to a gone
+     * network until some later event.
+     */
+    @Test
+    public void privateDnsChangeDoesNotCancelAPendingRestart() {
+        boolean pending = NetworkReloadPolicy.shouldRestartWireGuard(false, "Network changed");
+        assertTrue(pending);
+        assertTrue(NetworkReloadPolicy.shouldRestartWireGuard(pending, "private DNS changed"));
+    }
+
+    @Test
+    public void privateDnsChangeAloneStillDoesNotRestartWireGuard() {
+        assertFalse(NetworkReloadPolicy.shouldRestartWireGuard(false, "private DNS changed"));
+    }
+
     @Test
     public void physicalConnectivityReloadsRestartWireGuard() {
         assertTrue(NetworkReloadPolicy.shouldRestartWireGuard("network available"));

--- a/app/src/test/java/eu/faircode/netguard/PrivateDnsBlockedTest.java
+++ b/app/src/test/java/eu/faircode/netguard/PrivateDnsBlockedTest.java
@@ -1,0 +1,110 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.provider.Settings;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/**
+ * Which Private DNS configurations leave the device with no working resolver.
+ *
+ * <p>Only "hostname" mode does: Android falls back to plaintext DNS when a
+ * resolver it picked itself cannot be reached over DoT, but not when the user
+ * named one explicitly, so blocking port 853 stops resolution outright.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class PrivateDnsBlockedTest {
+    private Context context;
+    private SharedPreferences prefs;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.edit().clear().commit();
+        setPrivateDns("off", null);
+    }
+
+    private void setPrivateDns(String mode, String specifier) {
+        Settings.Global.putString(context.getContentResolver(), "private_dns_mode", mode);
+        Settings.Global.putString(context.getContentResolver(), "private_dns_specifier", specifier);
+    }
+
+    @Test
+    public void pinnedResolverWithDotBlockingBreaksResolution() {
+        setPrivateDns("hostname", "dns.google");
+        assertTrue(Util.isPrivateDnsBlocked(context));
+    }
+
+    @Test
+    public void automaticModeDoesNotBreakResolution() {
+        // Android falls back to plaintext on its own, which is the whole reason
+        // the onboarding slide could go.
+        setPrivateDns("opportunistic", null);
+        assertFalse(Util.isPrivateDnsBlocked(context));
+    }
+
+    @Test
+    public void privateDnsOffDoesNotBreakResolution() {
+        setPrivateDns("off", null);
+        assertFalse(Util.isPrivateDnsBlocked(context));
+    }
+
+    @Test
+    public void researchModeLeavesPinnedResolversAlone() {
+        // Research mode turns DoT blocking off, so a pinned resolver still works.
+        setPrivateDns("hostname", "dns.google");
+        prefs.edit().putBoolean("block_dot", false).commit();
+        assertFalse(Util.isPrivateDnsBlocked(context));
+    }
+
+    /**
+     * The decision must not hinge on reading the specifier: if that read comes
+     * back empty while the mode says "hostname", resolution is still broken and
+     * staying silent would leave the user with no explanation at all.
+     */
+    @Test
+    public void pinnedResolverWithoutReadableNameStillBreaksResolution() {
+        setPrivateDns("hostname", null);
+        assertTrue(Util.isPrivateDnsBlocked(context));
+        assertNull(Util.getPrivateDnsSpecifier(context));
+    }
+
+    @Test
+    public void specifierIsOnlyReportedForPinnedResolvers() {
+        setPrivateDns("hostname", "dns.google");
+        assertEquals("dns.google", Util.getPrivateDnsSpecifier(context));
+
+        setPrivateDns("opportunistic", "dns.google");
+        assertNull(Util.getPrivateDnsSpecifier(context));
+    }
+}


### PR DESCRIPTION
Follow-up to #711, which landed the Private DNS warning. Two gaps that review turned up after it merged; both are about the warning reaching the user, not about what it says.

### The warning only re-evaluated when the tunnel was built

`getBuilder()` is the only thing that posts or clears it, so the sequence I would expect to be the common one — VPN already running, user goes into Android settings and pins a resolver — broke name resolution and then said nothing until some unrelated network change happened to rebuild the tunnel. Device-checked on a Pixel 8 (Android 17): after changing the mode, no reload for at least 20s, and the notification appeared only once a Wi-Fi cycle forced one.

No observer is needed for this. `onLinkPropertiesChanged` already fires, and `LinkProperties` already carries the resolver name — unredacted for ordinary apps, which the app's own log confirms:

| `private_dns_mode` | app-visible `LinkProperties` |
|---|---|
| `hostname` | `UsePrivateDns: true PrivateDnsServerName: dns.google` |
| `off` / `opportunistic` | *(fields absent)* |

`NetworkReloadPolicy.onLinkPropertiesChanged` simply discarded it, comparing `getDnsServers()` alone — which a pinned resolver leaves untouched. It now compares the name too. The new reason is deliberately **not** in `shouldRestartWireGuard`: the tunnel is unaffected, only the warning is stale, so this must not cost a rebind and re-handshake. There is a test pinning that.

### The notification was the only surface, and it can be silently unavailable

`Util.notify()` no-ops without `POST_NOTIFICATIONS`. Onboarding asks, but a user can decline — and a user who declines is exactly the one who skipped through onboarding, which is who the removed slide was for. In that combination there was no warning anywhere, in the one state where nothing loads at all.

So: a row on the main screen, next to the local-network one from #709 and re-evaluated in the same `onResume`, tapping through to the network settings. That also covers merely reopening the app, which reloads nothing. It is gated on the VPN actually running, since port 853 is only blocked while it is — with the VPN off a pinned resolver works fine and a warning would be wrong.

It reuses `msg_private_dns`, which lost its last caller when the onboarding slide went, so this adds no new string and the existing translations apply.

### Also

The condition both surfaces share is now `Util.isPrivateDnsBlocked()` rather than duplicated at each call site, covered by `PrivateDnsBlockedTest`: hostname vs automatic vs off, research mode (`block_dot` off), and that a specifier which reads back empty must not silence the warning — failing silent in the broken state is the one outcome worth designing against.

### Testing

`testGithubDebugUnitTest` and `lintGithubDebug` pass. Both behaviours are unit-tested; neither has been exercised on a device in this form — the row in particular has not been seen rendered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
