### PR TITLE
Replace the three per-app toggles with one protection state

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -58,6 +58,7 @@ import com.google.android.material.snackbar.Snackbar;
 import net.kollnig.missioncontrol.Common;
 import net.kollnig.missioncontrol.DetailsActivity;
 import net.kollnig.missioncontrol.R;
+import net.kollnig.missioncontrol.data.AppProtectionState;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
 
@@ -242,10 +243,16 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
         // Get rule
         final Rule rule = listFiltered.get(position);
-        // In minimal mode, tracker_protect is not user-controllable
-        final boolean active = BlockingMode.isMinimalMode(context)
-                ? rule.apply
-                : rule.apply && rule.tracker_protect;
+        final InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
+        final boolean blockedInternet = internetBlocklist.blockedInternet(rule.uid);
+        final AppProtectionState state = AppProtectionState.resolve(
+                rule.apply, rule.tracker_protect, blockedInternet);
+        // The Internet toggle below is available for every app TrackerControl
+        // still sees. Reading it off the shared state model keeps the main list
+        // and the details screen in agreement — in particular, an app with its
+        // tracker protection turned off can still have its Internet blocked,
+        // which the old apply && tracker_protect test denied outside Minimal.
+        final boolean active = state != AppProtectionState.BYPASSED;
 
         // Show if non default rules
         holder.itemView.setBackgroundColor(rule.changed ? colorChanged : Color.TRANSPARENT);
@@ -270,8 +277,6 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
         // Show if Internet access blocked
         final ImageView iv = holder.ivIcon;
