### PR TITLE
Split agent guidance into a shared agents/ directory and add a Gradle quiet hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/agents/hooks/gradle-quiet.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .env
 /output/
 
-.claude/
+.claude/*
+!.claude/settings.json
+.claude/settings.local.json
 /fdroidserver/
 /fdroiddata/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,21 +1,14 @@
 # AGENTS.md
 
 This is the shared, tool-agnostic guide for anyone — human or AI agent — working
-in this repository. It is the single source of truth for how to navigate, build,
-and reason about TrackerControl, plus the rationale used when triaging issues.
-
-Two documents sit next to this one and stay authoritative for their own scope:
-
-- **[wgbridge-rs/README.md](wgbridge-rs/README.md)** — the Rust WireGuard bridge:
-  architecture, the JNI API surface, and how to build/test the crate. Read it
-  before touching anything under `wgbridge-rs/` or `net.kollnig.missioncontrol.wg*`.
-- **[docs/RELEASING.md](docs/RELEASING.md)** — cutting a release: version bump,
-  Fastlane changelog, the tag-triggered unsigned build, local signing, and the
-  smoke-test checklist the signed APK must pass before the draft is published.
+in this repository. Keep it short: everything here is loaded into *every*
+session, so anything situational belongs in `agents/docs/` instead (see the table
+below). `CLAUDE.md` is a one-line pointer at this file; Codex and other tools
+read it directly.
 
 ---
 
-## 1. What TrackerControl is
+## What TrackerControl is
 
 An Android app that monitors and blocks hidden tracking in other apps. It runs a
 local `VpnService` (no root, no external server by default) and detects trackers
@@ -25,221 +18,28 @@ VPN egress** (WireGuard, via Mullvad/IVPN/self-hosted). It is a fork of NetGuard
 the firewall/VPN core still lives in the `eu.faircode.netguard` package.
 
 The design bias is **simplicity and rigour over configurability**, and
-**privacy-preserving by construction** (no SSL/TLS interception). These two
-sentences decide most feature requests — see §5.
+**privacy-preserving by construction** (no SSL/TLS interception). Those two
+sentences decide most feature requests.
 
 ---
 
-## 2. Repository layout — how to navigate
+## Read these when the situation applies
 
-```
-app/                         Android app module
-  src/main/java/
-    eu/faircode/netguard/    NetGuard fork: VPN service, firewall, DB, UI shell
-    net/kollnig/missioncontrol/   TrackerControl additions (detection + UI)
-  src/main/jni/netguard/     Native C packet engine (built via CMake)
-  src/main/assets/           Blocklists (Disconnect, X-Ray, DDG), hosts.txt, GeoLite2
-  src/main/res/              Layouts, strings (values-*/ are Crowdin translations)
-  src/{github,fdroid,play}/  Per-flavour overrides (differ mainly in update-check)
-  build.gradle               App build + the wgbridgeBuild (Rust) task
-  CMakeLists.txt             Native C library build
-wgbridge-rs/                 Rust crate embedding gotatun (Mullvad WireGuard)
-```
+These files are not in context. Read the whole file before doing the work it
+covers — don't rely on what you remember of it.
 
-**Where things live (the files you'll actually open):**
-
-- **VPN / firewall core** — `eu.faircode.netguard`:
-  - `ServiceSinkhole.java` — the `VpnService`. Packet loop wiring, DNS handling,
-    `getDns()`, per-connection block dispatch, lifecycle (`onStartCommand`,
-    `onRevoke`), MTU/routes, native start/stop. **This is the load-bearing file;
-    most connectivity/battery/lifecycle issues trace here.**
-  - `DatabaseHelper.java` — the `dns`, `access`, and `log` tables. Note the DNS
-    history is **UID-global** (`getQAName` ignores `uid`) — see §4 and §5.
-  - `ActivityMain.java`, `ActivitySettings.java`, `ActivityLog.java`,
-    `ActivityDns.java` — main UI, settings, raw traffic log, DNS log.
-  - `WidgetAdmin.java` — pause/resume alarms (`INTENT_ON`). `ServiceTileMain.java`
-    — Quick-Settings tile. `ReceiverAutostart.java` — boot/always-on restart.
-  - `VpnRoutes.java` — the tun route set (RFC1918/CGNAT excludes).
-  - Policy helpers: `InteractiveStatePolicy`, `NativeFailureRecoveryPolicy`,
-    `NetworkReloadPolicy`, `VpnReplacementSequencer`.
-- **Tracker detection + TC UI** — `net.kollnig.missioncontrol`:
-  - `data/TrackerList.java` — loads the blocklists into the static
-    `hostnameToTracker` map; the heart of detection. Blocking-mode list selection
-    lives here (`loadTrackers`). Watch memory.
-  - `data/InsightsData*.java`, `InsightsActivity.kt` — the insights/summary UI.
-  - `analysis/` — static tracker-library detection in app code (dexlib2 signatures).
-  - `details/`, `DetailsActivity.java`, `TrackersListAdapter` — per-app tracker
-    list + the ALLOWED/BLOCKED toggles.
-  - `dns/DnsOverHttpsClient.java`, `dns/DnsProxyServer.java` — Secure DNS (DoH).
-  - `wg/` (Kotlin) — WireGuard config/egress: `WgConfig.kt` (wg-quick → UAPI),
-    `WgEgress.kt` (lifecycle, hostname re-resolution), `WgConnectivityMonitor.kt`
-    (the 1 s stats poll — battery-relevant).
-  - `wgbridge/` — hand-written JNI bindings to the Rust crate: `Wgbridge`,
-    `Tunnel`, `Protector`, `Logger`, `DnsRecorder`. Mirror of `wgbridge-rs`.
-- **Native C packet engine** — `app/src/main/jni/netguard/`: `netguard.c`,
-  `session.c`, `ip.c`, `tcp.c`, `udp.c`, `icmp.c`, `dns.c` (plaintext DNS parse),
-  `tls.c` (SNI, research-only), `dhcp.c`, `pcap.c`. Built by `CMakeLists.txt`.
-- **Rust WireGuard bridge** — `wgbridge-rs/` (see its README): `jni_bindings.rs`,
-  `tunnel.rs`, `config.rs` (UAPI), `dns.rs` (passive DNS inspection), `transport/`
-  (socketpair + tun-fd transports), `keys.rs`, `callbacks.rs`.
-
-**End-to-end data flow.** App packets → `VpnService` tun → native C engine parses
-DNS and applies IP-based, per-app blocking → traffic either sinks, exits directly,
-or is handed to egress (global SOCKS5, or WireGuard via `wgbridge-rs`/gotatun). DNS
-answers (from C, or from the Rust side when WireGuard is up) feed `TrackerList`'s
-IP→hostname mapping, which drives future block decisions recorded in `DatabaseHelper`.
-
-**Blocking modes (central to many issues).** *Minimal* loads only the DDG list
-(low battery, default for many after onboarding); *Standard* loads Disconnect +
-X-Ray + DDG and **allows** ambiguous shared-IP hosts; *Strict* **blocks** those
-ambiguous shared-IP hosts. Shared-IP ambiguity + UID-global DNS evidence is the
-root of a whole cluster of reports (see §4).
+| Read | When |
+|---|---|
+| `agents/docs/codebase-map.md` | finding your way around: which file owns a behaviour, how a packet flows from tun to egress, what the blocking modes change |
+| `agents/docs/build-and-test.md` | anything beyond the commands below — prerequisites, flavours, the native C/Rust builds, the reproducibility flags |
+| `agents/docs/device-testing.md` | **before any `adb` command** — flavour choice, seeding away the permission prompts, editing preferences safely |
+| `agents/docs/triage.md` | reviewing, triaging or closing an issue — the verdict vocabulary and the two reusable close messages |
+| `wgbridge-rs/README.md` | touching `wgbridge-rs/` or `net.kollnig.missioncontrol.wg*` — architecture, the JNI API surface, building/testing the crate |
+| `docs/RELEASING.md` | cutting a release — version bump, Fastlane changelog, tag-triggered unsigned build, local signing, smoke-test checklist |
 
 ---
 
-## 3. Building, testing, linting
-
-Prerequisites: JDK 17, Android SDK (compile/target SDK 37, min SDK 23), NDK
-`27.2.12479018`, CMake. For the WireGuard bridge you also need Rust ≥ 1.95 with the
-four Android targets and `cargo-ndk` — but the Gradle build wires that in for you
-(it even installs `cargo-ndk` if missing). See `wgbridge-rs/README.md` for the
-exact `rustup target add …` list and F-Droid build metadata.
-
-Three product flavours — **github**, **fdroid**, **play** — differ only in the
-update-check API; **github** is the normal local dev flavour. Debug builds install
-side-by-side (`applicationIdSuffix ".test"`).
-
-**Connected-device testing:** build and install the **fdroid debug** variant,
-which installs as `net.kollnig.missioncontrol.fdroid.test`.
-
-```bash
-./gradlew assembleFdroidDebug
-adb install -r app/build/outputs/apk/fdroid/debug/TrackerControl-fdroidDebug-latest.apk
-```
-
-Not github debug: that installs as `net.kollnig.missioncontrol.test`, which is
-also what a maintainer's own day-to-day dev build installs as. Testing against it
-overwrites their real preferences, and enabling its VPN takes the consent slot
-from whatever they were running. The flavours differ only in the update-check
-API, so nothing is lost by using fdroid for device work. (Working on the
-update-check itself is the exception — that needs github, and needs asking
-first.)
-
-**Never destroy state without asking.** `adb uninstall`, `pm clear`, overwriting
-a preferences file, revoking a permission — every one of these is irreversible
-and the device usually belongs to someone who has real configuration on it. Ask
-first, naming the package and what will be lost, and wait for a yes. This applies
-even when the target looks like a throwaway you installed yourself: it is one
-mistaken package name away from wiping the real install. Update in place with
-`adb install -r`, which preserves app data, preferences, VPN consent, and test
-state, and for cleanup reset only the specific state your test touched.
-
-One more side effect worth announcing before you trigger it: enabling the VPN
-calls `VpnService.prepare()`, which **revokes whatever VPN app currently holds
-consent** — the maintainer's own build, or their real VPN. It will need
-re-enabling afterwards.
-
-### Driving the app without permission popups
-
-Onboarding, the VPN consent dialog and the runtime permission prompts can all be
-pre-satisfied from adb, so an agent never has to tap through them.
-
-```bash
-PKG=net.kollnig.missioncontrol.fdroid.test
-
-# 1. Runtime permissions. -g grants everything the manifest declares, so revoke
-#    whichever one you are actually testing (checkSelfPermission would lie).
-adb install -r -g app/build/outputs/apk/fdroid/debug/TrackerControl-fdroidDebug-latest.apk
-adb shell pm revoke $PKG android.permission.ACCESS_LOCAL_NETWORK
-
-# 2. VPN consent. Makes VpnService.prepare() return null, which skips BOTH the
-#    system ConfirmDialog and TrackerControl's own explainer before it.
-adb shell appops set $PKG ACTIVATE_VPN allow
-
-# 3. Onboarding. ActivityMain checks onboarding_version against
-#    ActivityOnboarding.ONBOARDING_VERSION; seeding it lands you on the main
-#    screen. This works before the first launch — run-as can create the file.
-cat > /tmp/seed.xml <<'XML'
-<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
-<map>
-    <int name="onboarding_version" value="2" />
-</map>
-XML
-adb push /tmp/seed.xml /data/local/tmp/seed.xml
-adb shell "run-as $PKG sh -c 'mkdir -p shared_prefs && cat /data/local/tmp/seed.xml > shared_prefs/${PKG}_preferences.xml'"
-
-adb shell monkey -p $PKG -c android.intent.category.LAUNCHER 1
-```
-
-(Push through `/data/local/tmp` rather than piping a heredoc into `adb shell` —
-quoting survives the round trip intact.)
-
-The VPN switch is at roughly `input tap 108 216` on a 1080×2400 screen; from
-there the tunnel comes up with no dialogs at all. Verify with
-`adb shell dumpsys connectivity | grep -o "VPN:net.kollnig[a-z.]*"`.
-
-Preferences, once seeded:
-
-- **Force-stop before editing.** A running process holds prefs in memory and
-  will overwrite your file on exit: `adb shell am force-stop $PKG` first.
-- **Merge, never replace.** Rewriting the whole file drops `onboarding_version`
-  and drops you back into onboarding. Append inside `</map>` with `sed`, or read
-  the file, edit, and write it back whole.
-- **`adb uninstall` and `pm clear` wipe all of the above** — the seeded prefs,
-  the appop, and the granted permissions — which is a second reason not to reach
-  for them, on top of needing to ask first.
-
-To check a notification, read it with
-`adb shell dumpsys notification --noredact | grep -A6 '<your title>'` rather than
-screenshotting the shade, which captures the user's private notifications.
-
-None of the above applies unchanged to a **signed release APK**: it installs as
-`net.kollnig.missioncontrol` and is not debuggable, so `run-as` is refused and
-onboarding cannot be seeded away — only `appops` and `pm grant` still work. The
-release smoke-test procedure lives in
-[docs/RELEASING.md](docs/RELEASING.md#smoke-test-the-signed-apk).
-
-```bash
-# From the repo root. Use ./gradlew (the wrapper).
-
-# Full debug APK (also triggers the native C + Rust builds):
-./gradlew assembleGithubDebug
-
-# Fast compile check while iterating on Java (what most PRs verify against):
-./gradlew :app:compileGithubDebugJavaWithJavac -q
-
-# JVM unit tests (Robolectric); swap the flavour as needed:
-./gradlew :app:testGithubDebugUnitTest
-# One test class/method:
-./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.SomeTest'
-./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.SomeTest.someMethod'
-
-# Android lint (MissingTranslation / ExtraTranslation are disabled on purpose):
-./gradlew :app:lintGithubDebug
-```
-
-**Native code builds automatically** with the app:
-
-- The **C engine** builds via CMake through AGP's `externalNativeBuild`.
-- The **Rust WireGuard bridge** builds via the `wgbridgeBuild` Gradle task, which
-  runs `cargo ndk` for all four ABIs and is a `dependsOn` of `preBuild`. It only
-  re-runs when `wgbridge-rs/src/**`, `Cargo.toml`, or `Cargo.lock` change.
-  If Gradle can't find `cargo` (Android Studio sanitizes `PATH`), pass
-  `-PcargoBin=/path/to/cargo` or put `~/.cargo/bin` on `PATH`.
-
-**Rust host tests** (config/DNS/key parsing — no device needed):
-
-```bash
-cd wgbridge-rs && cargo test
-```
-
-Reproducibility is deliberately protected (path remapping, stripped `.comment`/
-build-id, 16 KB page alignment) in both `build.gradle` and `CMakeLists.txt` — don't
-undo those flags casually; IzzyOnDroid green-list depends on them.
-
----
-
-## 4. Design philosophy & standing constraints
+## Design philosophy & standing constraints
 
 The non-negotiables that decide most changes:
 
@@ -268,44 +68,45 @@ GitHub issue tracker — search there rather than re-deriving.
 
 ---
 
-## 5. Reviewing & triaging issues
+## Build & test commands
 
-The §4 constraints decide most triage. Trace any bug into the actual code before
-assigning a verdict — line numbers drift, and reports that look identical often have
-distinct root causes. Verdicts:
+```bash
+# Fast compile check while iterating on Java (what most PRs verify against):
+./gradlew :app:compileGithubDebugJavaWithJavac -q
 
-- **Fixable-aligned** — a real defect whose fix helps the default (minimal-mode) user or
-  recovers breakage, and fits the philosophy. Safe to implement.
-- **Fixable-with-tension** — implementable, but needs a product/design decision first.
-- **Unfixable-by-construction** — the request collides with a §4 constraint (always-on
-  VPN's idle cost; plaintext-DNS-only detection, which strict Private DNS/DoT defeats;
-  UID-global attribution; no SSL interception). Respond to the reporter; do **not** add a
-  knob to paper over it.
-- **External-platform/OEM** — root cause is Android/OEM/work-profile; not fixable in-app.
-- **Decline-philosophy** — a general-firewall or expert-knob request (§4 constraint 1),
-  which is NetGuard's role. The per-app "Exclude from VPN" toggle + Minimal-mode
-  auto-excludes already cover breakage-recovery.
+# JVM unit tests (Robolectric); swap the flavour as needed:
+./gradlew :app:testGithubDebugUnitTest
+./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.SomeTest'
 
-Two close messages get reused enough to keep on hand:
+# Android lint (MissingTranslation / ExtraTranslation are disabled on purpose):
+./gradlew :app:lintGithubDebug
 
-**A — configurability proliferation / firewall feature (use NetGuard):**
-> Thanks for the suggestion. TrackerControl is deliberately a focused tracker blocker, not
-> a general-purpose firewall — its design prioritises simplicity and sensible defaults over
-> fine-grained per-app/per-network configuration, and we explicitly avoid "Rethink-style"
-> expert knobs unless they directly help users recover from breakage. The firewall-style
-> control you're describing is exactly what NetGuard — the project TrackerControl is forked
-> from — already provides, and keeping that role there is what lets TrackerControl stay lean
-> and battery-friendly. If your goal is to stop a specific app breaking, the per-app "Exclude
-> from VPN" toggle (in that app's tracker details) bypasses TrackerControl entirely for it.
-> Closing as out of scope, but thank you for the thoughtful request.
+# Full debug APK (also triggers the native C + Rust builds):
+./gradlew assembleGithubDebug
 
-**B — requires SSL interception (privacy-by-construction):**
-> Thanks for the request. By design, TrackerControl never performs SSL/TLS interception — it
-> only ever logs connection metadata, and this "privacy-preserving by construction" property
-> is non-negotiable (it's also what lets the app run without root and stay trustworthy). What
-> you're describing would require decrypting HTTPS via a local man-in-the-middle, which we
-> will not add. Tracker detection therefore relies on DNS interception rather than payload
-> inspection; even TLS/SNI parsing is confined to an opt-in research mode, because acting on
-> it would leak your IP to the tracker before we could block. Closing as won't-fix-by-
-> construction — this isn't a limitation we can lift without breaking the app's core privacy
-> guarantee.
+# Rust host tests (config/DNS/key parsing — no device needed):
+cd wgbridge-rs && cargo test
+```
+
+Gradle at default log level floods an agent's context. `agents/hooks/gradle-quiet.sh`
+adds `-q` to `./gradlew` invocations that don't already carry a log-level flag:
+Claude Code applies it automatically as a `PreToolUse` hook (wired in
+`.claude/settings.json`), and any other tool can pipe a command through
+`agents/hooks/gradle-quiet.sh --rewrite '<command>'` — or just pass `-q` itself.
+`-q` hides `BUILD SUCCESSFUL`, so judge success by the exit code, and re-run
+without `-q` when you genuinely need the verbose output.
+
+---
+
+## Device work
+
+Full procedure — including how to skip every permission prompt — is in
+`agents/docs/device-testing.md`. Two rules that must not be discovered late:
+
+- **Never destroy state without asking.** `adb uninstall`, `pm clear`,
+  overwriting a preferences file, revoking a permission: all irreversible, on a
+  device that usually holds someone's real configuration. Ask first, naming the
+  package and what will be lost. Update in place with `adb install -r`.
+- **Announce the VPN side effect.** Enabling the VPN calls
+  `VpnService.prepare()`, which revokes whatever VPN app currently holds consent
+  — the maintainer's own build, or their real VPN.

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,0 +1,37 @@
+# `agents/` — shared agent configuration
+
+Everything an AI coding agent needs that isn't tied to one vendor lives here, so
+Claude Code, Codex and anything else read the same material.
+
+```
+AGENTS.md                 always loaded; entry point for every tool
+CLAUDE.md                 one line: @AGENTS.md (Claude Code's entry point)
+agents/docs/*.md          NOT loaded — read only when AGENTS.md's table says to
+agents/hooks/*.sh         tool-neutral scripts, invoked by whatever hook system exists
+.claude/settings.json     Claude-specific wiring only; no guidance content
+```
+
+## The rules that keep this useful
+
+1. **AGENTS.md stays short.** It is loaded in full, every session, by every tool.
+   If a piece of guidance only matters in one situation, it belongs in
+   `agents/docs/` with a row in AGENTS.md's "read these when the situation
+   applies" table.
+2. **Every doc is reachable.** Nothing loads `agents/docs/` on its own — a doc
+   that no always-loaded file points at will simply never be read. Adding a doc
+   means adding its row to the table.
+3. **No dangling pointers.** A mistyped path silently removes guidance instead of
+   failing loudly. Check paths when you move files.
+4. **Don't restate volatile facts.** Tool versions, SDK levels and library
+   versions belong in the build files; point at them rather than copying them, or
+   they go stale and mislead.
+5. **Vendor directories hold wiring, not content.** `.claude/` may contain
+   settings and pointers; the guidance and scripts it points at live here.
+
+## Hooks
+
+`hooks/gradle-quiet.sh` forces `./gradlew` runs to quiet logging so build output
+stays readable. It works two ways — as a Claude Code `PreToolUse(Bash)` hook, or
+as a plain filter (`--rewrite '<command>'`) for tools without a hook system.
+Prefer that shape for anything added here: a script that works standalone, with
+the vendor-specific glue kept thin.

--- a/agents/docs/build-and-test.md
+++ b/agents/docs/build-and-test.md
@@ -1,0 +1,61 @@
+# Building, testing, linting
+
+The everyday commands are in AGENTS.md. This file covers the prerequisites, the
+flavour matrix, the native builds, and the reproducibility flags.
+
+## Prerequisites
+
+JDK 17, Android SDK (compile/target SDK 37, min SDK 23), NDK `27.2.12479018`,
+CMake. For the WireGuard bridge you also need Rust ≥ 1.95 with the four Android
+targets and `cargo-ndk` — but the Gradle build wires that in for you (it even
+installs `cargo-ndk` if missing). See `wgbridge-rs/README.md` for the exact
+`rustup target add …` list and F-Droid build metadata.
+
+## Flavours
+
+Three product flavours — **github**, **fdroid**, **play** — differ only in the
+update-check API; **github** is the normal local dev flavour. Debug builds
+install side-by-side (`applicationIdSuffix ".test"`). For anything on a real
+device, build **fdroid debug** instead — see `agents/docs/device-testing.md`.
+
+## Commands
+
+```bash
+# From the repo root. Use ./gradlew (the wrapper).
+
+# Full debug APK (also triggers the native C + Rust builds):
+./gradlew assembleGithubDebug
+
+# Fast compile check while iterating on Java (what most PRs verify against):
+./gradlew :app:compileGithubDebugJavaWithJavac -q
+
+# JVM unit tests (Robolectric); swap the flavour as needed:
+./gradlew :app:testGithubDebugUnitTest
+# One test class/method:
+./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.SomeTest'
+./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.SomeTest.someMethod'
+
+# Android lint (MissingTranslation / ExtraTranslation are disabled on purpose):
+./gradlew :app:lintGithubDebug
+```
+
+**Rust host tests** (config/DNS/key parsing — no device needed):
+
+```bash
+cd wgbridge-rs && cargo test
+```
+
+## Native code builds automatically with the app
+
+- The **C engine** builds via CMake through AGP's `externalNativeBuild`.
+- The **Rust WireGuard bridge** builds via the `wgbridgeBuild` Gradle task, which
+  runs `cargo ndk` for all four ABIs and is a `dependsOn` of `preBuild`. It only
+  re-runs when `wgbridge-rs/src/**`, `Cargo.toml`, or `Cargo.lock` change.
+  If Gradle can't find `cargo` (Android Studio sanitizes `PATH`), pass
+  `-PcargoBin=/path/to/cargo` or put `~/.cargo/bin` on `PATH`.
+
+## Reproducibility
+
+Reproducibility is deliberately protected (path remapping, stripped `.comment`/
+build-id, 16 KB page alignment) in both `build.gradle` and `CMakeLists.txt` —
+don't undo those flags casually; IzzyOnDroid green-list depends on them.

--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -1,0 +1,71 @@
+# Codebase map
+
+How to navigate TrackerControl: where things live, how a packet flows, and what
+the blocking modes actually change.
+
+```
+app/                         Android app module
+  src/main/java/
+    eu/faircode/netguard/    NetGuard fork: VPN service, firewall, DB, UI shell
+    net/kollnig/missioncontrol/   TrackerControl additions (detection + UI)
+  src/main/jni/netguard/     Native C packet engine (built via CMake)
+  src/main/assets/           Blocklists (Disconnect, X-Ray, DDG), hosts.txt, GeoLite2
+  src/main/res/              Layouts, strings (values-*/ are Crowdin translations)
+  src/{github,fdroid,play}/  Per-flavour overrides (differ mainly in update-check)
+  build.gradle               App build + the wgbridgeBuild (Rust) task
+  CMakeLists.txt             Native C library build
+wgbridge-rs/                 Rust crate embedding gotatun (Mullvad WireGuard)
+```
+
+## Where things live (the files you'll actually open)
+
+- **VPN / firewall core** — `eu.faircode.netguard`:
+  - `ServiceSinkhole.java` — the `VpnService`. Packet loop wiring, DNS handling,
+    `getDns()`, per-connection block dispatch, lifecycle (`onStartCommand`,
+    `onRevoke`), MTU/routes, native start/stop. **This is the load-bearing file;
+    most connectivity/battery/lifecycle issues trace here.**
+  - `DatabaseHelper.java` — the `dns`, `access`, and `log` tables. Note the DNS
+    history is **UID-global** (`getQAName` ignores `uid`) — see the standing
+    constraints in AGENTS.md.
+  - `ActivityMain.java`, `ActivitySettings.java`, `ActivityLog.java`,
+    `ActivityDns.java` — main UI, settings, raw traffic log, DNS log.
+  - `WidgetAdmin.java` — pause/resume alarms (`INTENT_ON`). `ServiceTileMain.java`
+    — Quick-Settings tile. `ReceiverAutostart.java` — boot/always-on restart.
+  - `VpnRoutes.java` — the tun route set (RFC1918/CGNAT excludes).
+  - Policy helpers: `InteractiveStatePolicy`, `NativeFailureRecoveryPolicy`,
+    `NetworkReloadPolicy`, `VpnReplacementSequencer`.
+- **Tracker detection + TC UI** — `net.kollnig.missioncontrol`:
+  - `data/TrackerList.java` — loads the blocklists into the static
+    `hostnameToTracker` map; the heart of detection. Blocking-mode list selection
+    lives here (`loadTrackers`). Watch memory.
+  - `data/InsightsData*.java`, `InsightsActivity.kt` — the insights/summary UI.
+  - `analysis/` — static tracker-library detection in app code (dexlib2 signatures).
+  - `details/`, `DetailsActivity.java`, `TrackersListAdapter` — per-app tracker
+    list + the ALLOWED/BLOCKED toggles.
+  - `dns/DnsOverHttpsClient.java`, `dns/DnsProxyServer.java` — Secure DNS (DoH).
+  - `wg/` (Kotlin) — WireGuard config/egress: `WgConfig.kt` (wg-quick → UAPI),
+    `WgEgress.kt` (lifecycle, hostname re-resolution), `WgConnectivityMonitor.kt`
+    (the 1 s stats poll — battery-relevant).
+  - `wgbridge/` — hand-written JNI bindings to the Rust crate: `Wgbridge`,
+    `Tunnel`, `Protector`, `Logger`, `DnsRecorder`. Mirror of `wgbridge-rs`.
+- **Native C packet engine** — `app/src/main/jni/netguard/`: `netguard.c`,
+  `session.c`, `ip.c`, `tcp.c`, `udp.c`, `icmp.c`, `dns.c` (plaintext DNS parse),
+  `tls.c` (SNI, research-only), `dhcp.c`, `pcap.c`. Built by `CMakeLists.txt`.
+- **Rust WireGuard bridge** — `wgbridge-rs/` (see its README): `jni_bindings.rs`,
+  `tunnel.rs`, `config.rs` (UAPI), `dns.rs` (passive DNS inspection), `transport/`
+  (socketpair + tun-fd transports), `keys.rs`, `callbacks.rs`.
+
+## End-to-end data flow
+
+App packets → `VpnService` tun → native C engine parses DNS and applies IP-based,
+per-app blocking → traffic either sinks, exits directly, or is handed to egress
+(global SOCKS5, or WireGuard via `wgbridge-rs`/gotatun). DNS answers (from C, or
+from the Rust side when WireGuard is up) feed `TrackerList`'s IP→hostname mapping,
+which drives future block decisions recorded in `DatabaseHelper`.
+
+## Blocking modes (central to many issues)
+
+*Minimal* loads only the DDG list (low battery, default for many after
+onboarding); *Standard* loads Disconnect + X-Ray + DDG and **allows** ambiguous
+shared-IP hosts; *Strict* **blocks** those ambiguous shared-IP hosts. Shared-IP
+ambiguity + UID-global DNS evidence is the root of a whole cluster of reports.

--- a/agents/docs/device-testing.md
+++ b/agents/docs/device-testing.md
@@ -1,0 +1,101 @@
+# Connected-device testing
+
+Read this before any `adb` work. The two rules in AGENTS.md — never destroy
+state without asking, and announce the VPN-consent side effect — are restated
+here in full because they are the ones that cost a maintainer real data.
+
+## Use the fdroid debug variant
+
+Build and install **fdroid debug**, which installs as
+`net.kollnig.missioncontrol.fdroid.test`.
+
+```bash
+./gradlew assembleFdroidDebug
+adb install -r app/build/outputs/apk/fdroid/debug/TrackerControl-fdroidDebug-latest.apk
+```
+
+Not github debug: that installs as `net.kollnig.missioncontrol.test`, which is
+also what a maintainer's own day-to-day dev build installs as. Testing against it
+overwrites their real preferences, and enabling its VPN takes the consent slot
+from whatever they were running. The flavours differ only in the update-check
+API, so nothing is lost by using fdroid for device work. (Working on the
+update-check itself is the exception — that needs github, and needs asking
+first.)
+
+## Never destroy state without asking
+
+`adb uninstall`, `pm clear`, overwriting a preferences file, revoking a
+permission — every one of these is irreversible and the device usually belongs to
+someone who has real configuration on it. Ask first, naming the package and what
+will be lost, and wait for a yes. This applies even when the target looks like a
+throwaway you installed yourself: it is one mistaken package name away from
+wiping the real install. Update in place with `adb install -r`, which preserves
+app data, preferences, VPN consent, and test state, and for cleanup reset only
+the specific state your test touched.
+
+One more side effect worth announcing before you trigger it: enabling the VPN
+calls `VpnService.prepare()`, which **revokes whatever VPN app currently holds
+consent** — the maintainer's own build, or their real VPN. It will need
+re-enabling afterwards.
+
+## Driving the app without permission popups
+
+Onboarding, the VPN consent dialog and the runtime permission prompts can all be
+pre-satisfied from adb, so an agent never has to tap through them.
+
+```bash
+PKG=net.kollnig.missioncontrol.fdroid.test
+
+# 1. Runtime permissions. -g grants everything the manifest declares, so revoke
+#    whichever one you are actually testing (checkSelfPermission would lie).
+adb install -r -g app/build/outputs/apk/fdroid/debug/TrackerControl-fdroidDebug-latest.apk
+adb shell pm revoke $PKG android.permission.ACCESS_LOCAL_NETWORK
+
+# 2. VPN consent. Makes VpnService.prepare() return null, which skips BOTH the
+#    system ConfirmDialog and TrackerControl's own explainer before it.
+adb shell appops set $PKG ACTIVATE_VPN allow
+
+# 3. Onboarding. ActivityMain checks onboarding_version against
+#    ActivityOnboarding.ONBOARDING_VERSION; seeding it lands you on the main
+#    screen. This works before the first launch — run-as can create the file.
+cat > /tmp/seed.xml <<'XML'
+<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
+<map>
+    <int name="onboarding_version" value="2" />
+</map>
+XML
+adb push /tmp/seed.xml /data/local/tmp/seed.xml
+adb shell "run-as $PKG sh -c 'mkdir -p shared_prefs && cat /data/local/tmp/seed.xml > shared_prefs/${PKG}_preferences.xml'"
+
+adb shell monkey -p $PKG -c android.intent.category.LAUNCHER 1
+```
+
+(Push through `/data/local/tmp` rather than piping a heredoc into `adb shell` —
+quoting survives the round trip intact.)
+
+The VPN switch is at roughly `input tap 108 216` on a 1080×2400 screen; from
+there the tunnel comes up with no dialogs at all. Verify with
+`adb shell dumpsys connectivity | grep -o "VPN:net.kollnig[a-z.]*"`.
+
+## Preferences, once seeded
+
+- **Force-stop before editing.** A running process holds prefs in memory and
+  will overwrite your file on exit: `adb shell am force-stop $PKG` first.
+- **Merge, never replace.** Rewriting the whole file drops `onboarding_version`
+  and drops you back into onboarding. Append inside `</map>` with `sed`, or read
+  the file, edit, and write it back whole.
+- **`adb uninstall` and `pm clear` wipe all of the above** — the seeded prefs,
+  the appop, and the granted permissions — which is a second reason not to reach
+  for them, on top of needing to ask first.
+
+To check a notification, read it with
+`adb shell dumpsys notification --noredact | grep -A6 '<your title>'` rather than
+screenshotting the shade, which captures the user's private notifications.
+
+## Signed release APKs are different
+
+None of the above applies unchanged to a **signed release APK**: it installs as
+`net.kollnig.missioncontrol` and is not debuggable, so `run-as` is refused and
+onboarding cannot be seeded away — only `appops` and `pm grant` still work. The
+release smoke-test procedure lives in
+[docs/RELEASING.md](../../docs/RELEASING.md#smoke-test-the-signed-apk).

--- a/agents/docs/triage.md
+++ b/agents/docs/triage.md
@@ -1,0 +1,43 @@
+# Reviewing & triaging issues
+
+The standing constraints in AGENTS.md decide most triage. Trace any bug into the
+actual code before assigning a verdict — line numbers drift, and reports that
+look identical often have distinct root causes.
+
+## Verdicts
+
+- **Fixable-aligned** — a real defect whose fix helps the default (minimal-mode) user or
+  recovers breakage, and fits the philosophy. Safe to implement.
+- **Fixable-with-tension** — implementable, but needs a product/design decision first.
+- **Unfixable-by-construction** — the request collides with a standing constraint (always-on
+  VPN's idle cost; plaintext-DNS-only detection, which strict Private DNS/DoT defeats;
+  UID-global attribution; no SSL interception). Respond to the reporter; do **not** add a
+  knob to paper over it.
+- **External-platform/OEM** — root cause is Android/OEM/work-profile; not fixable in-app.
+- **Decline-philosophy** — a general-firewall or expert-knob request (constraint 1),
+  which is NetGuard's role. The per-app "Exclude from VPN" toggle + Minimal-mode
+  auto-excludes already cover breakage-recovery.
+
+## Reusable close messages
+
+**A — configurability proliferation / firewall feature (use NetGuard):**
+> Thanks for the suggestion. TrackerControl is deliberately a focused tracker blocker, not
+> a general-purpose firewall — its design prioritises simplicity and sensible defaults over
+> fine-grained per-app/per-network configuration, and we explicitly avoid "Rethink-style"
+> expert knobs unless they directly help users recover from breakage. The firewall-style
+> control you're describing is exactly what NetGuard — the project TrackerControl is forked
+> from — already provides, and keeping that role there is what lets TrackerControl stay lean
+> and battery-friendly. If your goal is to stop a specific app breaking, the per-app "Exclude
+> from VPN" toggle (in that app's tracker details) bypasses TrackerControl entirely for it.
+> Closing as out of scope, but thank you for the thoughtful request.
+
+**B — requires SSL interception (privacy-by-construction):**
+> Thanks for the request. By design, TrackerControl never performs SSL/TLS interception — it
+> only ever logs connection metadata, and this "privacy-preserving by construction" property
+> is non-negotiable (it's also what lets the app run without root and stay trustworthy). What
+> you're describing would require decrypting HTTPS via a local man-in-the-middle, which we
+> will not add. Tracker detection therefore relies on DNS interception rather than payload
+> inspection; even TLS/SNI parsing is confined to an opt-in research mode, because acting on
+> it would leak your IP to the tracker before we could block. Closing as won't-fix-by-
+> construction — this isn't a limitation we can lift without breaking the app's core privacy
+> guarantee.

--- a/agents/hooks/gradle-quiet.sh
+++ b/agents/hooks/gradle-quiet.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Force ./gradlew runs to quiet logging, so build output stays small enough for
+# an agent to read without burning its context on Gradle's progress noise.
+# A log-level flag the caller chose explicitly always wins.
+#
+# Two ways to use it, so it is not tied to one agent tool:
+#
+#   1. As a Claude Code PreToolUse(Bash) hook — reads the tool-call JSON on
+#      stdin and emits the rewritten command as JSON. Wired up in
+#      .claude/settings.json.
+#
+#   2. As a plain filter for any other tool (Codex, scripts, a shell alias):
+#         agents/hooks/gradle-quiet.sh --rewrite './gradlew assembleGithubDebug'
+#      prints the rewritten command on stdout.
+#
+# No-ops silently if jq is missing (hook mode), leaving the command untouched.
+set -uo pipefail
+
+# Rewrite a command string: add -q to each ./gradlew segment unless the caller
+# already picked a log level. Echoes the (possibly unchanged) command.
+rewrite() {
+  local cmd="$1"
+
+  if [[ ! "$cmd" =~ (^|[[:space:]])\./gradlew($|[[:space:]]) ]]; then
+    printf '%s' "$cmd"
+    return 1
+  fi
+
+  local segments
+  segments=$(printf '%s' "$cmd" | grep -oE '\./gradlew[^&|;]*')
+  if printf '%s' "$segments" |
+    grep -qE '(^|[[:space:]])(-q|-w|-i|-d|--quiet|--warn|--info|--debug)($|[[:space:]])'; then
+    printf '%s' "$cmd"
+    return 1
+  fi
+
+  printf '%s' "$cmd" | sed -E 's#\./gradlew#./gradlew -q#g'
+  return 0
+}
+
+if [[ "${1:-}" == "--rewrite" ]]; then
+  rewrite "${2:-}"
+  echo
+  exit 0
+fi
+
+# Claude Code PreToolUse hook mode.
+input=$(cat)
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+
+if [[ -z "$cmd" ]]; then
+  echo '{}'
+  exit 0
+fi
+
+if ! new_cmd=$(rewrite "$cmd"); then
+  echo '{}'
+  exit 0
+fi
+
+encoded=$(printf '%s' "$new_cmd" | jq -Rs .)
+printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","updatedInput":{"command":%s}}}\n' "$encoded"


### PR DESCRIPTION
Adopts two patterns from the agent setups in `brave/brave-core` and `duckduckgo/Android`: a small always-loaded entry point with situational material pulled in on demand, and a hook that keeps Gradle output from flooding the context window.

## What changed

**`AGENTS.md`: 311 → 112 lines.** It is loaded in full by every tool in every session, so it now holds only what decides most work — what the app is, the four standing constraints, the core build/test commands, and the two device-safety rules that must not be discovered late. Everything situational moved behind a "read these when the situation applies" table:

| New file | Content moved out of AGENTS.md |
|---|---|
| `agents/docs/codebase-map.md` | repository layout, where things live, end-to-end data flow, blocking modes |
| `agents/docs/build-and-test.md` | prerequisites, flavours, full command list, native C/Rust builds, reproducibility flags |
| `agents/docs/device-testing.md` | fdroid-debug rationale, never-destroy-state rule, seeding away permission prompts, preferences handling, signed-APK caveats |
| `agents/docs/triage.md` | verdict vocabulary and the two reusable close messages |

No guidance was dropped — a sentence-level diff of the old file against the new set shows only rewording of the intro and of `§4`/`§5` cross-references (now named rather than numbered).

**`agents/` is vendor-neutral by design.** Claude Code enters via `CLAUDE.md` → `AGENTS.md`; Codex reads `AGENTS.md` directly; both follow the same table. `.claude/` holds wiring only, no guidance content. `agents/README.md` writes down the conventions that keep this working: AGENTS.md stays short, every doc is reachable from an always-loaded file, no dangling pointers, no restated tool versions, vendor dirs hold wiring not content.

**`agents/hooks/gradle-quiet.sh`.** Adds `-q` to `./gradlew` invocations that carry no explicit log-level flag (`-q/-w/-i/-d` and long forms always win). It works two ways so it isn't tied to one tool: as a Claude Code `PreToolUse(Bash)` hook, and as a plain filter (`--rewrite '<command>'`) for tools without a hook system. It no-ops silently when `jq` is missing.

**`.gitignore`.** `.claude/` was ignored wholesale, which would have kept the hook wiring local. Narrowed to `.claude/*` with `!.claude/settings.json`, keeping `settings.local.json` ignored.

## Testing

- Hook verified against nine cases: plain build (rewritten), a command already carrying `-q` (untouched), `--info` (untouched), non-Gradle commands (untouched), `&&`-chained Gradle calls (both segments rewritten), an env-var prefix (rewritten), `--rewrite` filter mode, and empty/garbage stdin.
- All relative pointers in `AGENTS.md` and the new docs resolve to existing files.
- Docs-only otherwise; no source, build or resource files touched.

## Note for review

`-q` suppresses `BUILD SUCCESSFUL`, so success has to be judged by exit code — `AGENTS.md` says so explicitly, along with how to opt back out for verbose runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TL2vW7nHBGUqkA55wCHRqj

---
_Generated by [Claude Code](https://claude.ai/code/session_01TL2vW7nHBGUqkA55wCHRqj)_