-        InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
-        boolean blockedInternet = internetBlocklist.blockedInternet(rule.uid);
         setGreyscale(iv, rule.internet && active && blockedInternet);
         updateToggleContentDescription(iv, context, rule, active, blockedInternet);
         holder.ivIcon.setOnClickListener(view -> {
@@ -287,10 +292,10 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
 
             boolean wasBlocked = internetBlocklist.blockedInternet(rule.uid);
             if (wasBlocked) {
-                internetBlocklist.unblock(rule.uid);
+                internetBlocklist.unblock(context, rule.uid);
                 Toast.makeText(context, R.string.internet_unblocked, Toast.LENGTH_SHORT).show();
             } else {
-                internetBlocklist.block(rule.uid);
+                internetBlocklist.block(context, rule.uid);
                 Toast.makeText(context, R.string.internet_blocked, Toast.LENGTH_SHORT).show();
             }
             setGreyscale(iv, !wasBlocked);
@@ -376,7 +381,10 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         SharedPreferences notify = context.getSharedPreferences("notify", Context.MODE_PRIVATE);
 
         apply.edit().putBoolean(rule.packageName, rule.apply).apply();
-        BlockingMode.clearAutoExcludedApp(context, rule.packageName);
+        // Only a re-included app leaves the mode-managed exclusion set; clearing
+        // it on exclusion would make a Minimal-mode auto-exclusion permanent.
+        if (rule.apply)
+            BlockingMode.clearAutoExcludedApp(context, rule.packageName);
         tracker_protect.edit().putBoolean(rule.packageName, rule.tracker_protect).apply();
 
         if (rule.notify)

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2923,6 +2923,23 @@ public class ServiceSinkhole extends VpnService {
 
                 int uid = intent.getIntExtra(Intent.EXTRA_UID, 0);
                 if (uid > 0) {
+                    // The internet block is keyed by UID, not by package, so it
+                    // may still be in use by another package of a shared UID.
+                    // Drop it only once the UID has no package left, otherwise a
+                    // reinstall silently comes back with its Internet blocked.
+                    // A SecurityException (other user/profile on Android 16+)
+                    // means "unknown", which must not be read as "none left".
+                    try {
+                        String[] remaining = context.getPackageManager().getPackagesForUid(uid);
+                        if (remaining == null || remaining.length == 0) {
+                            InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
+                            if (internetBlocklist.blockedInternet(uid))
+                                internetBlocklist.unblock(context, uid);
+                        }
+                    } catch (SecurityException ex) {
+                        Log.w(TAG, "Keeping internet block uid=" + uid + ": " + ex.getMessage());
+                    }
+
                     DatabaseHelper dh = DatabaseHelper.getInstance(context);
                     dh.clearLog(uid);
                     dh.clearAccess(uid, false);

--- a/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionState.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionState.java
@@ -1,0 +1,101 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+/**
+ * The single per-app protection state shown in the app details header.
+ * <p>
+ * It is a derived view over three pre-existing stores — the per-package
+ * "apply" and "tracker_protect" preferences and the per-UID internet
+ * blocklist — none of which change format here. Those stores are written by
+ * more actors than the two UI paths (bulk settings actions, the beta
+ * vpn_exclude migration, blocking-mode exclusion sync, XML import), so every
+ * one of the eight combinations can legitimately exist on disk.
+ * {@link #resolve} is therefore a total derivation, not an invariant.
+ */
+public enum AppProtectionState {
+    /** Routed through the VPN, trackers blocked and recorded. */
+    PROTECTED,
+    /** Routed through the VPN, but trackers are neither blocked nor recorded. */
+    TRACKERS_ALLOWED,
+    /** Routed through the VPN, but all connections are dropped. */
+    NO_INTERNET,
+    /** Outside the VPN entirely; TrackerControl sees nothing of this app. */
+    BYPASSED;
+
+    /**
+     * Derive the state from the three stores.
+     * <p>
+     * Precedence is Bypass, then No-internet, then the protection flag. Bypass
+     * dominates for a mechanical reason rather than as a UI convention: an app
+     * with {@code apply == false} is handed to
+     * {@code Builder#addDisallowedApplication}, so its packets never reach the
+     * tun and the per-UID internet block cannot be enforced for it.
+     *
+     * @param apply           the per-package "apply" preference
+     * @param trackerProtect  the resolved tracker protection flag, i.e. the
+     *                        per-package preference with the browser default
+     *                        already applied (see
+     *                        {@link BlockingMode#isTrackerProtectionEnabled})
+     * @param internetBlocked whether the app's UID is in the internet blocklist
+     */
+    public static AppProtectionState resolve(boolean apply,
+            boolean trackerProtect,
+            boolean internetBlocked) {
+        if (!apply)
+            return BYPASSED;
+        if (internetBlocked)
+            return NO_INTERNET;
+        return trackerProtect ? PROTECTED : TRACKERS_ALLOWED;
+    }
+
+    /**
+     * The writes that move an app into {@code target}.
+     * <p>
+     * States that do not depend on a store leave it alone, so switching to
+     * "No internet" and back does not silently discard the app's tracker
+     * protection choice.
+     */
+    public static Change of(AppProtectionState target) {
+        switch (target) {
+            case PROTECTED:
+                return new Change(true, Boolean.TRUE, Boolean.FALSE);
+            case TRACKERS_ALLOWED:
+                return new Change(true, Boolean.FALSE, Boolean.FALSE);
+            case NO_INTERNET:
+                return new Change(true, null, Boolean.TRUE);
+            case BYPASSED:
+                return new Change(false, null, null);
+            default:
+                throw new IllegalArgumentException("Unknown state " + target);
+        }
+    }
+
+    /**
+     * A write plan over the three stores. A {@code null} field means the store
+     * is left untouched.
+     */
+    public static final class Change {
+        public final boolean apply;
+        public final Boolean trackerProtect;
+        public final Boolean internetBlocked;
+
+        Change(boolean apply, Boolean trackerProtect, Boolean internetBlocked) {
+            this.apply = apply;
+            this.trackerProtect = trackerProtect;
+            this.internetBlocked = internetBlocked;
+        }
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
@@ -88,6 +88,25 @@ public class InternetBlocklist {
     }
 
     /**
+     * Persist the current blocklist.
+     * <p>
+     * The list is otherwise only written when the details screen is paused, so
+     * a change made from the main screen — or made shortly before the process
+     * dies — would be lost. Both UI paths write through
+     * {@link #block(Context, int)} / {@link #unblock(Context, int)} instead.
+     *
+     * @param c Context
+     */
+    public synchronized void saveSettings(Context c) {
+        SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
+        Set<String> set = new HashSet<>();
+        for (Integer uid : blockmap)
+            set.add(Integer.toString(uid));
+
+        prefs.edit().putStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, set).apply();
+    }
+
+    /**
      * Block internet for a given app
      *
      * @param uid Uid of app to block internet
@@ -97,12 +116,53 @@ public class InternetBlocklist {
     }
 
     /**
+     * Block internet for a given app and persist the change immediately.
+     *
+     * @param c   Context
+     * @param uid Uid of app to block internet
+     */
+    public synchronized void block(Context c, int uid) {
+        block(uid);
+        saveSettings(c);
+    }
+
+    /**
      * Unblock internet for a given app
      *
      * @param uid Uid of app to unblock internet
      */
     public synchronized void unblock(int uid) {
         blockmap.remove(uid);
+    }
+
+    /**
+     * Unblock internet for a given app and persist the change immediately.
+     *
+     * @param c   Context
+     * @param uid Uid of app to unblock internet
+     */
+    public synchronized void unblock(Context c, int uid) {
+        unblock(uid);
+        saveSettings(c);
+    }
+
+    /**
+     * Apply a resolved protection state's internet decision, if it has one.
+     *
+     * @param c              Context
+     * @param uid            Uid of the app
+     * @param internetBlocked the {@code internetBlocked} field of an
+     *                       {@link AppProtectionState.Change}; {@code null}
+     *                       leaves the blocklist untouched
+     */
+    public void apply(Context c, int uid, Boolean internetBlocked) {
+        if (internetBlocked == null)
+            return;
+
+        if (internetBlocked)
+            block(c, uid);
+        else
+            unblock(c, uid);
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -460,7 +460,7 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             } else {
                 String explanation = mContext.getString(R.string.app_state_no_internet_explanation_shared,
                         mContext.getString(R.string.app_state_no_internet_explanation),
-                        relatedApps);
+                        mContext.getString(R.string.app_state_no_internet_shared_uid, relatedApps));
                 holder.mNoInternetExplanation.setText(explanation);
             }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -22,6 +22,7 @@ import static net.kollnig.missioncontrol.data.TrackerList.TRACKER_HOSTLIST;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.text.Spannable;
@@ -34,6 +35,7 @@ import android.view.ViewGroup;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.ProgressBar;
+import android.widget.RadioGroup;
 import com.google.android.material.materialswitch.MaterialSwitch;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -50,6 +52,7 @@ import net.kollnig.missioncontrol.Common;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.analysis.TrackerAnalysisManager;
 import net.kollnig.missioncontrol.analysis.TrackerAnalysisWorker;
+import net.kollnig.missioncontrol.data.AppProtectionState;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
 import net.kollnig.missioncontrol.data.Tracker;
@@ -390,9 +393,7 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 holder.mSwitchTracker.setOnCheckedChangeListener(null);
                 holder.mCompaniesList.setOnItemClickListener(null);
             } else {
-                boolean enabled = apply.getBoolean(mAppId, true)
-                        && !w.blockedInternet(mAppUid)
-                        && trackerProtectionEnabled;
+                boolean enabled = currentState(w) == AppProtectionState.PROTECTED;
                 holder.mSwitchTracker.setEnabled(enabled);
                 holder.mSwitchTracker.setChecked(
                         b.blocked(mAppUid, trackerCategoryName));
@@ -451,70 +452,124 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             holder.mLibraryExplanation.setText(R.string.trackers_static_explanation);
 
-            boolean isBrowser = BlockingMode.isBrowserApp(mContext, mAppId);
-            boolean showTrackerProtection = !BlockingMode.isMinimalMode(mContext) || isBrowser;
-            holder.mTrackerProtectionRow.setVisibility(showTrackerProtection ? View.VISIBLE : View.GONE);
-            holder.mTrackerProtectionDivider.setVisibility(showTrackerProtection ? View.VISIBLE : View.GONE);
-            holder.mSwitchVPN.setOnCheckedChangeListener(null);
-
-            // Tracker protection toggle. In minimal mode this is only shown for
-            // browsers, where tracker blocking defaults off but can be opted in.
-            if (showTrackerProtection) {
-                holder.mSwitchVPN.setVisibility(View.VISIBLE);
-                holder.mSwitchVPN.setEnabled(apply.getBoolean(mAppId, true)
-                        && !w.blockedInternet(mAppUid));
-                holder.mSwitchVPN.setChecked(BlockingMode.isTrackerProtectionEnabled(
-                        mContext, tracker_protect, mAppId));
-                holder.mSwitchVPN.setOnCheckedChangeListener((buttonView, isChecked) -> {
-                    if (!buttonView.isPressed())
-                        return; // to fix errors
-                    tracker_protect.edit().putBoolean(mAppId, isChecked).apply();
-
-                    // Move expensive operations off the main thread to prevent UI freezing
-                    // Rule.clearCache() can block waiting for a lock held by Rule.getRules()
-                    AsyncTask.execute(() -> {
-                        Rule.clearCache(mContext);
-                        ServiceSinkhole.reload("app blocking changed", mContext, false);
-                    });
-
-                    notifyDataSetChanged();
-                });
+            // The internet block is keyed by UID, so it necessarily covers every
+            // package sharing that UID. Say so rather than letting it surprise.
+            String relatedApps = getRelatedApps();
+            if (relatedApps == null) {
+                holder.mNoInternetExplanation.setText(R.string.app_state_no_internet_explanation);
             } else {
-                holder.mSwitchVPN.setVisibility(View.GONE);
+                String explanation = mContext.getString(R.string.app_state_no_internet_explanation_shared,
+                        mContext.getString(R.string.app_state_no_internet_explanation),
+                        relatedApps);
+                holder.mNoInternetExplanation.setText(explanation);
             }
 
-            // Blocking of Internet
-            holder.mSwitchInternet.setEnabled(apply.getBoolean(mAppId, true));
-            holder.mSwitchInternet.setChecked(
-                    !w.blockedInternet(mAppUid));
-            holder.mSwitchInternet.setOnCheckedChangeListener((buttonView, hasBecomeChecked) -> {
-                if (!buttonView.isPressed())
-                    return; // to fix errors
-
-                if (hasBecomeChecked)
-                    w.unblock(mAppUid);
-                else
-                    w.block(mAppUid);
-
-                notifyDataSetChanged();
-            });
-
-            // Exclude from VPN toggle (completely bypasses TrackerControl)
-            holder.mSwitchVpnExclude.setChecked(!apply.getBoolean(mAppId, true));
-            holder.mSwitchVpnExclude.setOnCheckedChangeListener((buttonView, isChecked) -> {
-                if (!buttonView.isPressed())
+            AppProtectionState state = currentState(w);
+            holder.mAppState.setOnCheckedChangeListener(null);
+            holder.mAppState.check(radioIdFor(state));
+            holder.mAppState.setOnCheckedChangeListener((group, checkedId) -> {
+                AppProtectionState selected = stateForRadioId(checkedId);
+                if (selected == null || selected == currentState(w))
                     return;
-                apply.edit().putBoolean(mAppId, !isChecked).apply();
-                BlockingMode.clearAutoExcludedApp(mContext, mAppId);
 
-                AsyncTask.execute(() -> {
-                    Rule.clearCache(mContext);
-                    ServiceSinkhole.reload("vpn exclude changed", mContext, false);
-                });
-
+                applyState(selected, w);
                 notifyDataSetChanged();
             });
         }
+    }
+
+    /**
+     * Comma-separated labels of the other packages sharing this app's UID, or
+     * {@code null} when the UID belongs to this package alone.
+     */
+    @Nullable
+    private String getRelatedApps() {
+        PackageManager pm = mContext.getPackageManager();
+        String[] packages = Util.getPackagesForUid(pm, mAppUid);
+        if (packages == null || packages.length < 2)
+            return null;
+
+        List<String> names = new ArrayList<>();
+        for (String packageName : packages) {
+            if (packageName.equals(mAppId))
+                continue;
+
+            try {
+                names.add(pm.getApplicationLabel(pm.getApplicationInfo(packageName, 0)).toString());
+            } catch (PackageManager.NameNotFoundException ignored) {
+                names.add(packageName);
+            }
+        }
+
+        return names.isEmpty() ? null : TextUtils.join(", ", names);
+    }
+
+    private AppProtectionState currentState(InternetBlocklist w) {
+        return AppProtectionState.resolve(
+                apply.getBoolean(mAppId, true),
+                BlockingMode.isTrackerProtectionEnabled(mContext, tracker_protect, mAppId),
+                w.blockedInternet(mAppUid));
+    }
+
+    private void applyState(AppProtectionState target, InternetBlocklist w) {
+        AppProtectionState.Change change = AppProtectionState.of(target);
+
+        boolean applyBefore = apply.getBoolean(mAppId, true);
+        boolean protectBefore = BlockingMode.isTrackerProtectionEnabled(mContext, tracker_protect, mAppId);
+
+        apply.edit().putBoolean(mAppId, change.apply).apply();
+        // Only a re-included app leaves the mode-managed exclusion set. Clearing
+        // it unconditionally would turn a Minimal-mode auto-exclusion into a
+        // permanent one as soon as the user toggled the app off and on again.
+        if (change.apply)
+            BlockingMode.clearAutoExcludedApp(mContext, mAppId);
+
+        if (change.trackerProtect != null)
+            tracker_protect.edit().putBoolean(mAppId, change.trackerProtect).apply();
+
+        w.apply(mContext, mAppUid, change.internetBlocked);
+
+        // The internet blocklist is read live by the packet path, so a change
+        // that only blocks or unblocks Internet needs no reload. Which apps are
+        // in the tun, and which of them are filtered, are baked into the rules.
+        boolean needsReload = change.apply != applyBefore
+                || (change.trackerProtect != null && change.trackerProtect != protectBefore);
+        if (!needsReload)
+            return;
+
+        // Move expensive operations off the main thread to prevent UI freezing
+        // Rule.clearCache() can block waiting for a lock held by Rule.getRules()
+        AsyncTask.execute(() -> {
+            Rule.clearCache(mContext);
+            ServiceSinkhole.reload("app protection changed", mContext, false);
+        });
+    }
+
+    private static int radioIdFor(AppProtectionState state) {
+        switch (state) {
+            case TRACKERS_ALLOWED:
+                return R.id.rbStateTrackersAllowed;
+            case NO_INTERNET:
+                return R.id.rbStateNoInternet;
+            case BYPASSED:
+                return R.id.rbStateBypassed;
+            case PROTECTED:
+            default:
+                return R.id.rbStateProtected;
+        }
+    }
+
+    @Nullable
+    private static AppProtectionState stateForRadioId(int checkedId) {
+        if (checkedId == R.id.rbStateProtected)
+            return AppProtectionState.PROTECTED;
+        if (checkedId == R.id.rbStateTrackersAllowed)
+            return AppProtectionState.TRACKERS_ALLOWED;
+        if (checkedId == R.id.rbStateNoInternet)
+            return AppProtectionState.NO_INTERNET;
+        if (checkedId == R.id.rbStateBypassed)
+            return AppProtectionState.BYPASSED;
+        return null;
     }
 
     @Override
@@ -558,21 +613,15 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     static class VHHeader extends RecyclerView.ViewHolder {
         final TextView mLibraryExplanation;
         final TextView mLibraryDisclaimer;
-        final MaterialSwitch mSwitchInternet;
-        final MaterialSwitch mSwitchVPN;
-        final MaterialSwitch mSwitchVpnExclude;
-        final View mTrackerProtectionRow;
-        final View mTrackerProtectionDivider;
+        final RadioGroup mAppState;
+        final TextView mNoInternetExplanation;
 
         VHHeader(View view) {
             super(view);
             mLibraryExplanation = view.findViewById(R.id.tvLibraryExplanation);
             mLibraryDisclaimer = view.findViewById(R.id.tvLibraryDisclaimer);
-            mSwitchInternet = view.findViewById(R.id.switch_internet);
-            mSwitchVPN = view.findViewById(R.id.switch_vpn);
-            mSwitchVpnExclude = view.findViewById(R.id.switch_vpn_exclude);
-            mTrackerProtectionRow = view.findViewById(R.id.rowTrackerProtection);
-            mTrackerProtectionDivider = view.findViewById(R.id.dividerTrackerProtection);
+            mAppState = view.findViewById(R.id.rgAppState);
+            mNoInternetExplanation = view.findViewById(R.id.tvStateNoInternetDesc);
         }
     }
 }

--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -180,7 +180,7 @@
 
     </androidx.cardview.widget.CardView>
 
-    <!-- App Controls Card - Groups all toggles together -->
+    <!-- App Protection Card - one state, four mutually exclusive options -->
     <androidx.cardview.widget.CardView
         android:layout_marginBottom="8dp"
         android:layout_width="match_parent"
@@ -196,144 +196,94 @@
             android:orientation="vertical"
             android:padding="16dp">
 
-            <!-- Exclude from VPN Toggle (troubleshooting - first for visibility) -->
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/cardVpnExclude"
+            <TextView
+                android:id="@+id/tvAppStateHeading"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_state_heading"
+                android:textColor="?android:textColorPrimary"
+                android:textSize="18sp"
+                android:textStyle="bold" />
 
-                <TextView
-                    android:id="@+id/vpn_exclude_name"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/vpn_exclude"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"/>
-
-                <TextView
-                    android:id="@+id/tvVpnExcludeExplanation"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="48dp"
-                    android:text="@string/vpn_exclude_explanation"
-                    android:textColor="?android:textColorSecondary"
-                    android:textSize="13sp"
-                    android:textStyle="italic"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/vpn_exclude_name" />
-
-                <com.google.android.material.materialswitch.MaterialSwitch
-                    android:id="@+id/switch_vpn_exclude"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:minHeight="0dp"
-                    android:textColor="?android:textColorPrimary"
-                    android:contentDescription="@string/vpn_exclude"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/vpn_exclude_name" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <View
-                android:id="@+id/dividerTrackerProtection"
+            <RadioGroup
+                android:id="@+id/rgAppState"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginVertical="12dp"
-                android:background="?android:attr/listDivider" />
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
 
-            <!-- Tracker Protection Toggle -->
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:id="@+id/rowTrackerProtection"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                <RadioButton
+                    android:id="@+id/rbStateProtected"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_state_protected"
+                    android:text="@string/app_state_protected"
+                    android:textStyle="bold" />
 
                 <TextView
-                    android:id="@+id/root_name"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/tvStateProtectedDesc"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/exclude_vpn"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"/>
+                    android:layout_marginStart="32dp"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/app_state_protected_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+                <RadioButton
+                    android:id="@+id/rbStateTrackersAllowed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_state_trackers_allowed"
+                    android:text="@string/app_state_trackers_allowed"
+                    android:textStyle="bold" />
 
                 <TextView
-                    android:id="@+id/tvTrackerProtectionExplanation"
-                    android:layout_width="0dp"
+                    android:id="@+id/tvStateTrackersAllowedDesc"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="48dp"
-                    android:text="@string/exclude_vpn_explanation"
-                    android:textColor="?android:textColorSecondary"
-                    android:textSize="13sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/root_name" />
+                    android:layout_marginStart="32dp"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/app_state_trackers_allowed_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
 
-                <com.google.android.material.materialswitch.MaterialSwitch
-                    android:id="@+id/switch_vpn"
-                    android:layout_width="wrap_content"
+                <RadioButton
+                    android:id="@+id/rbStateNoInternet"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:minHeight="0dp"
-                    android:textColor="?android:textColorPrimary"
-                    android:contentDescription="@string/exclude_vpn"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/root_name" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginVertical="12dp"
-                android:background="?android:attr/listDivider" />
-
-            <!-- Internet Access Toggle -->
-            <androidx.constraintlayout.widget.ConstraintLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_state_no_internet"
+                    android:text="@string/app_state_no_internet"
+                    android:textStyle="bold" />
 
                 <TextView
-                    android:id="@+id/root_name2"
-                    android:layout_width="wrap_content"
+                    android:id="@+id/tvStateNoInternetDesc"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:text="@string/internet_access"
-                    android:textColor="?android:textColorPrimary"
-                    android:textSize="18sp"
-                    android:textStyle="bold"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent"/>
+                    android:layout_marginStart="32dp"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/app_state_no_internet_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+                <RadioButton
+                    android:id="@+id/rbStateBypassed"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_state_bypassed"
+                    android:text="@string/app_state_bypassed"
+                    android:textStyle="bold" />
 
                 <TextView
-                    android:id="@+id/tvInternetAccessExplanation"
-                    android:layout_width="0dp"
+                    android:id="@+id/tvStateBypassedDesc"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="4dp"
-                    android:layout_marginEnd="48dp"
-                    android:text="@string/internet_access_explanation"
-                    android:textColor="?android:textColorSecondary"
-                    android:textSize="13sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/root_name2" />
+                    android:layout_marginStart="32dp"
+                    android:text="@string/app_state_bypassed_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
 
-                <com.google.android.material.materialswitch.MaterialSwitch
-                    android:id="@+id/switch_internet"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:minHeight="0dp"
-                    android:textColor="?android:textColorPrimary"
-                    android:contentDescription="@string/internet_access"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@+id/root_name2" />
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            </RadioGroup>
 
         </LinearLayout>
 

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -258,7 +258,6 @@
     <string name="tab_countries">البلدان</string>
     <string name="tab_actions">بياناتي</string>
     <string name="tracker_name">اسم أداة التتبع</string>
-    <string name="internet_access">الوصول إلى الإنترنت</string>
     <string name="app_info">إدارة التطبيق</string>
     <!-- Actions -->
     <string name="block_tracking">حظر أدوات التتبع</string>
@@ -377,4 +376,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">الحماية</string>
+    <string name="app_state_protected">محمي</string>
+    <string name="app_state_protected_explanation">يتم حظر أدوات التتبع وتسجيلها لهذا التطبيق.</string>
+    <string name="app_state_trackers_allowed">السماح بأدوات التتبع</string>
+    <string name="app_state_trackers_allowed_explanation">يواصل التطبيق العمل عبر TrackerControl، لكن أدوات التتبع الخاصة به لا تُحظر ولا تُسجَّل. استخدم هذا الخيار إذا كان الحظر يُعطِّل التطبيق.</string>
+    <string name="app_state_no_internet">بلا إنترنت</string>
+    <string name="app_state_no_internet_explanation">جميع اتصالات هذا التطبيق محظورة. يمكنك أيضًا الضغط على أيقونة التطبيق في الشاشة الرئيسية.</string>
+    <string name="app_state_no_internet_shared_uid">ينطبق أيضًا على %1$s، الذي يشارك هذا التطبيق مُعرِّف مستخدم أندرويد.</string>
+    <string name="app_state_bypassed">تجاوز TrackerControl</string>
+    <string name="app_state_bypassed_explanation">يتصل التطبيق مباشرةً، خارج TrackerControl. لا تتم مراقبة أو حظر أي شيء له. استخدم هذا كملاذ أخير إذا كان التطبيق لا يزال لا يعمل.\n\nملاحظة: يجب تعطيل \"حظر الاتصالات بدون VPN\" في إعدادات VPN بنظام أندرويد حتى يعمل هذا.</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -59,4 +59,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">সুরক্ষা</string>
+    <string name="app_state_protected">সুরক্ষিত</string>
+    <string name="app_state_protected_explanation">এই অ্যাপের জন্য ট্র্যাকার ব্লক ও রেকর্ড করা হয়।</string>
+    <string name="app_state_trackers_allowed">ট্র্যাকার অনুমোদিত</string>
+    <string name="app_state_trackers_allowed_explanation">অ্যাপটি TrackerControl-এর মধ্য দিয়েই চলতে থাকে, তবে এর ট্র্যাকারগুলি ব্লকও করা হয় না, রেকর্ডও করা হয় না। ব্লক করার ফলে অ্যাপ কাজ না করলে এটি ব্যবহার করুন।</string>
+    <string name="app_state_no_internet">ইন্টারনেট নেই</string>
+    <string name="app_state_no_internet_explanation">এই অ্যাপের সব সংযোগ ব্লক করা হয়েছে। আপনি প্রধান স্ক্রিনে অ্যাপের আইকনেও ট্যাপ করতে পারেন।</string>
+    <string name="app_state_no_internet_shared_uid">%1$s-এর ক্ষেত্রেও প্রযোজ্য, যেটি এই অ্যাপের সঙ্গে একই Android ব্যবহারকারী আইডি ভাগ করে।</string>
+    <string name="app_state_bypassed">TrackerControl এড়িয়ে যান</string>
+    <string name="app_state_bypassed_explanation">অ্যাপটি TrackerControl-এর বাইরে সরাসরি সংযোগ করে। এর জন্য কিছুই পর্যবেক্ষণ বা ব্লক করা হয় না। অ্যাপ তবুও কাজ না করলে শেষ উপায় হিসেবে এটি ব্যবহার করুন।\n\nদ্রষ্টব্য: এটি কাজ করতে হলে Android-এর VPN সেটিংসে \"VPN ছাড়া সংযোগ ব্লক করুন\" বন্ধ থাকতে হবে।</string>
 </resources>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -260,8 +260,6 @@ Váš internetový provoz není odesílán žádnému vzdálenému VPN serveru.<
     <string name="tab_countries">Země</string>
     <string name="tab_actions">Moje data</string>
     <string name="tracker_name">Název trackeru</string>
-    <string name="internet_access">Přístup k internetu</string>
-    <string name="internet_access_explanation">Můžete také klepnout na ikonu aplikace na hlavní obrazovce.</string>
     <string name="app_info">Spravovat aplikace</string>
     <!-- Actions -->
     <string name="block_tracking">Blokovat trackery</string>
@@ -340,9 +338,6 @@ Privátní DNS musí být vypnutá.</string>
     <string name="setting_strict_blocking">Přísné blokování</string>
     <string name="summary_strict_blocking">Blokovat skoro všechno sdílení dat nově nainstalovaných aplikací. Aplikace nemusí fungovat.</string>
     <string name="strict_blocking_explanation">Je doporučeno vypnout tuto možnost pro snížení počtu nefungujících aplikací. Je ale třeba k zakázání veškerého sdílení.</string>
-    <string name="exclude_vpn_explanation">Detekuje a blokuje trackery pro tuto aplikaci.</string>
-    <string name="vpn_exclude">Vyloučit z VPN</string>
-    <string name="vpn_exclude_explanation">Povolte tuto funkci, pokud narazíte na problémy. Aplikace zcela obejde TrackerControl.\n\nPoznámka: Aby tato funkce fungovala, musí být v nastavení VPN pro Android VYPNUTA možnost \"Blokovat připojení bez VPN\".</string>
     <string name="uninstall">Odinstalovat</string>
     <string name="settings_uninstall">Nastavení aplikace a odinstalace</string>
     <string name="no_trackers_found_message_disabled">Zapni switch v hlavním okně, pak zapni aplikaci pro nalezení trackerů</string>
@@ -397,4 +392,16 @@ Privátní DNS musí být vypnutá.</string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Ochrana</string>
+    <string name="app_state_protected">Chráněno</string>
+    <string name="app_state_protected_explanation">Trackery jsou pro tuto aplikaci blokovány a zaznamenávány.</string>
+    <string name="app_state_trackers_allowed">Trackery povoleny</string>
+    <string name="app_state_trackers_allowed_explanation">Aplikace dál běží přes TrackerControl, ale její trackery se neblokují ani nezaznamenávají. Použijte, pokud blokování aplikaci rozbíjí.</string>
+    <string name="app_state_no_internet">Bez internetu</string>
+    <string name="app_state_no_internet_explanation">Všechna připojení této aplikace jsou blokována. Můžete také klepnout na ikonu aplikace na hlavní obrazovce.</string>
+    <string name="app_state_no_internet_shared_uid">Platí i pro %1$s, která s touto aplikací sdílí uživatelské ID systému Android.</string>
+    <string name="app_state_bypassed">Obejít TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Aplikace se připojuje přímo, mimo TrackerControl. Nic se pro ni nesleduje ani neblokuje. Použijte jako poslední možnost, pokud aplikace stále nefunguje.\n\nPoznámka: Aby to fungovalo, musí být volba \"Blokovat připojení bez VPN\" v nastavení VPN systému Android VYPNUTA.</string>
 </resources>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -114,4 +114,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Beskyttelse</string>
+    <string name="app_state_protected">Beskyttet</string>
+    <string name="app_state_protected_explanation">Sporere blokeres og registreres for denne app.</string>
+    <string name="app_state_trackers_allowed">Sporere tilladt</string>
+    <string name="app_state_trackers_allowed_explanation">Appen kører fortsat gennem TrackerControl, men dens sporere hverken blokeres eller registreres. Brug dette, hvis blokering ødelægger appen.</string>
+    <string name="app_state_no_internet">Intet internet</string>
+    <string name="app_state_no_internet_explanation">Alle forbindelser fra denne app blokeres. Du kan også trykke på appikonet på hovedskærmen.</string>
+    <string name="app_state_no_internet_shared_uid">Gælder også %1$s, som deler et Android-bruger-id med denne app.</string>
+    <string name="app_state_bypassed">Omgå TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Appen forbinder direkte, uden om TrackerControl. Intet overvåges eller blokeres for den. Brug dette som sidste udvej, hvis appen stadig ikke virker.\n\nBemærk: \"Bloker forbindelser uden VPN\" i Androids VPN-indstillinger skal være DEAKTIVERET, for at dette virker.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -257,7 +257,6 @@
     <string name="tab_countries">Länder</string>
     <string name="tab_actions">Meine Daten</string>
     <string name="tracker_name">Trackername</string>
-    <string name="internet_access">Internetzugang</string>
     <string name="app_info">App verwalten</string>
     <!-- Actions -->
     <string name="block_tracking">Tracker blockieren</string>
@@ -342,4 +341,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Schutz</string>
+    <string name="app_state_protected">Geschützt</string>
+    <string name="app_state_protected_explanation">Tracker werden für diese App blockiert und aufgezeichnet.</string>
+    <string name="app_state_trackers_allowed">Tracker erlaubt</string>
+    <string name="app_state_trackers_allowed_explanation">Die App läuft weiterhin über TrackerControl, ihre Tracker werden aber weder blockiert noch aufgezeichnet. Nutze dies, wenn das Blockieren die App beeinträchtigt.</string>
+    <string name="app_state_no_internet">Kein Internet</string>
+    <string name="app_state_no_internet_explanation">Alle Verbindungen dieser App werden blockiert. Du kannst auch auf das App-Symbol im Hauptbildschirm tippen.</string>
+    <string name="app_state_no_internet_shared_uid">Gilt auch für %1$s, da diese App sich eine Android-Benutzer-ID mit dieser App teilt.</string>
+    <string name="app_state_bypassed">TrackerControl umgehen</string>
+    <string name="app_state_bypassed_explanation">Die App verbindet sich direkt, außerhalb von TrackerControl. Nichts wird für sie überwacht oder blockiert. Nutze dies als letzten Ausweg, wenn die App weiterhin nicht funktioniert.\n\nHinweis: \"Verbindungen ohne VPN blockieren\" in den Android-VPN-Einstellungen muss DEAKTIVIERT sein, damit dies funktioniert.</string>
 </resources>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -235,7 +235,6 @@
     <string name="tab_countries">Χώρες</string>
     <string name="tab_actions">Τα δεδομένα μου</string>
     <string name="tracker_name">Όνομα ιχνηλάτη</string>
-    <string name="internet_access">Πρόσβαση στο διαδίκτυο</string>
     <string name="app_info">Διαχείριση Εφαρμογής</string>
     <!-- Actions -->
     <string name="block_tracking">Αποκλεισμός Ιχνηλατών</string>
@@ -319,4 +318,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Προστασία</string>
+    <string name="app_state_protected">Προστατευμένη</string>
+    <string name="app_state_protected_explanation">Οι ιχνηλάτες αποκλείονται και καταγράφονται για αυτήν την εφαρμογή.</string>
+    <string name="app_state_trackers_allowed">Ιχνηλάτες επιτρεπτοί</string>
+    <string name="app_state_trackers_allowed_explanation">Η εφαρμογή συνεχίζει να περνά από το TrackerControl, αλλά οι ιχνηλάτες της ούτε αποκλείονται ούτε καταγράφονται. Χρησιμοποιήστε το αν ο αποκλεισμός χαλάει την εφαρμογή.</string>
+    <string name="app_state_no_internet">Χωρίς Internet</string>
+    <string name="app_state_no_internet_explanation">Όλες οι συνδέσεις αυτής της εφαρμογής αποκλείονται. Μπορείτε επίσης να πατήσετε το εικονίδιο της εφαρμογής στην κύρια οθόνη.</string>
+    <string name="app_state_no_internet_shared_uid">Ισχύει και για το %1$s, το οποίο μοιράζεται αναγνωριστικό χρήστη Android με αυτήν την εφαρμογή.</string>
+    <string name="app_state_bypassed">Παράκαμψη του TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Η εφαρμογή συνδέεται απευθείας, εκτός του TrackerControl. Τίποτα δεν παρακολουθείται ούτε αποκλείεται για αυτήν. Χρησιμοποιήστε το ως έσχατη λύση αν η εφαρμογή εξακολουθεί να μη λειτουργεί.\n\nΣημείωση: Η επιλογή \"Αποκλεισμός συνδέσεων χωρίς VPN\" στις ρυθμίσεις VPN του Android πρέπει να είναι ΑΠΕΝΕΡΓΟΠΟΙΗΜΕΝΗ για να λειτουργήσει αυτό.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -275,7 +275,6 @@ El tráfico de internet no será envíado a un servidor VPN ajeno.</string>
     <string name="tab_countries">Países</string>
     <string name="tab_actions">Mis datos</string>
     <string name="tracker_name">Nombre del rastreador</string>
-    <string name="internet_access">Acceso a Internet</string>
     <string name="app_info">Gestionar App</string>
     <!-- Actions -->
     <string name="block_tracking">Bloquear rastreadores</string>
@@ -394,4 +393,16 @@ Atentamente,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protección</string>
+    <string name="app_state_protected">Protegida</string>
+    <string name="app_state_protected_explanation">Los rastreadores se bloquean y se registran para esta aplicación.</string>
+    <string name="app_state_trackers_allowed">Rastreadores permitidos</string>
+    <string name="app_state_trackers_allowed_explanation">La aplicación sigue pasando por TrackerControl, pero sus rastreadores no se bloquean ni se registran. Usa esto si el bloqueo hace que la aplicación falle.</string>
+    <string name="app_state_no_internet">Sin Internet</string>
+    <string name="app_state_no_internet_explanation">Todas las conexiones de esta aplicación están bloqueadas. También puedes tocar el icono de la aplicación en la pantalla principal.</string>
+    <string name="app_state_no_internet_shared_uid">También se aplica a %1$s, que comparte un ID de usuario de Android con esta aplicación.</string>
+    <string name="app_state_bypassed">Omitir TrackerControl</string>
+    <string name="app_state_bypassed_explanation">La aplicación se conecta directamente, fuera de TrackerControl. No se supervisa ni se bloquea nada para ella. Usa esto como último recurso si la aplicación sigue sin funcionar.\n\nNota: \"Bloquear conexiones sin VPN\" en los ajustes de VPN de Android debe estar DESACTIVADO para que esto funcione.</string>
 </resources>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -161,8 +161,6 @@
     <string name="tab_countries">Maad</string>
     <string name="tab_actions">Minu andmed</string>
     <string name="tracker_name">Jälitaja nimi</string>
-    <string name="internet_access">Internetiühendus</string>
-    <string name="internet_access_explanation">Võida ka klõpsata rakenduse ikooni põhivaates.</string>
     <string name="app_info">Halda rakendust</string>
     <!-- Actions -->
     <string name="block_tracking">Blokeeri jälitajaid</string>
@@ -238,4 +236,16 @@
     <string name="log_connection_wifi">WiFi</string>
     <string name="log_connection_other">Muu võrk</string>
     <string name="log_app_icon">Rakenduse ikoon</string>
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Kaitse</string>
+    <string name="app_state_protected">Kaitstud</string>
+    <string name="app_state_protected_explanation">Jälitajad blokeeritakse ja salvestatakse selle rakenduse puhul.</string>
+    <string name="app_state_trackers_allowed">Jälitajad lubatud</string>
+    <string name="app_state_trackers_allowed_explanation">Rakendus töötab endiselt TrackerControli kaudu, kuid selle jälitajaid ei blokeerita ega salvestata. Kasuta seda, kui blokeerimine rikub rakenduse.</string>
+    <string name="app_state_no_internet">Internetita</string>
+    <string name="app_state_no_internet_explanation">Kõik selle rakenduse ühendused on blokeeritud. Võid ka põhiekraanil rakenduse ikoonile vajutada.</string>
+    <string name="app_state_no_internet_shared_uid">Kehtib ka rakendusele %1$s, mis jagab selle rakendusega Androidi kasutaja-ID-d.</string>
+    <string name="app_state_bypassed">TrackerControlist mööda</string>
+    <string name="app_state_bypassed_explanation">Rakendus ühendub otse, TrackerControlist mööda. Tema jaoks ei jälgita ega blokeerita midagi. Kasuta seda viimase abinõuna, kui rakendus ikka ei tööta.\n\nMärkus: Androidi VPN-i sätetes peab \"Blokeeri ühendused ilma VPN-ita\" olema VÄLJA LÜLITATUD, et see toimiks.</string>
 </resources>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -236,7 +236,6 @@ Zure internet trafikoa ez da kanpo VPN zerbitzari batera bidaltzen.</string>
     <string name="tab_countries">Herrialdeak</string>
     <string name="tab_actions">Nire datuak</string>
     <string name="tracker_name">Aztarnariaren izena</string>
-    <string name="internet_access">Internet sarbidea</string>
     <string name="app_info">Aplikazioa kudeatu</string>
     <!-- Actions -->
     <string name="block_tracking">Aztarnariak blokeatu</string>
@@ -358,4 +357,16 @@ Sareko trafikoan antzematen diren aztarnariak TrackerControl-ekin blokeatu daite
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Babesa</string>
+    <string name="app_state_protected">Babestuta</string>
+    <string name="app_state_protected_explanation">Aplikazio honetarako jarraitzaileak blokeatu eta erregistratzen dira.</string>
+    <string name="app_state_trackers_allowed">Jarraitzaileak onartuta</string>
+    <string name="app_state_trackers_allowed_explanation">Aplikazioak TrackerControl bidez jarraitzen du, baina bere jarraitzaileak ez dira ez blokeatzen ez erregistratzen. Erabili hau blokeatzeak aplikazioa hondatzen badu.</string>
+    <string name="app_state_no_internet">Internetik ez</string>
+    <string name="app_state_no_internet_explanation">Aplikazio honen konexio guztiak blokeatuta daude. Pantaila nagusiko aplikazioaren ikonoa ere uki dezakezu.</string>
+    <string name="app_state_no_internet_shared_uid">%1$s aplikazioari ere aplikatzen zaio, Android erabiltzaile-ID bera partekatzen baitu honekin.</string>
+    <string name="app_state_bypassed">Saihestu TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Aplikazioa zuzenean konektatzen da, TrackerControletik kanpo. Ez zaio ezer monitorizatzen ez blokeatzen. Erabili hau azken aukera gisa aplikazioak oraindik funtzionatzen ez badu.\n\nOharra: Androiden VPN ezarpenetako \"Blokeatu VPNrik gabeko konexioak\" DESAKTIBATUTA egon behar da hau funtziona dezan.</string>
 </resources>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -16,4 +16,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">محافظت</string>
+    <string name="app_state_protected">محافظت‌شده</string>
+    <string name="app_state_protected_explanation">ردیاب‌ها برای این برنامه مسدود و ثبت می‌شوند.</string>
+    <string name="app_state_trackers_allowed">ردیاب‌ها مجاز</string>
+    <string name="app_state_trackers_allowed_explanation">برنامه همچنان از طریق TrackerControl کار می‌کند، اما ردیاب‌های آن نه مسدود می‌شوند و نه ثبت. اگر مسدودسازی برنامه را خراب می‌کند از این گزینه استفاده کنید.</string>
+    <string name="app_state_no_internet">بدون اینترنت</string>
+    <string name="app_state_no_internet_explanation">همهٔ اتصال‌های این برنامه مسدود شده‌اند. می‌توانید روی نماد برنامه در صفحهٔ اصلی نیز ضربه بزنید.</string>
+    <string name="app_state_no_internet_shared_uid">برای %1$s نیز اعمال می‌شود، که شناسهٔ کاربری اندروید را با این برنامه به اشتراک می‌گذارد.</string>
+    <string name="app_state_bypassed">دور زدن TrackerControl</string>
+    <string name="app_state_bypassed_explanation">برنامه مستقیماً و خارج از TrackerControl متصل می‌شود. هیچ چیزی برای آن پایش یا مسدود نمی‌شود. اگر برنامه هنوز کار نمی‌کند، این را به‌عنوان آخرین راه‌حل استفاده کنید.\n\nتوجه: گزینهٔ \"مسدودسازی اتصال‌های بدون VPN\" در تنظیمات VPN اندروید باید غیرفعال باشد تا این کار کند.</string>
 </resources>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -254,8 +254,6 @@ Internet-liikennettäsi ei lähetetä VPN-etäpalvelimeen.</string>
     <string name="tab_countries">Maat</string>
     <string name="tab_actions">Omat tiedot</string>
     <string name="tracker_name">Seuraimen nimi</string>
-    <string name="internet_access">Internet-yhteys</string>
-    <string name="internet_access_explanation">Voit myös napauttaa sovelluksen kuvaketta päänäytöllä.</string>
     <string name="app_info">Hallitse sovellusta</string>
     <!-- Actions -->
     <string name="block_tracking">Estä seuraimet</string>
@@ -333,9 +331,6 @@ Ystävällisin terveisin,\n\n]]></string>
     <string name="setting_strict_blocking">Tiukka Esto</string>
     <string name="summary_strict_blocking">Estä juuri asennettujen sovellusten tietojen jakamista yritysten kanssa mahdollisimman paljon. Useampi sovelluksista lakkaa toimimasta.</string>
     <string name="strict_blocking_explanation">On suositeltavaa, että muut kuin asiantuntijat poistavat tämän vaihtoehdon käytöstä sovelluksten toimintahäiriöiden vähentämiseksi. Tämä kuitenkin mahdollistaa joitain olennaisia tiedonvaihtoja yritysten kanssa.</string>
-    <string name="exclude_vpn_explanation">Havaitsee ja estää tämän sovelluksen seuraimet.</string>
-    <string name="vpn_exclude">Ohita VPN-yhteys</string>
-    <string name="vpn_exclude_explanation">Ota käyttöön, jos kohtaat ongelmia. Sovellus ohittaa TrackerControlin kokonaan.\n\nHuomaa: Jotta tämä toimisi, Android-VPN-asetusten kohta ”Estä yhteydet ilman VPN: ää” on oltava POISSA KÄYTÖSTÄ.</string>
     <string name="uninstall">Poista asennus</string>
     <string name="settings_uninstall">Sovelluksen tiedot</string>
     <string name="no_trackers_found_message_disabled">Ota käyttöön päänäytön kytkimestä ja käynnistä sitten sovellus löytääksesi seuraimia</string>
@@ -451,4 +446,16 @@ Ystävällisin terveisin,\n\n]]></string>
     <string name="msg_invalid_url">Virheellinen URL-osoite</string>
     <string name="msg_last_update">Päivitetty viimeksi: %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Suojaus</string>
+    <string name="app_state_protected">Suojattu</string>
+    <string name="app_state_protected_explanation">Seuraimet estetään ja kirjataan tälle sovellukselle.</string>
+    <string name="app_state_trackers_allowed">Seuraimet sallittu</string>
+    <string name="app_state_trackers_allowed_explanation">Sovellus kulkee edelleen TrackerControlin kautta, mutta sen seuraimia ei estetä eikä kirjata. Käytä tätä, jos esto rikkoo sovelluksen.</string>
+    <string name="app_state_no_internet">Ei internetiä</string>
+    <string name="app_state_no_internet_explanation">Kaikki tämän sovelluksen yhteydet on estetty. Voit myös napauttaa sovelluksen kuvaketta päänäytöllä.</string>
+    <string name="app_state_no_internet_shared_uid">Koskee myös sovellusta %1$s, jolla on sama Android-käyttäjätunnus kuin tällä sovelluksella.</string>
+    <string name="app_state_bypassed">Ohita TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Sovellus muodostaa yhteyden suoraan, TrackerControlin ohi. Sille ei valvota eikä estetä mitään. Käytä tätä viimeisenä keinona, jos sovellus ei vieläkään toimi.\n\nHuomaa: Androidin VPN-asetusten kohdan \"Estä yhteydet ilman VPN:ää\" on oltava POIS KÄYTÖSTÄ, jotta tämä toimii.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -385,8 +385,6 @@ Votre trafic internet n\'est pas envoyé vers un serveur VPN distant.</string>
     <string name="tab_countries">Pays</string>
     <string name="tab_actions">Mes données</string>
     <string name="tracker_name">Nom du traqueur</string>
-    <string name="internet_access">Accès à internet</string>
-    <string name="internet_access_explanation">Vous pouvez également appuyer sur l\'icône de l\'application sur l\'écran principal.</string>
     <string name="app_info">Gérer l\'application</string>
     <!-- Actions -->
     <string name="block_tracking">Bloquer les traqueurs</string>
@@ -478,8 +476,6 @@ Cordialement,\n\n]]></string>
     <string name="onboarding_blockingmode_standard_label">Standard</string>
     <string name="onboarding_blockingmode_strict_label">Strict</string>
     <string name="onboarding_blockingmode_research_label">Recherche</string>
-    <string name="exclude_vpn_explanation">Détecte et bloque les trackers pour cette application.</string>
-    <string name="vpn_exclude">Exclure du VPN</string>
     <string name="uninstall">Désinstaller</string>
     <string name="settings_uninstall">Paramètres de l\'application &amp; Désinstaller</string>
     <string name="no_trackers_found_message_disabled">Activer l\'interrupteur sur l\'écran principal, puis lancer l\'application pour trouver des traqueurs</string>
@@ -578,4 +574,16 @@ Cordialement,\n\n]]></string>
     <string name="msg_apply_blocklists_failed">Échec de l\'application des fichiers hôtes</string>
     <string name="msg_last_update">Dernière mise à jour : %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protection</string>
+    <string name="app_state_protected">Protégée</string>
+    <string name="app_state_protected_explanation">Les traqueurs sont bloqués et enregistrés pour cette application.</string>
+    <string name="app_state_trackers_allowed">Traqueurs autorisés</string>
+    <string name="app_state_trackers_allowed_explanation">L\'application continue de passer par TrackerControl, mais ses traqueurs ne sont ni bloqués ni enregistrés. À utiliser si le blocage empêche l\'application de fonctionner.</string>
+    <string name="app_state_no_internet">Pas d\'Internet</string>
+    <string name="app_state_no_internet_explanation">Toutes les connexions de cette application sont bloquées. Vous pouvez aussi appuyer sur l\'icône de l\'application dans l\'écran principal.</string>
+    <string name="app_state_no_internet_shared_uid">S\'applique également à %1$s, qui partage un identifiant utilisateur Android avec cette application.</string>
+    <string name="app_state_bypassed">Contourner TrackerControl</string>
+    <string name="app_state_bypassed_explanation">L\'application se connecte directement, en dehors de TrackerControl. Rien n\'est surveillé ni bloqué pour elle. À utiliser en dernier recours si l\'application ne fonctionne toujours pas.\n\nRemarque : \"Bloquer les connexions sans VPN\" doit être DÉSACTIVÉ dans les paramètres VPN d\'Android pour que cela fonctionne.</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -79,4 +79,16 @@ O seu tráfico de internet non será enviado a ningún servidor VPN remoto.</str
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protección</string>
+    <string name="app_state_protected">Protexida</string>
+    <string name="app_state_protected_explanation">Os rastrexadores bloquéanse e rexístranse para esta aplicación.</string>
+    <string name="app_state_trackers_allowed">Rastrexadores permitidos</string>
+    <string name="app_state_trackers_allowed_explanation">A aplicación segue pasando por TrackerControl, pero os seus rastrexadores non se bloquean nin se rexistran. Usa isto se o bloqueo estraga a aplicación.</string>
+    <string name="app_state_no_internet">Sen Internet</string>
+    <string name="app_state_no_internet_explanation">Todas as conexións desta aplicación están bloqueadas. Tamén podes tocar a icona da aplicación na pantalla principal.</string>
+    <string name="app_state_no_internet_shared_uid">Tamén se aplica a %1$s, que comparte un ID de usuario de Android con esta aplicación.</string>
+    <string name="app_state_bypassed">Omitir TrackerControl</string>
+    <string name="app_state_bypassed_explanation">A aplicación conéctase directamente, fóra de TrackerControl. Non se supervisa nin se bloquea nada para ela. Usa isto como último recurso se a aplicación segue sen funcionar.\n\nNota: \"Bloquear conexións sen VPN\" nos axustes de VPN de Android debe estar DESACTIVADO para que isto funcione.</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -238,7 +238,6 @@ Az Ön internetes forgalmát nem küldi el egy távoli VPN-kiszolgálóra.</stri
     <string name="tab_countries">Országok</string>
     <string name="tab_actions">Adataim</string>
     <string name="tracker_name">Nyomkövető neve</string>
-    <string name="internet_access">Internet-hozzáférés</string>
     <string name="app_info">Alkalmazáskezelés</string>
     <!-- Actions -->
     <string name="block_tracking">Nyomkövetők blokkolása</string>
@@ -357,4 +356,16 @@ Tisztelettel,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Védelem</string>
+    <string name="app_state_protected">Védett</string>
+    <string name="app_state_protected_explanation">A követők blokkolva és rögzítve vannak ennél az alkalmazásnál.</string>
+    <string name="app_state_trackers_allowed">Követők engedélyezve</string>
+    <string name="app_state_trackers_allowed_explanation">Az alkalmazás továbbra is a TrackerControlon keresztül fut, de a követőit sem nem blokkolja, sem nem rögzíti. Használja ezt, ha a blokkolás elrontja az alkalmazást.</string>
+    <string name="app_state_no_internet">Nincs internet</string>
+    <string name="app_state_no_internet_explanation">Az alkalmazás összes kapcsolata blokkolva van. A főképernyőn az alkalmazás ikonjára is koppinthat.</string>
+    <string name="app_state_no_internet_shared_uid">Erre is vonatkozik: %1$s, amely Android-felhasználóazonosítón osztozik ezzel az alkalmazással.</string>
+    <string name="app_state_bypassed">TrackerControl megkerülése</string>
+    <string name="app_state_bypassed_explanation">Az alkalmazás közvetlenül, a TrackerControlon kívül csatlakozik. Semmit sem figyel és blokkol nála. Végső megoldásként használja, ha az alkalmazás továbbra sem működik.\n\nMegjegyzés: az Android VPN-beállításaiban a \"Kapcsolatok blokkolása VPN nélkül\" beállításnak KIKAPCSOLVA kell lennie, hogy ez működjön.</string>
 </resources>

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -3,4 +3,16 @@
     <!-- App Overview -->
     <!-- App Details -->
     <!-- Actions -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Vörn</string>
+    <string name="app_state_protected">Varið</string>
+    <string name="app_state_protected_explanation">Rekjarar eru útilokaðir og skráðir fyrir þetta forrit.</string>
+    <string name="app_state_trackers_allowed">Rekjarar leyfðir</string>
+    <string name="app_state_trackers_allowed_explanation">Forritið fer áfram um TrackerControl en rekjarar þess eru hvorki útilokaðir né skráðir. Notaðu þetta ef útilokun skemmir forritið.</string>
+    <string name="app_state_no_internet">Ekkert internet</string>
+    <string name="app_state_no_internet_explanation">Allar tengingar þessa forrits eru útilokaðar. Þú getur einnig ýtt á táknmynd forritsins á aðalskjánum.</string>
+    <string name="app_state_no_internet_shared_uid">Á einnig við um %1$s, sem deilir Android-notandaauðkenni með þessu forriti.</string>
+    <string name="app_state_bypassed">Sniðganga TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Forritið tengist beint, utan TrackerControl. Ekkert er vaktað eða útilokað fyrir það. Notaðu þetta sem síðasta úrræði ef forritið virkar enn ekki.\n\nAthugið: \"Loka á tengingar án VPN\" í VPN-stillingum Android verður að vera SLÖKKT til að þetta virki.</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -236,7 +236,6 @@ Il tuo traffico di rete non è inoltrato verso un server remoto, ma viene monito
     <string name="tab_countries">Paesi</string>
     <string name="tab_actions">I miei dati</string>
     <string name="tracker_name">Nome del tracker</string>
-    <string name="internet_access">Accesso ad internet</string>
     <string name="app_info">Gestisci l\'applicazione</string>
     <!-- Actions -->
     <string name="block_tracking">Blocca i tracker</string>
@@ -354,4 +353,16 @@ Cordiali saluti,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protezione</string>
+    <string name="app_state_protected">Protetta</string>
+    <string name="app_state_protected_explanation">I tracker vengono bloccati e registrati per questa app.</string>
+    <string name="app_state_trackers_allowed">Tracker consentiti</string>
+    <string name="app_state_trackers_allowed_explanation">L\'app continua a passare per TrackerControl, ma i suoi tracker non vengono né bloccati né registrati. Usa questa opzione se il blocco impedisce all\'app di funzionare.</string>
+    <string name="app_state_no_internet">Nessuna connessione</string>
+    <string name="app_state_no_internet_explanation">Tutte le connessioni di questa app sono bloccate. Puoi anche toccare l\'icona dell\'app nella schermata principale.</string>
+    <string name="app_state_no_internet_shared_uid">Vale anche per %1$s, che condivide un ID utente Android con questa app.</string>
+    <string name="app_state_bypassed">Ignora TrackerControl</string>
+    <string name="app_state_bypassed_explanation">L\'app si connette direttamente, al di fuori di TrackerControl. Per essa non viene monitorato né bloccato nulla. Usa questa opzione come ultima risorsa se l\'app continua a non funzionare.\n\nNota: \"Blocca connessioni senza VPN\" nelle impostazioni VPN di Android deve essere DISATTIVATO perché funzioni.</string>
 </resources>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -242,7 +242,6 @@
     <string name="tab_countries">מדינות</string>
     <string name="tab_actions">הנתונים שלי</string>
     <string name="tracker_name">שם עוקב</string>
-    <string name="internet_access">גישה לאינטרנט</string>
     <string name="app_info">ניהול אפליקציה</string>
     <!-- Actions -->
     <string name="block_tracking">חסימת עוקבים</string>
@@ -338,4 +337,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">הגנה</string>
+    <string name="app_state_protected">מוגן</string>
+    <string name="app_state_protected_explanation">רכיבי מעקב נחסמים ונרשמים עבור אפליקציה זו.</string>
+    <string name="app_state_trackers_allowed">רכיבי מעקב מותרים</string>
+    <string name="app_state_trackers_allowed_explanation">האפליקציה ממשיכה לעבור דרך TrackerControl, אך רכיבי המעקב שלה אינם נחסמים ואינם נרשמים. השתמשו בכך אם החסימה שוברת את האפליקציה.</string>
+    <string name="app_state_no_internet">אין אינטרנט</string>
+    <string name="app_state_no_internet_explanation">כל החיבורים של אפליקציה זו חסומים. אפשר גם להקיש על סמל האפליקציה במסך הראשי.</string>
+    <string name="app_state_no_internet_shared_uid">חל גם על %1$s, שחולקת מזהה משתמש של Android עם אפליקציה זו.</string>
+    <string name="app_state_bypassed">עקיפת TrackerControl</string>
+    <string name="app_state_bypassed_explanation">האפליקציה מתחברת ישירות, מחוץ ל-TrackerControl. דבר אינו מנוטר או נחסם עבורה. השתמשו בכך כמוצא אחרון אם האפליקציה עדיין לא עובדת.\n\nהערה: האפשרות \"חסום חיבורים ללא VPN\" בהגדרות ה-VPN של Android חייבת להיות מושבתת כדי שזה יעבוד.</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -230,7 +230,6 @@
     <string name="tab_countries">国</string>
     <string name="tab_actions">自分のデータ</string>
     <string name="tracker_name">トラッカー名</string>
-    <string name="internet_access">インターネットアクセス</string>
     <string name="app_info">アプリの管理</string>
     <!-- Actions -->
     <string name="block_tracking">トラッカーをブロック</string>
@@ -314,4 +313,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">保護</string>
+    <string name="app_state_protected">保護中</string>
+    <string name="app_state_protected_explanation">このアプリのトラッカーをブロックし、記録します。</string>
+    <string name="app_state_trackers_allowed">トラッカーを許可</string>
+    <string name="app_state_trackers_allowed_explanation">アプリは引き続き TrackerControl を経由しますが、トラッカーはブロックも記録もされません。ブロックによってアプリが正常に動作しない場合に使用してください。</string>
+    <string name="app_state_no_internet">インターネットなし</string>
+    <string name="app_state_no_internet_explanation">このアプリのすべての接続をブロックします。メイン画面のアプリアイコンをタップしても切り替えられます。</string>
+    <string name="app_state_no_internet_shared_uid">このアプリと Android のユーザー ID を共有する %1$s にも適用されます。</string>
+    <string name="app_state_bypassed">TrackerControl を迂回</string>
+    <string name="app_state_bypassed_explanation">アプリは TrackerControl を経由せず直接接続します。監視もブロックも行われません。アプリがそれでも動作しない場合の最終手段として使用してください。\n\n注意: これを機能させるには、Android の VPN 設定で \"VPN なしの接続をブロック\" を無効にする必要があります。</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -88,4 +88,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">보호</string>
+    <string name="app_state_protected">보호됨</string>
+    <string name="app_state_protected_explanation">이 앱의 트래커를 차단하고 기록합니다.</string>
+    <string name="app_state_trackers_allowed">트래커 허용</string>
+    <string name="app_state_trackers_allowed_explanation">앱은 계속 TrackerControl을 통해 연결되지만 트래커는 차단되지도 기록되지도 않습니다. 차단으로 앱이 제대로 동작하지 않을 때 사용하세요.</string>
+    <string name="app_state_no_internet">인터넷 없음</string>
+    <string name="app_state_no_internet_explanation">이 앱의 모든 연결이 차단됩니다. 메인 화면에서 앱 아이콘을 눌러도 됩니다.</string>
+    <string name="app_state_no_internet_shared_uid">이 앱과 Android 사용자 ID를 공유하는 %1$s에도 적용됩니다.</string>
+    <string name="app_state_bypassed">TrackerControl 우회</string>
+    <string name="app_state_bypassed_explanation">앱이 TrackerControl을 거치지 않고 직접 연결합니다. 이 앱에 대해서는 아무것도 감시하거나 차단하지 않습니다. 앱이 여전히 동작하지 않을 때 최후의 수단으로 사용하세요.\n\n참고: 이 기능이 동작하려면 Android VPN 설정에서 \"VPN 없이 연결 차단\"이 사용 중지되어 있어야 합니다.</string>
 </resources>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -351,8 +351,6 @@ Het internetverkeer wordt niet naar een externe VPN-server gestuurd.</string>
     <string name="tab_countries">Landen</string>
     <string name="tab_actions">Mijn gegevens</string>
     <string name="tracker_name">Tracker naam</string>
-    <string name="internet_access">Internettoegang</string>
-    <string name="internet_access_explanation">Je kunt ook op het app-icoon tikken in het hoofdscherm.</string>
     <string name="app_info">App beheren</string>
     <!-- Actions -->
     <string name="block_tracking">Trackers blokkeren</string>
@@ -409,7 +407,6 @@ Het internetverkeer wordt niet naar een externe VPN-server gestuurd.</string>
     <string name="onboarding_blockingmode_standard_label">Standaard</string>
     <string name="onboarding_blockingmode_strict_label">Strikt</string>
     <string name="onboarding_blockingmode_research_label">Onderzoek</string>
-    <string name="vpn_exclude">Uitsluiten van vpn</string>
     <string name="uninstall">Deïnstalleren</string>
     <string name="settings_uninstall">App-instellingen &amp; deïnstalleren</string>
     <string name="no_trackers_found_message_disabled">Zet de schakelaar in het hoofdscherm op aan en start de app om trackers op te sporen</string>
@@ -463,4 +460,16 @@ Het internetverkeer wordt niet naar een externe VPN-server gestuurd.</string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Bescherming</string>
+    <string name="app_state_protected">Beschermd</string>
+    <string name="app_state_protected_explanation">Trackers worden voor deze app geblokkeerd en geregistreerd.</string>
+    <string name="app_state_trackers_allowed">Trackers toegestaan</string>
+    <string name="app_state_trackers_allowed_explanation">De app blijft via TrackerControl lopen, maar de trackers worden niet geblokkeerd en niet geregistreerd. Gebruik dit als blokkeren de app stukmaakt.</string>
+    <string name="app_state_no_internet">Geen internet</string>
+    <string name="app_state_no_internet_explanation">Alle verbindingen van deze app worden geblokkeerd. Je kunt ook op het app-pictogram in het hoofdscherm tikken.</string>
+    <string name="app_state_no_internet_shared_uid">Geldt ook voor %1$s, die een Android-gebruikers-ID deelt met deze app.</string>
+    <string name="app_state_bypassed">TrackerControl omzeilen</string>
+    <string name="app_state_bypassed_explanation">De app maakt rechtstreeks verbinding, buiten TrackerControl om. Er wordt niets voor gecontroleerd of geblokkeerd. Gebruik dit als laatste redmiddel als de app nog steeds niet werkt.\n\nLet op: \"Verbindingen zonder VPN blokkeren\" in de Android-VPN-instellingen moet UITGESCHAKELD zijn om dit te laten werken.</string>
 </resources>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -235,7 +235,6 @@ Internett-trafikken din blir ikke sendt til en ekstern VPN-server.</string>
     <string name="tab_countries">Land</string>
     <string name="tab_actions">Mine data</string>
     <string name="tracker_name">Sporernavn</string>
-    <string name="internet_access">Internett-tilgang</string>
     <string name="app_info">Behandle app</string>
     <!-- Actions -->
     <string name="block_tracking">Block sporere</string>
@@ -354,4 +353,16 @@ Vennlig hilsen,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Beskyttelse</string>
+    <string name="app_state_protected">Beskyttet</string>
+    <string name="app_state_protected_explanation">Sporere blokkeres og registreres for denne appen.</string>
+    <string name="app_state_trackers_allowed">Sporere tillatt</string>
+    <string name="app_state_trackers_allowed_explanation">Appen går fortsatt gjennom TrackerControl, men sporerne blir verken blokkert eller registrert. Bruk dette hvis blokkering ødelegger appen.</string>
+    <string name="app_state_no_internet">Ingen internett</string>
+    <string name="app_state_no_internet_explanation">Alle tilkoblinger fra denne appen blokkeres. Du kan også trykke på appikonet på hovedskjermen.</string>
+    <string name="app_state_no_internet_shared_uid">Gjelder også %1$s, som deler en Android-bruker-ID med denne appen.</string>
+    <string name="app_state_bypassed">Omgå TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Appen kobler til direkte, utenfor TrackerControl. Ingenting overvåkes eller blokkeres for den. Bruk dette som siste utvei hvis appen fortsatt ikke virker.\n\nMerk: \"Blokker tilkoblinger uten VPN\" i Androids VPN-innstillinger må være DEAKTIVERT for at dette skal virke.</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -243,7 +243,6 @@ Twój ruch internetowy nie jest wysyłany do zdalnego serwera VPN.</string>
     <string name="tab_countries">Kraje</string>
     <string name="tab_actions">Moje dane</string>
     <string name="tracker_name">Nazwa znacznika</string>
-    <string name="internet_access">Dostęp do internetu</string>
     <string name="app_info">Zarządzaj aplikacją</string>
     <!-- Actions -->
     <string name="block_tracking">Trackery blokowe</string>
@@ -362,4 +361,16 @@ Z poważaniem,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Ochrona</string>
+    <string name="app_state_protected">Chroniona</string>
+    <string name="app_state_protected_explanation">Trackery są blokowane i rejestrowane dla tej aplikacji.</string>
+    <string name="app_state_trackers_allowed">Trackery dozwolone</string>
+    <string name="app_state_trackers_allowed_explanation">Aplikacja nadal działa przez TrackerControl, ale jej trackery nie są ani blokowane, ani rejestrowane. Użyj tego, jeśli blokowanie psuje aplikację.</string>
+    <string name="app_state_no_internet">Brak Internetu</string>
+    <string name="app_state_no_internet_explanation">Wszystkie połączenia tej aplikacji są zablokowane. Możesz też dotknąć ikony aplikacji na ekranie głównym.</string>
+    <string name="app_state_no_internet_shared_uid">Dotyczy też %1$s, która współdzieli z tą aplikacją identyfikator użytkownika Androida.</string>
+    <string name="app_state_bypassed">Pomiń TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Aplikacja łączy się bezpośrednio, poza TrackerControl. Nic nie jest dla niej monitorowane ani blokowane. Użyj tego w ostateczności, jeśli aplikacja nadal nie działa.\n\nUwaga: opcja \"Blokuj połączenia bez VPN\" w ustawieniach VPN Androida musi być WYŁĄCZONA, aby to zadziałało.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -284,8 +284,6 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <string name="tab_countries">Países</string>
     <string name="tab_actions">Meus dados</string>
     <string name="tracker_name">Nome do rastreador</string>
-    <string name="internet_access">Acesso à Internet</string>
-    <string name="internet_access_explanation">Você também pode tocar no ícone do app na tela principal.</string>
     <string name="app_info">Gerenciar app</string>
     <!-- Actions -->
     <string name="block_tracking">Bloquear rastreadores</string>
@@ -346,9 +344,6 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <string name="onboarding_blockingmode_strict_desc">Bloqueia tudo, incluindo serviços essenciais e domínios ambíguos. Falhas significativas em aplicativos — muitos aplicativos precisarão ser excluídos manualmente.</string>
     <string name="onboarding_blockingmode_research_label">Pesquisa</string>
     <string name="onboarding_blockingmode_research_desc">Sem bloqueio do rastreador. Transmissões de logs para ADB e permite a extração SNI para melhor detecção de nome de host. Apenas pesquisa: isso vaza seu endereço IP para servidores de rastreadores.</string>
-    <string name="exclude_vpn_explanation">Detecta e bloqueia rastreadores para este app.</string>
-    <string name="vpn_exclude">Excluir da VPN</string>
-    <string name="vpn_exclude_explanation">Habilite se você se deparar com problemas. O aplicativo irá ignorar completamente o TrackerControl\n\nNota: \"Bloquear conexões sem VPN\" nas configurações de VPN do Android deve ser DESATIVADA para funcionar.</string>
     <string name="uninstall">Desinstalar</string>
     <string name="settings_uninstall">Configurações do app &amp; Desinstalar</string>
     <string name="no_trackers_found_message_disabled">Habilite o interruptor na tela principal e inicie o app para encontrar rastreadores</string>
@@ -454,4 +449,16 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <string name="msg_apply_blocklists_failed">Falha ao aplicar arquivos host</string>
     <string name="msg_last_update">Última atualização: %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Proteção</string>
+    <string name="app_state_protected">Protegido</string>
+    <string name="app_state_protected_explanation">Os rastreadores são bloqueados e registrados para este aplicativo.</string>
+    <string name="app_state_trackers_allowed">Rastreadores permitidos</string>
+    <string name="app_state_trackers_allowed_explanation">O aplicativo continua passando pelo TrackerControl, mas seus rastreadores não são bloqueados nem registrados. Use isto se o bloqueio quebrar o aplicativo.</string>
+    <string name="app_state_no_internet">Sem Internet</string>
+    <string name="app_state_no_internet_explanation">Todas as conexões deste aplicativo estão bloqueadas. Você também pode tocar no ícone do aplicativo na tela principal.</string>
+    <string name="app_state_no_internet_shared_uid">Também se aplica a %1$s, que compartilha um ID de usuário do Android com este aplicativo.</string>
+    <string name="app_state_bypassed">Ignorar o TrackerControl</string>
+    <string name="app_state_bypassed_explanation">O aplicativo se conecta diretamente, fora do TrackerControl. Nada é monitorado nem bloqueado para ele. Use isto como último recurso se o aplicativo ainda não funcionar.\n\nObservação: \"Bloquear conexões sem VPN\" nas configurações de VPN do Android precisa estar DESATIVADO para que isto funcione.</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -238,7 +238,6 @@ Seu tráfego de Internet não está sendo enviado para um servidor VPN remoto.</
     <string name="tab_countries">Países</string>
     <string name="tab_actions">Meus dados</string>
     <string name="tracker_name">Nome do Tracker</string>
-    <string name="internet_access">Acesso de Internet</string>
     <string name="app_info">Gerenciar o aplicativo</string>
     <!-- Actions -->
     <string name="block_tracking">Rastreadores de bloqueio</string>
@@ -330,4 +329,16 @@ disso,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Proteção</string>
+    <string name="app_state_protected">Protegida</string>
+    <string name="app_state_protected_explanation">Os rastreadores são bloqueados e registados para esta aplicação.</string>
+    <string name="app_state_trackers_allowed">Rastreadores permitidos</string>
+    <string name="app_state_trackers_allowed_explanation">A aplicação continua a passar pelo TrackerControl, mas os seus rastreadores não são bloqueados nem registados. Utilize isto se o bloqueio impedir a aplicação de funcionar.</string>
+    <string name="app_state_no_internet">Sem Internet</string>
+    <string name="app_state_no_internet_explanation">Todas as ligações desta aplicação estão bloqueadas. Também pode tocar no ícone da aplicação no ecrã principal.</string>
+    <string name="app_state_no_internet_shared_uid">Aplica-se também a %1$s, que partilha um ID de utilizador Android com esta aplicação.</string>
+    <string name="app_state_bypassed">Ignorar o TrackerControl</string>
+    <string name="app_state_bypassed_explanation">A aplicação liga-se diretamente, fora do TrackerControl. Nada é monitorizado nem bloqueado para ela. Utilize isto como último recurso se a aplicação continuar a não funcionar.\n\nNota: \"Bloquear ligações sem VPN\" nas definições de VPN do Android tem de estar DESATIVADO para que isto funcione.</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -73,4 +73,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protecție</string>
+    <string name="app_state_protected">Protejată</string>
+    <string name="app_state_protected_explanation">Urmăritorii sunt blocați și înregistrați pentru această aplicație.</string>
+    <string name="app_state_trackers_allowed">Urmăritori permiși</string>
+    <string name="app_state_trackers_allowed_explanation">Aplicația trece în continuare prin TrackerControl, dar urmăritorii ei nu sunt nici blocați, nici înregistrați. Folosiți această opțiune dacă blocarea strică aplicația.</string>
+    <string name="app_state_no_internet">Fără Internet</string>
+    <string name="app_state_no_internet_explanation">Toate conexiunile acestei aplicații sunt blocate. Puteți atinge și pictograma aplicației din ecranul principal.</string>
+    <string name="app_state_no_internet_shared_uid">Se aplică și pentru %1$s, care împarte un ID de utilizator Android cu această aplicație.</string>
+    <string name="app_state_bypassed">Ocolește TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Aplicația se conectează direct, în afara TrackerControl. Nimic nu este monitorizat sau blocat pentru ea. Folosiți această opțiune ca ultimă soluție dacă aplicația tot nu funcționează.\n\nNotă: \"Blochează conexiunile fără VPN\" din setările VPN Android trebuie să fie DEZACTIVAT pentru ca aceasta să funcționeze.</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -299,8 +299,6 @@
     <string name="tab_countries">Страны</string>
     <string name="tab_actions">Мои данные</string>
     <string name="tracker_name">Название трекера</string>
-    <string name="internet_access">Интернет-доступ</string>
-    <string name="internet_access_explanation">Вы также можете нажать на значок приложения на главном экране.</string>
     <string name="app_info">Управление приложением</string>
     <!-- Actions -->
     <string name="block_tracking">Блокировать трекеры</string>
@@ -364,9 +362,6 @@
     <string name="onboarding_blockingmode_strict_desc">Блокирует все, включая основные сервисы и неоднозначные домены. Значительные поломки приложений — многие приложения должны быть исключены вручную.</string>
     <string name="onboarding_blockingmode_research_label">Исследование</string>
     <string name="onboarding_blockingmode_research_desc">Нет блокировки трекера. Логирует передачу в ADB и позволяет извлекать SNI для лучшего определения имени хоста. Только для исследований: это позволяет утечь вашему IP-адреу на сервера трекера.</string>
-    <string name="exclude_vpn_explanation">Обнаружает и блокирует трекеры для этого приложения.</string>
-    <string name="vpn_exclude">Исключить из VPN</string>
-    <string name="vpn_exclude_explanation">Включите, если вы столкнулись с проблемами. Приложение полностью обходит TrackerControl.\n\nПримечание: «Блокировать соединения без VPN» в настройках Android VPN должен быть отключен, чтобы это работало.</string>
     <string name="uninstall">Удаление</string>
     <string name="settings_uninstall">Настройки приложения и деинсталляция</string>
     <string name="no_trackers_found_message_disabled">Включите переключатель на главном экране, затем запустите приложение, чтобы найти трекеры</string>
@@ -491,4 +486,16 @@
     <string name="msg_apply_blocklists_failed">Не удалось применить hosts файлы</string>
     <string name="msg_last_update">Последнее обновление: %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Защита</string>
+    <string name="app_state_protected">Защищено</string>
+    <string name="app_state_protected_explanation">Трекеры для этого приложения блокируются и записываются.</string>
+    <string name="app_state_trackers_allowed">Трекеры разрешены</string>
+    <string name="app_state_trackers_allowed_explanation">Приложение по-прежнему работает через TrackerControl, но его трекеры не блокируются и не записываются. Выберите этот вариант, если блокировка ломает приложение.</string>
+    <string name="app_state_no_internet">Без Интернета</string>
+    <string name="app_state_no_internet_explanation">Все соединения этого приложения заблокированы. Также можно нажать на значок приложения на главном экране.</string>
+    <string name="app_state_no_internet_shared_uid">Относится и к %1$s: это приложение использует общий с ним идентификатор пользователя Android.</string>
+    <string name="app_state_bypassed">В обход TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Приложение подключается напрямую, минуя TrackerControl. Для него ничего не отслеживается и не блокируется. Используйте это как крайнюю меру, если приложение по-прежнему не работает.\n\nПримечание: параметр \"Блокировать соединения без VPN\" в настройках VPN Android должен быть ОТКЛЮЧЁН, чтобы это работало.</string>
 </resources>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -415,8 +415,6 @@ Vaš internetni promet se ne pošilja na oddaljeni strežnik VPN.</string>
     <string name="tab_countries">Države</string>
     <string name="tab_actions">Moji podatki</string>
     <string name="tracker_name">Ime sledilca</string>
-    <string name="internet_access">Dostop do interneta</string>
-    <string name="internet_access_explanation">Lahko se tudi dotaknete ikone programa na glavnem zaslonu.</string>
     <string name="app_info">Upravljanje programa</string>
     <!-- Actions -->
     <string name="block_tracking">Blokiraj sledilce</string>
@@ -482,9 +480,6 @@ Vaš internetni promet se ne pošilja na oddaljeni strežnik VPN.</string>
     <string name="onboarding_blockingmode_strict_desc">Blokira vse, vključno z osnovnimi storitvami in nejasnimi domenami.  Delovanje nekaterih programov bo znatno prizadeto in jih boste morali ročno izključiti.</string>
     <string name="onboarding_blockingmode_research_label">Raziskovalno</string>
     <string name="onboarding_blockingmode_research_desc">Brez blokiranja sledilcev.  Beleži prenose v ADB in omogoči izločitev SNI za boljše zaznavanje gostiteljskih imen.  Samo za raziskave: to sledilnim strežnikom razkrije vaš naslov IP.</string>
-    <string name="exclude_vpn_explanation">Zazna in blokira sledilce za ta program.</string>
-    <string name="vpn_exclude">Izključi iz VPN-a</string>
-    <string name="vpn_exclude_explanation">Omogočite, če naletite na težave.  Program bo v celoti zaobšel TrackerControl.\n\nOpomba: Da bi to delovalo, morate v Androidovih nastavitvah VPN-a ONEMOGOČITI \"Blokiraj povezave brez VPN-a\".</string>
     <string name="uninstall">Odstrani</string>
     <string name="settings_uninstall">Nastavitve programa in odstranitev</string>
     <string name="no_trackers_found_message_disabled">Omogočite stikalo na glavnem zaslonu, nato zaženite program, da poiščete sledilce.</string>
@@ -613,4 +608,16 @@ Vaš internetni promet se ne pošilja na oddaljeni strežnik VPN.</string>
     <string name="msg_apply_blocklists_failed">Uporaba datotek z gostitelji je spodletela.</string>
     <string name="msg_last_update">Zadnja posodobitev: %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Zaščita</string>
+    <string name="app_state_protected">Zaščiteno</string>
+    <string name="app_state_protected_explanation">Sledilniki so za to aplikacijo blokirani in zabeleženi.</string>
+    <string name="app_state_trackers_allowed">Sledilniki dovoljeni</string>
+    <string name="app_state_trackers_allowed_explanation">Aplikacija še naprej teče prek TrackerControla, njeni sledilniki pa niso ne blokirani ne zabeleženi. Uporabite to, če blokiranje pokvari aplikacijo.</string>
+    <string name="app_state_no_internet">Brez interneta</string>
+    <string name="app_state_no_internet_explanation">Vse povezave te aplikacije so blokirane. Lahko se tudi dotaknete ikone aplikacije na glavnem zaslonu.</string>
+    <string name="app_state_no_internet_shared_uid">Velja tudi za %1$s, ki si s to aplikacijo deli Androidov ID uporabnika.</string>
+    <string name="app_state_bypassed">Obidi TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Aplikacija se poveže neposredno, mimo TrackerControla. Zanjo se nič ne spremlja in nič ne blokira. Uporabite to kot zadnjo možnost, če aplikacija še vedno ne deluje.\n\nOpomba: možnost \"Blokiraj povezave brez VPN\" v Androidovih nastavitvah VPN mora biti IZKLOPLJENA, da to deluje.</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -3,4 +3,16 @@
     <!-- App Overview -->
     <!-- App Details -->
     <!-- Actions -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Skydd</string>
+    <string name="app_state_protected">Skyddad</string>
+    <string name="app_state_protected_explanation">Spårare blockeras och registreras för den här appen.</string>
+    <string name="app_state_trackers_allowed">Spårare tillåts</string>
+    <string name="app_state_trackers_allowed_explanation">Appen fortsätter att gå via TrackerControl, men dess spårare varken blockeras eller registreras. Använd detta om blockeringen gör att appen slutar fungera.</string>
+    <string name="app_state_no_internet">Inget internet</string>
+    <string name="app_state_no_internet_explanation">Alla anslutningar från den här appen blockeras. Du kan även trycka på appikonen på huvudskärmen.</string>
+    <string name="app_state_no_internet_shared_uid">Gäller även %1$s, som delar ett Android-användar-ID med den här appen.</string>
+    <string name="app_state_bypassed">Förbigå TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Appen ansluter direkt, utanför TrackerControl. Ingenting övervakas eller blockeras för den. Använd detta som sista utväg om appen fortfarande inte fungerar.\n\nObs: \"Blockera anslutningar utan VPN\" i Androids VPN-inställningar måste vara INAKTIVERAT för att detta ska fungera.</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -12,4 +12,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">பாதுகாப்பு</string>
+    <string name="app_state_protected">பாதுகாக்கப்பட்டது</string>
+    <string name="app_state_protected_explanation">இந்த ஆப்ஸுக்கான டிராக்கர்கள் தடுக்கப்பட்டு பதிவு செய்யப்படுகின்றன.</string>
+    <string name="app_state_trackers_allowed">டிராக்கர்கள் அனுமதிக்கப்பட்டன</string>
+    <string name="app_state_trackers_allowed_explanation">ஆப்ஸ் தொடர்ந்து TrackerControl வழியாகச் செல்கிறது, ஆனால் அதன் டிராக்கர்கள் தடுக்கப்படுவதுமில்லை, பதிவு செய்யப்படுவதுமில்லை. தடுப்பதால் ஆப்ஸ் வேலை செய்யாவிட்டால் இதைப் பயன்படுத்தவும்.</string>
+    <string name="app_state_no_internet">இணையம் இல்லை</string>
+    <string name="app_state_no_internet_explanation">இந்த ஆப்ஸின் அனைத்து இணைப்புகளும் தடுக்கப்படுகின்றன. முதன்மைத் திரையில் ஆப்ஸ் ஐகானைத் தட்டியும் மாற்றலாம்.</string>
+    <string name="app_state_no_internet_shared_uid">இந்த ஆப்ஸுடன் Android பயனர் ஐடியைப் பகிர்ந்துகொள்ளும் %1$s-க்கும் இது பொருந்தும்.</string>
+    <string name="app_state_bypassed">TrackerControl-ஐத் தவிர்</string>
+    <string name="app_state_bypassed_explanation">ஆப்ஸ் TrackerControl-ஐத் தவிர்த்து நேரடியாக இணைகிறது. அதற்காக எதுவும் கண்காணிக்கப்படுவதோ தடுக்கப்படுவதோ இல்லை. ஆப்ஸ் இன்னும் வேலை செய்யாவிட்டால் கடைசி வழியாக இதைப் பயன்படுத்தவும்.\n\nகுறிப்பு: இது வேலை செய்ய Android VPN அமைப்புகளில் \"VPN இல்லாத இணைப்புகளைத் தடு\" முடக்கப்பட்டிருக்க வேண்டும்.</string>
 </resources>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -12,4 +12,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">రక్షణ</string>
+    <string name="app_state_protected">రక్షించబడింది</string>
+    <string name="app_state_protected_explanation">ఈ యాప్ కోసం ట్రాకర్‌లు నిరోధించబడతాయి మరియు రికార్డ్ చేయబడతాయి.</string>
+    <string name="app_state_trackers_allowed">ట్రాకర్‌లు అనుమతించబడ్డాయి</string>
+    <string name="app_state_trackers_allowed_explanation">యాప్ TrackerControl ద్వారానే కొనసాగుతుంది, కానీ దాని ట్రాకర్‌లు నిరోధించబడవు, రికార్డ్ చేయబడవు. నిరోధించడం వల్ల యాప్ పని చేయకపోతే దీన్ని ఉపయోగించండి.</string>
+    <string name="app_state_no_internet">ఇంటర్నెట్ లేదు</string>
+    <string name="app_state_no_internet_explanation">ఈ యాప్ యొక్క అన్ని కనెక్షన్‌లు నిరోధించబడ్డాయి. ప్రధాన స్క్రీన్‌లో యాప్ చిహ్నాన్ని కూడా నొక్కవచ్చు.</string>
+    <string name="app_state_no_internet_shared_uid">ఈ యాప్‌తో Android వినియోగదారు ID‌ను పంచుకునే %1$sకు కూడా ఇది వర్తిస్తుంది.</string>
+    <string name="app_state_bypassed">TrackerControlను దాటవేయి</string>
+    <string name="app_state_bypassed_explanation">యాప్ TrackerControl వెలుపల నేరుగా కనెక్ట్ అవుతుంది. దాని కోసం ఏదీ పర్యవేక్షించబడదు లేదా నిరోధించబడదు. యాప్ ఇప్పటికీ పని చేయకపోతే చివరి ప్రయత్నంగా దీన్ని ఉపయోగించండి.\n\nగమనిక: ఇది పని చేయాలంటే Android VPN సెట్టింగ్‌లలో \"VPN లేకుండా కనెక్షన్‌లను నిరోధించు\" నిలిపివేయబడాలి.</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -237,7 +237,6 @@ Bu nedenle, lütfen bir sonraki iletişim kutusunda bir VPN bağlantısına izin
     <string name="tab_countries">Ülkeler</string>
     <string name="tab_actions">Bilgilerim</string>
     <string name="tracker_name">İzleyici Adı</string>
-    <string name="internet_access">İnternet Erişimi</string>
     <string name="app_info">Uygulama Yönet</string>
     <!-- Actions -->
     <string name="block_tracking">İzleyicileri engelle</string>
@@ -356,4 +355,16 @@ Saygılarımla,\n\n]]></string>
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Koruma</string>
+    <string name="app_state_protected">Korunuyor</string>
+    <string name="app_state_protected_explanation">Bu uygulama için izleyiciler engelleniyor ve kaydediliyor.</string>
+    <string name="app_state_trackers_allowed">İzleyicilere izin ver</string>
+    <string name="app_state_trackers_allowed_explanation">Uygulama TrackerControl üzerinden çalışmaya devam eder, ancak izleyicileri ne engellenir ne de kaydedilir. Engelleme uygulamayı bozuyorsa bunu kullanın.</string>
+    <string name="app_state_no_internet">İnternet yok</string>
+    <string name="app_state_no_internet_explanation">Bu uygulamanın tüm bağlantıları engellendi. Ana ekrandaki uygulama simgesine de dokunabilirsiniz.</string>
+    <string name="app_state_no_internet_shared_uid">Bu uygulamayla Android kullanıcı kimliğini paylaşan %1$s için de geçerlidir.</string>
+    <string name="app_state_bypassed">TrackerControl\'ü atla</string>
+    <string name="app_state_bypassed_explanation">Uygulama, TrackerControl dışında doğrudan bağlanır. Onun için hiçbir şey izlenmez veya engellenmez. Uygulama hâlâ çalışmıyorsa son çare olarak bunu kullanın.\n\nNot: Bunun çalışması için Android VPN ayarlarındaki \"VPN olmadan bağlantıları engelle\" seçeneği KAPALI olmalıdır.</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -412,8 +412,6 @@
     <string name="tab_countries">Країни</string>
     <string name="tab_actions">Мої дані</string>
     <string name="tracker_name">Назва трекера</string>
-    <string name="internet_access">Доступ до Інтернету</string>
-    <string name="internet_access_explanation">Ви також можете натиснути на значок програми на головному екрані.</string>
     <string name="app_info">Керувати додатком</string>
     <!-- Actions -->
     <string name="block_tracking">Блокувати трекери</string>
@@ -513,9 +511,6 @@
     <string name="onboarding_blockingmode_strict_desc">Блокує все, включаючи важливі служби та неоднозначні домени. Значні пошкодження програм — багато програм потрібно буде виключити вручну.</string>
     <string name="onboarding_blockingmode_research_label">Дослідження</string>
     <string name="onboarding_blockingmode_research_desc">Не блокує трекери. Реєструє передачу даних до ADB та вмикає вилучення SNI для кращого виявлення імені хоста. Тільки для дослідницьких цілей: це призводить до витоку вашої IP-адреси на сервери трекерів.</string>
-    <string name="exclude_vpn_explanation">Виявляє та блокує трекери для цієї програми.</string>
-    <string name="vpn_exclude">Виключити з VPN</string>
-    <string name="vpn_exclude_explanation">Увімкніть, якщо виникнуть проблеми. Додаток повністю обійде TrackerControl.\n\nПримітка: щоб це працювало, у налаштуваннях VPN Android необхідно вимкнути опцію «Блокувати з\'єднання без VPN».</string>
     <string name="uninstall">Видалити</string>
     <string name="settings_uninstall">Налаштування Програми &amp; Видалення</string>
     <string name="no_trackers_found_message_disabled">Увімкніть перемикач на головному екрані, а потім запустіть додаток, щоб знайти трекери</string>
@@ -644,4 +639,16 @@
     <string name="msg_apply_blocklists_failed">Не вдалося застосувати файли хосту</string>
     <string name="msg_last_update">Останнє оновлення: %s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Захист</string>
+    <string name="app_state_protected">Захищено</string>
+    <string name="app_state_protected_explanation">Трекери для цього застосунку блокуються та записуються.</string>
+    <string name="app_state_trackers_allowed">Трекери дозволено</string>
+    <string name="app_state_trackers_allowed_explanation">Застосунок і далі працює через TrackerControl, але його трекери не блокуються й не записуються. Виберіть це, якщо блокування ламає застосунок.</string>
+    <string name="app_state_no_internet">Без Інтернету</string>
+    <string name="app_state_no_internet_explanation">Усі з\'єднання цього застосунку заблоковано. Також можна торкнутися значка застосунку на головному екрані.</string>
+    <string name="app_state_no_internet_shared_uid">Стосується також %1$s, який має спільний із цим застосунком ідентифікатор користувача Android.</string>
+    <string name="app_state_bypassed">Обійти TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Застосунок з\'єднується напряму, поза TrackerControl. Для нього нічого не відстежується й не блокується. Використовуйте це як останній засіб, якщо застосунок і далі не працює.\n\nПримітка: параметр \"Блокувати з\'єднання без VPN\" у налаштуваннях VPN Android має бути ВИМКНЕНИЙ, щоб це працювало.</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -294,7 +294,6 @@
     <string name="tab_countries">Quốc gia</string>
     <string name="tab_actions">Dữ liệu của tôi</string>
     <string name="tracker_name">Tên trình theo dõi</string>
-    <string name="internet_access">Truy cập Internet</string>
     <string name="app_info">Quản lý ứng dụng</string>
     <!-- Actions -->
     <string name="block_tracking">Chặn trình theo dõi</string>
@@ -375,4 +374,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Bảo vệ</string>
+    <string name="app_state_protected">Được bảo vệ</string>
+    <string name="app_state_protected_explanation">Trình theo dõi bị chặn và được ghi lại cho ứng dụng này.</string>
+    <string name="app_state_trackers_allowed">Cho phép trình theo dõi</string>
+    <string name="app_state_trackers_allowed_explanation">Ứng dụng vẫn đi qua TrackerControl, nhưng các trình theo dõi của nó không bị chặn và cũng không được ghi lại. Hãy dùng tuỳ chọn này nếu việc chặn làm hỏng ứng dụng.</string>
+    <string name="app_state_no_internet">Không có Internet</string>
+    <string name="app_state_no_internet_explanation">Mọi kết nối của ứng dụng này đều bị chặn. Bạn cũng có thể chạm vào biểu tượng ứng dụng ở màn hình chính.</string>
+    <string name="app_state_no_internet_shared_uid">Cũng áp dụng cho %1$s, ứng dụng dùng chung ID người dùng Android với ứng dụng này.</string>
+    <string name="app_state_bypassed">Bỏ qua TrackerControl</string>
+    <string name="app_state_bypassed_explanation">Ứng dụng kết nối trực tiếp, bên ngoài TrackerControl. Không có gì được giám sát hay chặn cho nó. Hãy dùng tuỳ chọn này như biện pháp cuối cùng nếu ứng dụng vẫn không hoạt động.\n\nLưu ý: \"Chặn kết nối khi không có VPN\" trong cài đặt VPN của Android phải được TẮT thì tuỳ chọn này mới hoạt động.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -408,8 +408,6 @@
     <string name="tab_countries">国家</string>
     <string name="tab_actions">我的数据</string>
     <string name="tracker_name">追踪器名称</string>
-    <string name="internet_access">互联网访问</string>
-    <string name="internet_access_explanation">您也可以点击主屏幕上的应用图标。</string>
     <string name="app_info">管理应用</string>
     <!-- Actions -->
     <string name="block_tracking">屏蔽追踪器</string>
@@ -508,9 +506,6 @@
     <string name="onboarding_blockingmode_strict_desc">屏蔽一切，包括基本服务和模糊域。严重的应用程序异常 — 需手动排除众多应用。</string>
     <string name="onboarding_blockingmode_research_label">研究</string>
     <string name="onboarding_blockingmode_research_desc">无跟踪器屏蔽。传输日志到 ADB 并允许提取SNI以更好地检测主机名。仅研究：这将泄漏您的 IP 地址到跟踪服务器。</string>
-    <string name="exclude_vpn_explanation">检测并阻止此应用的跟踪器。</string>
-    <string name="vpn_exclude">从 VPN 中排除</string>
-    <string name="vpn_exclude_explanation">如果您遇到问题，请启用。应用将完全绕过 TrackerControl。\n\n注意：在Android VPN 设置中\"屏蔽不使用VPN的所有连接\"必须禁用才能让这个选项正常工作。</string>
     <string name="uninstall">卸载</string>
     <string name="settings_uninstall">应用设置 &amp; 卸载</string>
     <string name="no_trackers_found_message_disabled">在主界面开启开关，然后启动应用寻找追踪器</string>
@@ -639,4 +634,16 @@
     <string name="msg_apply_blocklists_failed">应用主机文件失败</string>
     <string name="msg_last_update">上次更新：%s</string>
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">保护</string>
+    <string name="app_state_protected">已保护</string>
+    <string name="app_state_protected_explanation">为此应用拦截并记录跟踪器。</string>
+    <string name="app_state_trackers_allowed">允许跟踪器</string>
+    <string name="app_state_trackers_allowed_explanation">应用仍然通过 TrackerControl 联网，但其跟踪器既不被拦截也不被记录。如果拦截导致应用无法正常使用，可选择此项。</string>
+    <string name="app_state_no_internet">无网络</string>
+    <string name="app_state_no_internet_explanation">此应用的所有连接都会被拦截。你也可以在主界面点按应用图标。</string>
+    <string name="app_state_no_internet_shared_uid">同样适用于 %1$s，它与此应用共用同一个 Android 用户 ID。</string>
+    <string name="app_state_bypassed">绕过 TrackerControl</string>
+    <string name="app_state_bypassed_explanation">应用将绕过 TrackerControl 直接联网，不会对其进行任何监测或拦截。仅在应用仍然无法使用时作为最后手段使用。\n\n注意：必须在 Android 的 VPN 设置中停用\"屏蔽不使用 VPN 的连接\"，此项才能生效。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -126,7 +126,6 @@
     <string name="tab_countries">國家</string>
     <string name="tab_actions">我的資料</string>
     <string name="tracker_name">追蹤器名稱</string>
-    <string name="internet_access">網際網路連線</string>
     <string name="app_info">管理應用程式</string>
     <!-- Actions -->
     <string name="block_tracking">阻擋追蹤器</string>
@@ -165,4 +164,16 @@
     <!-- Insights Screen -->
     <!-- What's New onboarding slide (not translated) -->
     <!-- Accessibility labels -->
+
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">保護</string>
+    <string name="app_state_protected">已保護</string>
+    <string name="app_state_protected_explanation">為此應用程式封鎖並記錄追蹤器。</string>
+    <string name="app_state_trackers_allowed">允許追蹤器</string>
+    <string name="app_state_trackers_allowed_explanation">應用程式仍會經由 TrackerControl 連線，但其追蹤器既不會被封鎖也不會被記錄。若封鎖導致應用程式無法正常運作，請選擇此項。</string>
+    <string name="app_state_no_internet">無網際網路</string>
+    <string name="app_state_no_internet_explanation">此應用程式的所有連線都會被封鎖。你也可以在主畫面點按應用程式圖示。</string>
+    <string name="app_state_no_internet_shared_uid">同樣適用於 %1$s，它與此應用程式共用同一個 Android 使用者 ID。</string>
+    <string name="app_state_bypassed">略過 TrackerControl</string>
+    <string name="app_state_bypassed_explanation">應用程式會略過 TrackerControl 直接連線，不會對其進行任何監控或封鎖。僅在應用程式仍無法使用時作為最後手段使用。\n\n注意：必須在 Android 的 VPN 設定中停用\"封鎖不使用 VPN 的連線\"，此項才會生效。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -519,8 +519,6 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="tab_countries">Countries</string>
     <string name="tab_actions">My Data</string>
     <string name="tracker_name">Tracker Name</string>
-    <string name="internet_access">Internet Access</string>
-    <string name="internet_access_explanation">You can also tap the app icon in the main screen.</string>
     <string name="app_info">Manage App</string>
 
     <!-- Actions -->
@@ -633,10 +631,18 @@ Sincerely,\n\n]]></string>
     <string name="onboarding_blockingmode_research_label">Research</string>
     <string name="onboarding_blockingmode_research_desc">No tracker blocking. Logs transmissions to ADB and enables SNI extraction for better hostname detection. Research only: this leaks your IP address to tracker servers.</string>
 
-    <string name="exclude_vpn" translatable="false">Tracker Protection</string>
-    <string name="exclude_vpn_explanation">Detects and blocks trackers for this app.</string>
-    <string name="vpn_exclude">Exclude from VPN</string>
-    <string name="vpn_exclude_explanation">Enable if you run into issues. App will bypass TrackerControl completely.\n\nNote: \"Block connections without VPN\" in the Android VPN settings must be DISABLED for this to work.</string>
+    <!-- Per-app protection state -->
+    <string name="app_state_heading">Protection</string>
+    <string name="app_state_protected">Protected</string>
+    <string name="app_state_protected_explanation">Trackers are blocked and recorded for this app.</string>
+    <string name="app_state_trackers_allowed">Trackers allowed</string>
+    <string name="app_state_trackers_allowed_explanation">The app keeps running through TrackerControl, but its trackers are neither blocked nor recorded. Use this if blocking breaks the app.</string>
+    <string name="app_state_no_internet">No Internet</string>
+    <string name="app_state_no_internet_explanation">All connections from this app are blocked. You can also tap the app icon in the main screen.</string>
+    <string name="app_state_no_internet_explanation_shared" translatable="false">%1$s %2$s</string>
+    <string name="app_state_no_internet_shared_uid">Also applies to %1$s, which shares an Android user ID with this app.</string>
+    <string name="app_state_bypassed">Bypass TrackerControl</string>
+    <string name="app_state_bypassed_explanation">The app connects directly, outside TrackerControl. Nothing is monitored or blocked for it. Use this as a last resort if the app still does not work.\n\nNote: \"Block connections without VPN\" in the Android VPN settings must be DISABLED for this to work.</string>
     <string name="uninstall">Uninstall</string>
     <string name="settings_uninstall">App Settings &amp; Uninstall</string>
 

--- a/app/src/test/java/net/kollnig/missioncontrol/data/AppProtectionStateTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/AppProtectionStateTest.java
@@ -1,0 +1,143 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import net.kollnig.missioncontrol.data.AppProtectionState.Change;
+
+import org.junit.Test;
+
+public class AppProtectionStateTest {
+
+    @Test
+    public void defaultCombinationIsProtected() {
+        assertEquals(AppProtectionState.PROTECTED,
+                AppProtectionState.resolve(true, true, false));
+    }
+
+    @Test
+    public void protectionOffInsideTunnelIsTrackersAllowed() {
+        assertEquals(AppProtectionState.TRACKERS_ALLOWED,
+                AppProtectionState.resolve(true, false, false));
+    }
+
+    @Test
+    public void internetBlockWinsOverProtectionFlag() {
+        assertEquals(AppProtectionState.NO_INTERNET,
+                AppProtectionState.resolve(true, true, true));
+        assertEquals(AppProtectionState.NO_INTERNET,
+                AppProtectionState.resolve(true, false, true));
+    }
+
+    /**
+     * An excluded app is removed from the tun, so the per-UID internet block
+     * cannot be enforced for it; Bypass has to dominate.
+     */
+    @Test
+    public void bypassWinsOverEverything() {
+        for (boolean trackerProtect : new boolean[] { true, false })
+            for (boolean internetBlocked : new boolean[] { true, false })
+                assertEquals(AppProtectionState.BYPASSED,
+                        AppProtectionState.resolve(false, trackerProtect, internetBlocked));
+    }
+
+    /**
+     * XML import restores the three stores independently and never normalises
+     * them, so resolve() must be total over all eight inputs.
+     */
+    @Test
+    public void resolveIsTotalOverAllCombinations() {
+        int combinations = 0;
+        for (boolean apply : new boolean[] { true, false })
+            for (boolean trackerProtect : new boolean[] { true, false })
+                for (boolean internetBlocked : new boolean[] { true, false }) {
+                    assertNotNull(AppProtectionState.resolve(apply, trackerProtect, internetBlocked));
+                    combinations++;
+                }
+        assertEquals(8, combinations);
+    }
+
+    @Test
+    public void everyStateRoundTripsThroughItsChange() {
+        for (AppProtectionState state : AppProtectionState.values()) {
+            Change change = AppProtectionState.of(state);
+
+            // Worst case: apply the change on top of every possible prior state.
+            for (boolean priorProtect : new boolean[] { true, false })
+                for (boolean priorInternet : new boolean[] { true, false }) {
+                    boolean protect = change.trackerProtect == null
+                            ? priorProtect
+                            : change.trackerProtect;
+                    boolean internet = change.internetBlocked == null
+                            ? priorInternet
+                            : change.internetBlocked;
+                    assertEquals(state,
+                            AppProtectionState.resolve(change.apply, protect, internet));
+                }
+        }
+    }
+
+    @Test
+    public void noInternetKeepsTrackerProtectionChoice() {
+        Change change = AppProtectionState.of(AppProtectionState.NO_INTERNET);
+        assertNull(change.trackerProtect);
+        assertTrue(change.apply);
+        assertEquals(Boolean.TRUE, change.internetBlocked);
+    }
+
+    @Test
+    public void bypassTouchesOnlyApply() {
+        Change change = AppProtectionState.of(AppProtectionState.BYPASSED);
+        assertNull(change.trackerProtect);
+        assertNull(change.internetBlocked);
+    }
+
+    /**
+     * Leaving No-internet has to clear the block, otherwise the app would fall
+     * straight back into No-internet by precedence.
+     */
+    @Test
+    public void leavingNoInternetClearsTheBlock() {
+        assertEquals(Boolean.FALSE,
+                AppProtectionState.of(AppProtectionState.PROTECTED).internetBlocked);
+        assertEquals(Boolean.FALSE,
+                AppProtectionState.of(AppProtectionState.TRACKERS_ALLOWED).internetBlocked);
+    }
+
+    /**
+     * Browsers default to tracker protection off, so an untouched browser
+     * resolves to Trackers allowed while an ordinary app resolves to Protected.
+     * Selecting Protected writes the flag explicitly and overrides that default.
+     */
+    @Test
+    public void browserDefaultResolvesToTrackersAllowed() {
+        boolean browserDefault = BlockingMode.resolveTrackerProtection(true, null);
+        assertEquals(AppProtectionState.TRACKERS_ALLOWED,
+                AppProtectionState.resolve(true, browserDefault, false));
+
+        boolean ordinaryDefault = BlockingMode.resolveTrackerProtection(false, null);
+        assertEquals(AppProtectionState.PROTECTED,
+                AppProtectionState.resolve(true, ordinaryDefault, false));
+
+        Change change = AppProtectionState.of(AppProtectionState.PROTECTED);
+        boolean configuredBrowser = BlockingMode.resolveTrackerProtection(true, change.trackerProtect);
+        assertEquals(AppProtectionState.PROTECTED,
+                AppProtectionState.resolve(change.apply, configuredBrowser, false));
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
@@ -131,6 +131,55 @@ public class BlockingModeLogicTest {
                 BlockingModeLogic.clearAutoExcludedApp(Set.of("browser", "other"), "other"));
     }
 
+    /**
+     * The UI must keep an auto-excluded app in the managed set while it stays
+     * excluded, otherwise toggling it off and on again before the next mode
+     * switch silently converts a Minimal-mode auto-exclusion into a permanent
+     * one. This is the pre-sync window: syncVpnExclusions self-heals on the
+     * next mode switch, but only if membership survived until then.
+     */
+    @Test
+    public void reExcludedAutoExcludedAppStillRestoresOnModeSwitch() {
+        Map<String, Boolean> applyPrefs = new HashMap<>();
+        applyPrefs.put("incompatible", false);
+
+        // Membership is retained because the resulting apply is false.
+        Set<String> autoExcludedApps = Set.of("incompatible");
+
+        BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
+                BlockingModeLogic.MODE_STANDARD,
+                Set.of("incompatible"),
+                applyPrefs,
+                autoExcludedApps);
+
+        assertEquals(Set.of("incompatible"), result.applyRemovals);
+        assertTrue(result.autoExcludedApps.isEmpty());
+    }
+
+    /**
+     * Re-including an auto-excluded app does clear its membership, and the next
+     * sync must then leave the app alone rather than excluding it again.
+     */
+    @Test
+    public void reIncludedAutoExcludedAppIsNotExcludedAgain() {
+        Set<String> autoExcludedApps =
+                BlockingModeLogic.clearAutoExcludedApp(Set.of("incompatible"), "incompatible");
+        assertTrue(autoExcludedApps.isEmpty());
+
+        Map<String, Boolean> applyPrefs = new HashMap<>();
+        applyPrefs.put("incompatible", true);
+
+        BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
+                BlockingModeLogic.MODE_MINIMAL,
+                Set.of("incompatible"),
+                applyPrefs,
+                autoExcludedApps);
+
+        assertTrue(result.applyFalsePackages.isEmpty());
+        assertTrue(result.applyRemovals.isEmpty());
+        assertTrue(result.autoExcludedApps.isEmpty());
+    }
+
     @Test
     public void browserCategoryIsNotParsedAsVpnExclusion() {
         Set<String> excludedApps = BlockingModeLogic.parseExcludedAppsJson(


### PR DESCRIPTION
Exclude from VPN, Tracker Protection and Internet Access were three
booleans giving eight combinations of which only four are meaningful,
with the dependency structure invisible: when Exclude was on the other
two were inert but still rendered. Worse, in Minimal mode — the default,
and forced on Play — the Tracker Protection row only rendered for
browsers, so an ordinary app had no way to stay in the tunnel with
blocking turned off. The levers were "bypass TrackerControl entirely"
and "no internet at all".

Replace all three with one four-option radio group over the same three
stores, so no migration is needed: Protected, Trackers allowed, No
internet, Bypass TrackerControl. AppProtectionState.resolve() derives
the state and is total over all eight combinations, because the stores
are written by more actors than the two UI paths — bulk settings
actions, the beta vpn_exclude migration, mode exclusion sync and XML
import can all leave arbitrary combinations on disk. Bypass takes
precedence for a mechanical reason: an excluded app is handed to
addDisallowedApplication, so the per-UID internet block cannot be
enforced for it.

Two defects found while wiring this up:

The internet blocklist was only ever persisted from DetailsActivity's
onPause, so the main-list icon toggle never persisted at all and the
details screen tore on process death. InternetBlocklist now writes
through on block/unblock, with the onPause save kept as a backstop.
Uninstall cleanup also never dropped the UID's block, so a reinstall
came back silently blocked; it now does, once no package remains in
that UID.

clearAutoExcludedApp was called unconditionally from both UI paths, so
toggling an auto-excluded app off and on again converted a Minimal-mode
auto-exclusion into a permanent one. It is now gated on the resulting
apply being true, at those two sites only — the uninstall call site is
correct as it stands.

The main list read tracker protection differently from the details
screen (apply && tracker_protect outside Minimal, apply alone inside),
which denied the Internet toggle to any app with protection off. Both
now read the shared state model.

Copy is fresh for all four states and hand-translated into all 35
locales. It says trackers are neither blocked nor recorded, because
tracker_protect=false gates updateAccess as well as blockKnownTracker —
the old wording promised monitoring that does not happen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>