### PR TITLE
Route apps around the remote VPN without leaving TrackerControl

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library( netguard
              src/main/jni/netguard/netguard.c
              src/main/jni/netguard/session.c
              src/main/jni/netguard/ip.c
+             src/main/jni/netguard/route.c
              src/main/jni/netguard/tls.c
              src/main/jni/netguard/tcp.c
              src/main/jni/netguard/udp.c

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -896,6 +896,12 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         } else if ("wg_keepalive_when_screen_off".equals(name)) {
             ServiceSinkhole.reload("changed " + name, this, false);
 
+        } else if (Rule.PREF_WG_ROUTE_MODE.equals(name)) {
+            // The reload restarts the tunnel thread, which is what picks up the
+            // matching fwd53 change — that flag is only read at jni_run.
+            Rule.clearCache(this);
+            ServiceSinkhole.reload("changed " + name, this, false);
+
         } else if ("wg_config".equals(name)) {
             String wg_config = prefs.getString(name, null);
             boolean valid = true;
@@ -1257,6 +1263,10 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         xmlExport(getSharedPreferences("tracker_protect", Context.MODE_PRIVATE), serializer);
         serializer.endTag(null, "tracker_protect");
 
+        serializer.startTag(null, Rule.PREF_WG_ROUTE);
+        xmlExport(getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE), serializer);
+        serializer.endTag(null, Rule.PREF_WG_ROUTE);
+
         serializer.startTag(null, "notify");
         xmlExport(getSharedPreferences("notify", Context.MODE_PRIVATE), serializer);
         serializer.endTag(null, "notify");
@@ -1435,6 +1445,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         xmlImport(handler.application, prefs);
         xmlImport(handler.apply, getSharedPreferences("apply", Context.MODE_PRIVATE));
         xmlImport(handler.tracker_protect, getSharedPreferences("tracker_protect", Context.MODE_PRIVATE));
+        xmlImport(handler.wg_route, getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE));
         xmlImport(handler.notify, getSharedPreferences("notify", Context.MODE_PRIVATE));
         xmlImport(handler.blocklist, getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE));
 
@@ -1489,6 +1500,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         public Map<String, Object> roaming = new HashMap<>();
         public Map<String, Object> apply = new HashMap<>();
         public Map<String, Object> tracker_protect = new HashMap<>();
+        public Map<String, Object> wg_route = new HashMap<>();
         public Map<String, Object> notify = new HashMap<>();
         public Map<String, Object> blocklist = new HashMap<>();
         private Map<String, Object> current = null;
@@ -1528,6 +1540,8 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
             else if (qName.equals("tracker_protect"))
                 current = tracker_protect;
+            else if (qName.equals(Rule.PREF_WG_ROUTE))
+                current = wg_route;
 
             else if (qName.equals("notify"))
                 current = notify;

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -42,6 +42,7 @@ import net.kollnig.missioncontrol.Common;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.data.Pair;
 import net.kollnig.missioncontrol.data.BlockingMode;
+import net.kollnig.missioncontrol.data.RemoteRoutingLogic;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
 
@@ -59,6 +60,10 @@ import java.util.Map;
 
 public class Rule {
     private static final String TAG = "TrackerControl.Rule";
+    /** Per-package remote-routing overrides, mirroring "apply"/"tracker_protect". */
+    public static final String PREF_WG_ROUTE = "wg_route";
+    /** Global remote-routing mode, in the default shared preferences. */
+    public static final String PREF_WG_ROUTE_MODE = "wg_route_mode";
 
     public int uid;
     public String packageName;
@@ -84,6 +89,11 @@ public class Rule {
 
     public boolean apply = true; // If false, completely exclude from VPN (no DNS, no routing)
     public boolean tracker_protect = true; // If false, don't block trackers (but still route through VPN)
+    // Whether this app's traffic is forwarded through the remote VPN. Filtering
+    // and remote routing are independent choices (#723): an app can be fully
+    // monitored and blocked while still connecting from the device's own
+    // network. Resolved from the global mode plus an optional per-app override.
+    public boolean wg_route = true;
     public boolean notify = true;
 
     public boolean relateduids = false;
@@ -301,7 +311,10 @@ public class Rule {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
             SharedPreferences tracker_protect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+            SharedPreferences wg_route = context.getSharedPreferences(PREF_WG_ROUTE, Context.MODE_PRIVATE);
             SharedPreferences notify = context.getSharedPreferences("notify", Context.MODE_PRIVATE);
+            String wgRouteMode = RemoteRoutingLogic.normalizeMode(
+                    prefs.getString(PREF_WG_ROUTE_MODE, RemoteRoutingLogic.getDefaultMode()));
 
             // Get settings
             boolean manage_system = prefs.getBoolean("manage_system", false);
@@ -417,6 +430,12 @@ public class Rule {
                         rule.apply = apply.getBoolean(info.packageName, true);
                         rule.tracker_protect = BlockingMode.isTrackerProtectionEnabled(
                                 context, tracker_protect, info.packageName);
+                        rule.wg_route = RemoteRoutingLogic.routesThroughTunnel(
+                                wgRouteMode,
+                                wg_route.contains(info.packageName)
+                                        ? wg_route.getBoolean(info.packageName, true)
+                                        : null,
+                                rule.apply);
                         rule.notify = notify.getBoolean(info.packageName, true);
 
                         // Related packages
@@ -557,7 +576,11 @@ public class Rule {
 
             SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
             SharedPreferences tracker_protect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+            SharedPreferences wg_route = context.getSharedPreferences(PREF_WG_ROUTE, Context.MODE_PRIVATE);
             SharedPreferences notify = context.getSharedPreferences("notify", Context.MODE_PRIVATE);
+            String wgRouteMode = RemoteRoutingLogic.normalizeMode(
+                    PreferenceManager.getDefaultSharedPreferences(context)
+                            .getString(PREF_WG_ROUTE_MODE, RemoteRoutingLogic.getDefaultMode()));
 
             DatabaseHelper dh = DatabaseHelper.getInstance(context);
             for (PackageInfo info : getPackages(context))
@@ -570,6 +593,12 @@ public class Rule {
                     rule.apply = apply.getBoolean(info.packageName, true);
                     rule.tracker_protect = BlockingMode.isTrackerProtectionEnabled(
                             context, tracker_protect, info.packageName);
+                    rule.wg_route = RemoteRoutingLogic.routesThroughTunnel(
+                            wgRouteMode,
+                            wg_route.contains(info.packageName)
+                                    ? wg_route.getBoolean(info.packageName, true)
+                                    : null,
+                            rule.apply);
                     rule.notify = notify.getBoolean(info.packageName, true);
                     rule.updateChanged();
                     listStub.add(rule);

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -196,6 +196,9 @@ public class ServiceSinkhole extends VpnService {
     // Resolver used by apps routed around the remote tunnel. Null when the
     // system offers none, in which case their DNS stays in the tunnel.
     private String directDnsTarget = null;
+    // Whether any app is routed around the tunnel, which is what makes the
+    // extra per-query DNS cost worth paying.
+    private boolean anyDirectRouting = false;
     private final Map<IPKey, Map<InetAddress, IPRule>> mapUidIPFilters = new HashMap<>();
     private Map<Integer, Forward> mapForward = new HashMap<>();
     public static ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
@@ -1871,12 +1874,14 @@ public class ServiceSinkhole extends VpnService {
         final int rcode = Integer.parseInt(prefs.getString("rcode", "3"));
         // Port 53 is the only UDP traffic that skips the UID lookup entirely
         // today, so turning fwd53 on costs a lookup, a JNI upcall and a real
-        // UDP session per query. Only pay that where some app actually needs
-        // its DNS kept out of the tunnel.
+        // UDP session per query. Only pay that when some app actually is routed
+        // around the tunnel — which is a property of the resolved rules, not of
+        // the mode: a per-app override sends an app direct in either mode, and
+        // gating on the mode alone left such an app tunnelling its DNS while
+        // its traffic went direct, exactly the split the redirect exists to
+        // avoid.
         final boolean fwd53 = mapForward.containsKey(53)
-                || RemoteRoutingLogic.redirectDirectDns(
-                        prefs.getString(Rule.PREF_WG_ROUTE_MODE,
-                                RemoteRoutingLogic.getDefaultMode()));
+                || RemoteRoutingLogic.redirectDirectDns(anyDirectRouting);
         if (prefs.getBoolean("socks5_enabled", false))
             jni_socks5(
                     prefs.getString("socks5_addr", ""),
@@ -2010,6 +2015,7 @@ public class ServiceSinkhole extends VpnService {
             mapUidKnown.put(rule.uid, rule.uid);
 
         mapUidTunnel = mapUidTunnel(listRule);
+        anyDirectRouting = anyDirectRouting(listRule);
         // Util.getDefaultDNS does binder calls, so resolve it once per reload
         // rather than on the DNS path.
         directDnsTarget = resolveDirectDnsTarget();
@@ -2054,6 +2060,24 @@ public class ServiceSinkhole extends VpnService {
 
         Log.w(TAG, "No system DNS for direct apps; keeping their DNS in the tunnel");
         return null;
+    }
+
+    private static boolean anyDirectRouting(List<Rule> listRule) {
+        for (Rule rule : listRule)
+            if (rule.apply && !rule.wg_route)
+                return true;
+        return false;
+    }
+
+    /**
+     * Whether this UID is routed around the remote tunnel. Mirrors the native
+     * is_tunnel_uid: a UID with no rule of its own — unknown or system traffic
+     * — follows the global default rather than counting as "not tunnelled",
+     * which a bare mapUidTunnel lookup would wrongly report.
+     */
+    private boolean routesDirect(int uid) {
+        return RemoteRoutingLogic.routesDirect(
+                mapUidTunnel.contains(uid), mapUidKnown.containsKey(uid), defaultTunnel);
     }
 
     /** Hands the current routing decision to the packet path. */
@@ -2478,7 +2502,7 @@ public class ServiceSinkhole extends VpnService {
                     packet.data = "> " + fwd.raddr + "/" + fwd.rport;
                 }
             } else if (packet.dport == 53 && directDnsTarget != null
-                    && !mapUidTunnel.contains(packet.uid)) {
+                    && routesDirect(packet.uid)) {
                 // An app routed around the remote tunnel resolves against the
                 // underlying network instead of the tunnel's resolver. The
                 // redirect is transparent: replies are rebuilt from the

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -189,9 +189,9 @@ public class ServiceSinkhole extends VpnService {
     private static final Map<Network, Long> mapValidated = new ConcurrentHashMap<>();
     private Map<Integer, Boolean> mapUidAllowed = new HashMap<>();
     private Map<Integer, Integer> mapUidKnown = new HashMap<>();
-    // UIDs forwarded through the remote WireGuard tunnel. Pushed down to the
+    // UIDs whose routing differs from the global default. Pushed down to the
     // packet path as a sorted array; unlisted UIDs follow the global default.
-    private Set<Integer> mapUidTunnel = new HashSet<>();
+    private Set<Integer> mapUidRouteOverride = new HashSet<>();
     private boolean defaultTunnel = true;
     // Resolver used by apps routed around the remote tunnel. Null when the
     // system offers none, in which case their DNS stays in the tunnel.
@@ -311,12 +311,14 @@ public class ServiceSinkhole extends VpnService {
     private native void jni_wireguard_required(boolean required);
 
     /**
-     * Pushes the set of UIDs routed through the remote tunnel down to the
-     * packet path, plus the default applied to every UID not in the set
-     * (unknown UIDs and system traffic). Java writes this while the tunnel
-     * thread reads it, so the native side guards it with its own lock.
+     * Pushes the set of UIDs whose routing differs from the global default down
+     * to the packet path, plus that default (applied to every UID not in the
+     * set — unknown UIDs and system traffic included) and whether direct apps'
+     * DNS is redirected to the system resolver rather than always taking the
+     * tunnel. Java writes this while the tunnel thread reads it, so the native
+     * side guards it with its own lock.
      */
-    private native void jni_wireguard_route(int[] tunnelUids, boolean defaultTunnel);
+    private native void jni_wireguard_route(int[] overrideUids, boolean defaultTunnel, boolean dnsDirect);
 
     private native void jni_done(long context);
 
@@ -2014,33 +2016,46 @@ public class ServiceSinkhole extends VpnService {
         for (Rule rule : listRule)
             mapUidKnown.put(rule.uid, rule.uid);
 
-        mapUidTunnel = mapUidTunnel(listRule);
-        anyDirectRouting = anyDirectRouting(listRule);
-        // Util.getDefaultDNS does binder calls, so resolve it once per reload
-        // rather than on the DNS path.
-        directDnsTarget = resolveDirectDnsTarget();
         defaultTunnel = RemoteRoutingLogic.defaultTunnel(
                 RemoteRoutingLogic.normalizeMode(
                         PreferenceManager.getDefaultSharedPreferences(this)
                                 .getString(Rule.PREF_WG_ROUTE_MODE,
                                         RemoteRoutingLogic.getDefaultMode())));
+        mapUidRouteOverride = mapUidRouteOverride(listRule, defaultTunnel);
+        anyDirectRouting = anyDirectRouting(listRule);
+        // Util.getDefaultDNS does binder calls, so resolve it once per reload
+        // rather than on the DNS path.
+        directDnsTarget = resolveDirectDnsTarget();
 
         lock.writeLock().unlock();
     }
 
     /**
-     * The UIDs whose traffic goes through the remote tunnel.
+     * The UIDs whose routing differs from the global default.
      * <p>
      * A shared UID is tunnelled if any of its packages is: the packet path only
      * ever sees the UID, so the finer per-package answer cannot be honoured and
      * the more private of the two is the right way to round.
+     * <p>
+     * Bypassed apps are skipped rather than counted as direct. They are handed
+     * to {@code addDisallowedApplication}, so no packet of theirs ever reaches
+     * the tun — listing them would put an entry in the override set for every
+     * bypassed app and defeat the empty-set fast path for no benefit.
      */
-    private static Set<Integer> mapUidTunnel(List<Rule> listRule) {
-        Set<Integer> tunnel = new HashSet<>();
-        for (Rule rule : listRule)
-            if (rule.wg_route)
-                tunnel.add(rule.uid);
-        return tunnel;
+    private static Set<Integer> mapUidRouteOverride(List<Rule> listRule, boolean defaultTunnel) {
+        Map<Integer, Boolean> tunnelByUid = new HashMap<>();
+        for (Rule rule : listRule) {
+            if (!rule.apply)
+                continue;
+            Boolean current = tunnelByUid.get(rule.uid);
+            tunnelByUid.put(rule.uid, (current != null && current) || rule.wg_route);
+        }
+
+        Set<Integer> overrides = new HashSet<>();
+        for (Map.Entry<Integer, Boolean> entry : tunnelByUid.entrySet())
+            if (RemoteRoutingLogic.isRouteOverride(entry.getValue(), defaultTunnel))
+                overrides.add(entry.getKey());
+        return overrides;
     }
 
     /**
@@ -2071,26 +2086,27 @@ public class ServiceSinkhole extends VpnService {
 
     /**
      * Whether this UID is routed around the remote tunnel. Mirrors the native
-     * is_tunnel_uid: a UID with no rule of its own — unknown or system traffic
-     * — follows the global default rather than counting as "not tunnelled",
-     * which a bare mapUidTunnel lookup would wrongly report.
+     * is_tunnel_uid: a UID absent from the override set follows the global
+     * default rather than counting as "not tunnelled", which a bare
+     * mapUidRouteOverride lookup would wrongly report.
      */
     private boolean routesDirect(int uid) {
         return RemoteRoutingLogic.routesDirect(
-                mapUidTunnel.contains(uid), mapUidKnown.containsKey(uid), defaultTunnel);
+                mapUidRouteOverride.contains(uid), defaultTunnel);
     }
 
     /** Hands the current routing decision to the packet path. */
     private void pushRoutingToNative() {
         lock.readLock().lock();
-        int[] uids = new int[mapUidTunnel.size()];
+        int[] uids = new int[mapUidRouteOverride.size()];
         int i = 0;
-        for (Integer uid : mapUidTunnel)
+        for (Integer uid : mapUidRouteOverride)
             uids[i++] = uid;
         boolean defaults = defaultTunnel;
+        boolean dnsDirect = RemoteRoutingLogic.redirectDirectDns(anyDirectRouting);
         lock.readLock().unlock();
 
-        jni_wireguard_route(uids, defaults);
+        jni_wireguard_route(uids, defaults, dnsDirect);
     }
 
     public static void prepareHostsBlocked(Context c) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -87,6 +87,7 @@ import net.kollnig.missioncontrol.analysis.TrackerAnalysisManager;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.BlockingModeLogic;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
+import net.kollnig.missioncontrol.data.RemoteRoutingLogic;
 import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
@@ -111,10 +112,12 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -186,6 +189,13 @@ public class ServiceSinkhole extends VpnService {
     private static final Map<Network, Long> mapValidated = new ConcurrentHashMap<>();
     private Map<Integer, Boolean> mapUidAllowed = new HashMap<>();
     private Map<Integer, Integer> mapUidKnown = new HashMap<>();
+    // UIDs forwarded through the remote WireGuard tunnel. Pushed down to the
+    // packet path as a sorted array; unlisted UIDs follow the global default.
+    private Set<Integer> mapUidTunnel = new HashSet<>();
+    private boolean defaultTunnel = true;
+    // Resolver used by apps routed around the remote tunnel. Null when the
+    // system offers none, in which case their DNS stays in the tunnel.
+    private String directDnsTarget = null;
     private final Map<IPKey, Map<InetAddress, IPRule>> mapUidIPFilters = new HashMap<>();
     private Map<Integer, Forward> mapForward = new HashMap<>();
     public static ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
@@ -296,6 +306,14 @@ public class ServiceSinkhole extends VpnService {
      *  running (restart window, failed start) hijack-eligible traffic is
      *  dropped instead of forwarded directly, so restarts never leak. */
     private native void jni_wireguard_required(boolean required);
+
+    /**
+     * Pushes the set of UIDs routed through the remote tunnel down to the
+     * packet path, plus the default applied to every UID not in the set
+     * (unknown UIDs and system traffic). Java writes this while the tunnel
+     * thread reads it, so the native side guards it with its own lock.
+     */
+    private native void jni_wireguard_route(int[] tunnelUids, boolean defaultTunnel);
 
     private native void jni_done(long context);
 
@@ -1851,6 +1869,14 @@ public class ServiceSinkhole extends VpnService {
 
         int prio = Integer.parseInt(prefs.getString("loglevel", Integer.toString(Log.WARN)));
         final int rcode = Integer.parseInt(prefs.getString("rcode", "3"));
+        // Port 53 is the only UDP traffic that skips the UID lookup entirely
+        // today, so turning fwd53 on costs a lookup, a JNI upcall and a real
+        // UDP session per query. Only pay that where some app actually needs
+        // its DNS kept out of the tunnel.
+        final boolean fwd53 = mapForward.containsKey(53)
+                || RemoteRoutingLogic.redirectDirectDns(
+                        prefs.getString(Rule.PREF_WG_ROUTE_MODE,
+                                RemoteRoutingLogic.getDefaultMode()));
         if (prefs.getBoolean("socks5_enabled", false))
             jni_socks5(
                     prefs.getString("socks5_addr", ""),
@@ -1861,6 +1887,7 @@ public class ServiceSinkhole extends VpnService {
             jni_socks5("", 0, "", "");
 
         jni_sni(prefs.getBoolean("sni_enabled", false));
+        pushRoutingToNative();
         updateUnderlyingNetworks();
 
         // WireGuard egress. startOrUpdate is idempotent: same config +
@@ -1898,7 +1925,7 @@ public class ServiceSinkhole extends VpnService {
                 @Override
                 public void run() {
                     Log.i(TAG, "Running tunnel context=" + jni_context);
-                    jni_run(jni_context, vpn.getFd(), mapForward.containsKey(53), rcode);
+                    jni_run(jni_context, vpn.getFd(), fwd53, rcode);
                     Log.i(TAG, "Tunnel exited");
                     tunnelThread = null;
                 }
@@ -1982,7 +2009,64 @@ public class ServiceSinkhole extends VpnService {
         for (Rule rule : listRule)
             mapUidKnown.put(rule.uid, rule.uid);
 
+        mapUidTunnel = mapUidTunnel(listRule);
+        // Util.getDefaultDNS does binder calls, so resolve it once per reload
+        // rather than on the DNS path.
+        directDnsTarget = resolveDirectDnsTarget();
+        defaultTunnel = RemoteRoutingLogic.defaultTunnel(
+                RemoteRoutingLogic.normalizeMode(
+                        PreferenceManager.getDefaultSharedPreferences(this)
+                                .getString(Rule.PREF_WG_ROUTE_MODE,
+                                        RemoteRoutingLogic.getDefaultMode())));
+
         lock.writeLock().unlock();
+    }
+
+    /**
+     * The UIDs whose traffic goes through the remote tunnel.
+     * <p>
+     * A shared UID is tunnelled if any of its packages is: the packet path only
+     * ever sees the UID, so the finer per-package answer cannot be honoured and
+     * the more private of the two is the right way to round.
+     */
+    private static Set<Integer> mapUidTunnel(List<Rule> listRule) {
+        Set<Integer> tunnel = new HashSet<>();
+        for (Rule rule : listRule)
+            if (rule.wg_route)
+                tunnel.add(rule.uid);
+        return tunnel;
+    }
+
+    /**
+     * The system resolver for apps routed around the remote tunnel.
+     * <p>
+     * With the tunnel up, the tun advertises the tunnel's own resolvers, which
+     * a direct app may not be able to reach at all. Redirecting its queries to
+     * the underlying network's resolver is what makes direct routing work when
+     * the tunnel drops — at the cost, stated in the UI, of that app's DNS being
+     * visible to its local network rather than to the VPN provider.
+     */
+    private String resolveDirectDnsTarget() {
+        List<String> sysDns = Util.getDefaultDNS(ServiceSinkhole.this);
+        for (String dns : sysDns)
+            if (!TextUtils.isEmpty(dns))
+                return dns;
+
+        Log.w(TAG, "No system DNS for direct apps; keeping their DNS in the tunnel");
+        return null;
+    }
+
+    /** Hands the current routing decision to the packet path. */
+    private void pushRoutingToNative() {
+        lock.readLock().lock();
+        int[] uids = new int[mapUidTunnel.size()];
+        int i = 0;
+        for (Integer uid : mapUidTunnel)
+            uids[i++] = uid;
+        boolean defaults = defaultTunnel;
+        lock.readLock().unlock();
+
+        jni_wireguard_route(uids, defaults);
     }
 
     public static void prepareHostsBlocked(Context c) {
@@ -2393,6 +2477,13 @@ public class ServiceSinkhole extends VpnService {
                     allowed = new Allowed(fwd.raddr, fwd.rport);
                     packet.data = "> " + fwd.raddr + "/" + fwd.rport;
                 }
+            } else if (packet.dport == 53 && directDnsTarget != null
+                    && !mapUidTunnel.contains(packet.uid)) {
+                // An app routed around the remote tunnel resolves against the
+                // underlying network instead of the tunnel's resolver. The
+                // redirect is transparent: replies are rebuilt from the
+                // session's original addresses, so the app never sees it.
+                allowed = new Allowed(directDnsTarget, 53);
             } else
                 allowed = new Allowed();
 
@@ -2919,6 +3010,7 @@ public class ServiceSinkhole extends VpnService {
                 context.getSharedPreferences("apply", Context.MODE_PRIVATE).edit().remove(packageName).apply();
                 BlockingMode.clearAutoExcludedApp(context, packageName);
                 context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE).edit().remove(packageName).apply();
+                context.getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE).edit().remove(packageName).apply();
                 context.getSharedPreferences("notify", Context.MODE_PRIVATE).edit().remove(packageName).apply();
 
                 int uid = intent.getIntExtra(Intent.EXTRA_UID, 0);

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1876,14 +1876,15 @@ public class ServiceSinkhole extends VpnService {
         final int rcode = Integer.parseInt(prefs.getString("rcode", "3"));
         // Port 53 is the only UDP traffic that skips the UID lookup entirely
         // today, so turning fwd53 on costs a lookup, a JNI upcall and a real
-        // UDP session per query. Only pay that when some app actually is routed
-        // around the tunnel — which is a property of the resolved rules, not of
-        // the mode: a per-app override sends an app direct in either mode, and
-        // gating on the mode alone left such an app tunnelling its DNS while
-        // its traffic went direct, exactly the split the redirect exists to
-        // avoid.
+        // UDP session per query. Only pay that when some app is routed around
+        // the tunnel and a non-null underlying resolver target is available —
+        // which are both properties of the resolved rules, not of the mode: a
+        // per-app override sends an app direct in either mode, and gating on
+        // the mode alone left such an app tunnelling its DNS while its traffic
+        // went direct, exactly the split the redirect exists to avoid.
         final boolean fwd53 = mapForward.containsKey(53)
-                || RemoteRoutingLogic.redirectDirectDns(anyDirectRouting);
+                || RemoteRoutingLogic.redirectDirectDns(anyDirectRouting,
+                        directDnsTarget != null);
         if (prefs.getBoolean("socks5_enabled", false))
             jni_socks5(
                     prefs.getString("socks5_addr", ""),
@@ -2103,7 +2104,8 @@ public class ServiceSinkhole extends VpnService {
         for (Integer uid : mapUidRouteOverride)
             uids[i++] = uid;
         boolean defaults = defaultTunnel;
-        boolean dnsDirect = RemoteRoutingLogic.redirectDirectDns(anyDirectRouting);
+        boolean dnsDirect = RemoteRoutingLogic.redirectDirectDns(anyDirectRouting,
+                directDnsTarget != null);
         lock.readLock().unlock();
 
         jni_wireguard_route(uids, defaults, dnsDirect);

--- a/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
@@ -108,13 +108,15 @@ public final class RemoteRoutingLogic {
      * <p>
      * Turning this on makes every DNS query cost a UID lookup, an
      * isAddressAllowed upcall and a real UDP session — today port 53 skips all
-     * three. It is therefore only enabled once some app actually is routed
-     * around the tunnel, so everyone else keeps the existing zero-cost DNS
-     * path. Note this is a property of the resolved rules, not of the mode: a
-     * per-app override sends an app direct in either mode.
+     * three. It is therefore only enabled once some app is routed around the
+     * tunnel and a non-null underlying resolver target is available, so
+     * everyone else keeps the existing zero-cost DNS path. Note this is a
+     * property of the resolved rules, not of the mode: a per-app override
+     * sends an app direct in either mode.
      */
-    public static boolean redirectDirectDns(boolean anyAppRoutedDirect) {
-        return anyAppRoutedDirect;
+    public static boolean redirectDirectDns(boolean anyAppRoutedDirect,
+            boolean resolverTargetAvailable) {
+        return anyAppRoutedDirect && resolverTargetAvailable;
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
@@ -108,12 +108,33 @@ public final class RemoteRoutingLogic {
      * <p>
      * Turning this on makes every DNS query cost a UID lookup, an
      * isAddressAllowed upcall and a real UDP session — today port 53 skips all
-     * three. It is therefore only enabled when some app actually needs its DNS
-     * kept out of the tunnel, so users of the default mode keep the existing
-     * zero-cost DNS path.
+     * three. It is therefore only enabled once some app actually is routed
+     * around the tunnel, so everyone else keeps the existing zero-cost DNS
+     * path. Note this is a property of the resolved rules, not of the mode: a
+     * per-app override sends an app direct in either mode.
      */
-    public static boolean redirectDirectDns(String mode) {
-        return MODE_SELECTED.equals(normalizeMode(mode));
+    public static boolean redirectDirectDns(boolean anyAppRoutedDirect) {
+        return anyAppRoutedDirect;
+    }
+
+    /**
+     * Whether one UID's traffic leaves outside the tunnel, mirroring the native
+     * is_tunnel_uid.
+     * <p>
+     * A UID with no rule of its own — unknown or system traffic — follows the
+     * global default. Treating it as "not tunnelled" merely because it is
+     * absent from the tunnelled set would quietly route system traffic direct.
+     *
+     * @param inTunnelSet   whether the UID is in the tunnelled set
+     * @param known         whether any installed app maps to this UID
+     * @param defaultTunnel the global default for unlisted UIDs
+     */
+    public static boolean routesDirect(boolean inTunnelSet, boolean known, boolean defaultTunnel) {
+        if (inTunnelSet)
+            return false;
+        if (known)
+            return true;
+        return !defaultTunnel;
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
@@ -1,0 +1,151 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+/**
+ * Decides which apps are forwarded through the remote WireGuard tunnel.
+ * <p>
+ * Whether an app is <em>filtered</em> by TrackerControl and whether it is
+ * <em>forwarded through the remote VPN</em> are independent choices. Before
+ * this existed the only way to keep an app off the remote tunnel was to
+ * exclude it from the VPN altogether, which also dropped local monitoring and
+ * blocking (#723).
+ * <p>
+ * Pure helpers, no Android dependencies, so the decision table is JVM-testable
+ * — the native packet path has no test harness at all.
+ */
+public final class RemoteRoutingLogic {
+    /** Every app goes through the remote tunnel. The shipped default. */
+    public static final String MODE_ALL = "all";
+    /** Only apps with an explicit per-app override go through the tunnel. */
+    public static final String MODE_SELECTED = "selected";
+
+    private RemoteRoutingLogic() {
+    }
+
+    public static String getDefaultMode() {
+        return MODE_ALL;
+    }
+
+    public static String normalizeMode(String mode) {
+        return MODE_SELECTED.equals(mode) ? MODE_SELECTED : MODE_ALL;
+    }
+
+    /**
+     * Whether unknown-UID and system traffic takes the tunnel. In
+     * {@link #MODE_ALL} this is true, which makes the whole feature a no-op
+     * against the behaviour that shipped before it.
+     */
+    public static boolean defaultTunnel(String mode) {
+        return !MODE_SELECTED.equals(normalizeMode(mode));
+    }
+
+    /**
+     * Whether one app is routed through the remote tunnel.
+     *
+     * @param mode     the global routing mode
+     * @param override the per-app override, or {@code null} when unset
+     * @param apply    the app's "apply" preference; a bypassed app is outside
+     *                 the tun entirely, so it has no routing to decide
+     */
+    public static boolean routesThroughTunnel(String mode, Boolean override, boolean apply) {
+        if (!apply)
+            return false;
+
+        if (override != null)
+            return override;
+
+        return defaultTunnel(mode);
+    }
+
+    /**
+     * Whether the per-app routing control should be offered at all.
+     * <p>
+     * Routes come from the tunnel's AllowedIPs, and they are a property of the
+     * one tun every app shares — narrowing them to route some apps around the
+     * tunnel would shrink them for the tunnelled apps too. v1 therefore only
+     * offers the control for a default-route tunnel. gotatun silently drops
+     * packets whose destination matches no peer's AllowedIPs, so a narrower
+     * tunnel would blackhole traffic rather than fail visibly.
+     *
+     * @param wgEnabled     whether remote egress is configured and on
+     * @param defaultRoutes whether AllowedIPs covers 0.0.0.0/0 (and ::/0 when
+     *                      IPv6 is enabled)
+     * @param apply         the app's "apply" preference
+     */
+    public static boolean isControlAvailable(boolean wgEnabled, boolean defaultRoutes, boolean apply) {
+        return wgEnabled && defaultRoutes && apply;
+    }
+
+    /**
+     * Why the control is unavailable, for the explanation shown in its place.
+     */
+    public static Unavailable getUnavailableReason(boolean wgEnabled, boolean defaultRoutes,
+            boolean apply) {
+        if (!wgEnabled)
+            return Unavailable.NO_REMOTE_VPN;
+        if (!apply)
+            return Unavailable.BYPASSED;
+        if (!defaultRoutes)
+            return Unavailable.PARTIAL_ROUTES;
+        return null;
+    }
+
+    /**
+     * Whether direct apps' DNS is redirected to the system resolver.
+     * <p>
+     * Turning this on makes every DNS query cost a UID lookup, an
+     * isAddressAllowed upcall and a real UDP session — today port 53 skips all
+     * three. It is therefore only enabled when some app actually needs its DNS
+     * kept out of the tunnel, so users of the default mode keep the existing
+     * zero-cost DNS path.
+     */
+    public static boolean redirectDirectDns(String mode) {
+        return MODE_SELECTED.equals(normalizeMode(mode));
+    }
+
+    /**
+     * Whether the tunnel's AllowedIPs is a default route.
+     * <p>
+     * Routes are a property of the single tun every app shares, so a narrower
+     * AllowedIPs shrinks them for directly-routed apps too. v1 therefore only
+     * offers per-app routing for a full-tunnel config.
+     *
+     * @param allowedIps the union of every peer's AllowedIPs
+     * @param ip6        whether IPv6 is enabled, in which case ::/0 is required too
+     */
+    public static boolean hasDefaultRoutes(java.util.List<String> allowedIps, boolean ip6) {
+        boolean v4 = false;
+        boolean v6 = false;
+        for (String allowedIp : allowedIps) {
+            String trimmed = allowedIp == null ? "" : allowedIp.trim();
+            if ("0.0.0.0/0".equals(trimmed))
+                v4 = true;
+            else if ("::/0".equals(trimmed))
+                v6 = true;
+        }
+
+        return v4 && (!ip6 || v6);
+    }
+
+    public enum Unavailable {
+        /** No remote VPN is configured or enabled. */
+        NO_REMOTE_VPN,
+        /** The app bypasses TrackerControl, so it is outside the tun. */
+        BYPASSED,
+        /** The tunnel's AllowedIPs is not a default route. */
+        PARTIAL_ROUTES
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/RemoteRoutingLogic.java
@@ -23,8 +23,8 @@ package net.kollnig.missioncontrol.data;
  * exclude it from the VPN altogether, which also dropped local monitoring and
  * blocking (#723).
  * <p>
- * Pure helpers, no Android dependencies, so the decision table is JVM-testable
- * — the native packet path has no test harness at all.
+ * Pure helpers mirroring the native routing decision, no Android dependencies,
+ * kept JVM-testable so the decision table is covered by unit tests.
  */
 public final class RemoteRoutingLogic {
     /** Every app goes through the remote tunnel. The shipped default. */
@@ -118,23 +118,33 @@ public final class RemoteRoutingLogic {
     }
 
     /**
+     * Whether a UID whose routing differs from the global default should be
+     * pushed to the packet path.
+     * <p>
+     * Only the exceptions are pushed, never the whole tunnelled set: with no
+     * per-app override the set is then empty, which is what lets the packet
+     * path skip the UID lookup entirely. Pushing every tunnelled UID instead
+     * made the default mode — where every applied app is tunnelled — look
+     * indistinguishable from a heavily-overridden one.
+     */
+    public static boolean isRouteOverride(boolean tunnelled, boolean defaultTunnel) {
+        return tunnelled != defaultTunnel;
+    }
+
+    /**
      * Whether one UID's traffic leaves outside the tunnel, mirroring the native
      * is_tunnel_uid.
      * <p>
-     * A UID with no rule of its own — unknown or system traffic — follows the
-     * global default. Treating it as "not tunnelled" merely because it is
-     * absent from the tunnelled set would quietly route system traffic direct.
+     * A UID absent from the override set follows the global default, whatever
+     * it is. That includes system traffic and UIDs belonging to no installed
+     * app, which is what makes the default mode identical to the behaviour
+     * before per-app routing existed.
      *
-     * @param inTunnelSet   whether the UID is in the tunnelled set
-     * @param known         whether any installed app maps to this UID
-     * @param defaultTunnel the global default for unlisted UIDs
+     * @param inOverrideSet whether the UID's routing differs from the default
+     * @param defaultTunnel the global default
      */
-    public static boolean routesDirect(boolean inTunnelSet, boolean known, boolean defaultTunnel) {
-        if (inTunnelSet)
-            return false;
-        if (known)
-            return true;
-        return !defaultTunnel;
+    public static boolean routesDirect(boolean inOverrideSet, boolean defaultTunnel) {
+        return !(defaultTunnel != inOverrideSet);
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -25,6 +25,7 @@ import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.util.Log;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -43,6 +44,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
+import androidx.preference.PreferenceManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.recyclerview.widget.SimpleItemAnimator;
 import androidx.work.Data;
@@ -54,6 +56,7 @@ import net.kollnig.missioncontrol.analysis.TrackerAnalysisManager;
 import net.kollnig.missioncontrol.analysis.TrackerAnalysisWorker;
 import net.kollnig.missioncontrol.data.AppProtectionState;
 import net.kollnig.missioncontrol.data.BlockingMode;
+import net.kollnig.missioncontrol.data.RemoteRoutingLogic;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
 import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
@@ -475,6 +478,88 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 applyState(selected, w);
                 notifyDataSetChanged();
             });
+
+            bindRemoteRouting(holder);
+        }
+    }
+
+    /**
+     * The remote-routing control, which is deliberately independent of the
+     * protection state above: whether an app is filtered and whether it is
+     * forwarded through the remote VPN are separate choices (#723).
+     */
+    private void bindRemoteRouting(VHHeader holder) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        boolean wgEnabled = prefs.getBoolean("wg_enabled", false)
+                && !TextUtils.isEmpty(prefs.getString("wg_config", ""));
+        boolean applyApp = apply.getBoolean(mAppId, true);
+        boolean defaultRoutes = wgEnabled && hasDefaultRoutes(prefs);
+
+        RemoteRoutingLogic.Unavailable unavailable =
+                RemoteRoutingLogic.getUnavailableReason(wgEnabled, defaultRoutes, applyApp);
+        if (unavailable != null) {
+            holder.mAppRoute.setVisibility(View.GONE);
+            holder.mAppRouteUnavailable.setVisibility(View.VISIBLE);
+            holder.mAppRouteUnavailable.setText(explainUnavailable(unavailable));
+            return;
+        }
+
+        holder.mAppRouteUnavailable.setVisibility(View.GONE);
+        holder.mAppRoute.setVisibility(View.VISIBLE);
+
+        String mode = RemoteRoutingLogic.normalizeMode(
+                prefs.getString(Rule.PREF_WG_ROUTE_MODE, RemoteRoutingLogic.getDefaultMode()));
+        boolean tunnelled = RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true);
+
+        holder.mAppRoute.setOnCheckedChangeListener(null);
+        holder.mAppRoute.check(tunnelled ? R.id.rbRouteTunnel : R.id.rbRouteDirect);
+        holder.mAppRoute.setOnCheckedChangeListener((group, checkedId) -> {
+            boolean wantsTunnel = (checkedId == R.id.rbRouteTunnel);
+            if (wantsTunnel == RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true))
+                return;
+
+            mContext.getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE)
+                    .edit().putBoolean(mAppId, wantsTunnel).apply();
+
+            AsyncTask.execute(() -> {
+                Rule.clearCache(mContext);
+                ServiceSinkhole.reload("app routing changed", mContext, false);
+            });
+        });
+    }
+
+    @Nullable
+    private Boolean getRouteOverride() {
+        SharedPreferences wgRoute = mContext.getSharedPreferences(Rule.PREF_WG_ROUTE,
+                Context.MODE_PRIVATE);
+        return wgRoute.contains(mAppId) ? wgRoute.getBoolean(mAppId, true) : null;
+    }
+
+    private boolean hasDefaultRoutes(SharedPreferences prefs) {
+        try {
+            net.kollnig.missioncontrol.wg.WgConfig config =
+                    net.kollnig.missioncontrol.wg.WgConfigParser.INSTANCE
+                            .parse(prefs.getString("wg_config", ""));
+            List<String> allowedIps = new ArrayList<>();
+            for (net.kollnig.missioncontrol.wg.WgPeer peer : config.getPeers())
+                allowedIps.addAll(peer.getAllowedIPs());
+            return RemoteRoutingLogic.hasDefaultRoutes(allowedIps,
+                    prefs.getBoolean("ip6", true));
+        } catch (Throwable ex) {
+            Log.w(TAG, "Cannot read AllowedIPs, hiding per-app routing: " + ex);
+            return false;
+        }
+    }
+
+    private String explainUnavailable(RemoteRoutingLogic.Unavailable unavailable) {
+        switch (unavailable) {
+            case BYPASSED:
+                return mContext.getString(R.string.app_route_unavailable_bypassed);
+            case PARTIAL_ROUTES:
+                return mContext.getString(R.string.app_route_unavailable_partial_routes);
+            case NO_REMOTE_VPN:
+            default:
+                return mContext.getString(R.string.app_route_unavailable_no_vpn);
         }
     }
 
@@ -615,6 +700,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         final TextView mLibraryDisclaimer;
         final RadioGroup mAppState;
         final TextView mNoInternetExplanation;
+        final View mAppRouteCard;
+        final RadioGroup mAppRoute;
+        final TextView mAppRouteUnavailable;
 
         VHHeader(View view) {
             super(view);
@@ -622,6 +710,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             mLibraryDisclaimer = view.findViewById(R.id.tvLibraryDisclaimer);
             mAppState = view.findViewById(R.id.rgAppState);
             mNoInternetExplanation = view.findViewById(R.id.tvStateNoInternetDesc);
+            mAppRouteCard = view.findViewById(R.id.cardAppRoute);
+            mAppRoute = view.findViewById(R.id.rgAppRoute);
+            mAppRouteUnavailable = view.findViewById(R.id.tvAppRouteUnavailable);
         }
     }
 }

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -61,6 +61,10 @@ static int is_local_dest(int version, const void *daddr) {
 // and defaulting on a miss would send the rest of an established, already-NATted
 // flow into the tunnel mid-stream. The session table is the authoritative and
 // free source, so consult it before giving up.
+//
+// This runs only behind a route_flow_lookup miss, so it is the second fallback
+// rather than the per-packet cost it once was. The UDP arm repeats the 5-tuple
+// match in udp.c's has_udp_session; keep the two in step.
 static jint get_session_uid(const struct arguments *args, int version, int protocol,
                             const uint8_t *pkt, const uint8_t *payload) {
     const struct iphdr *ip4 = (struct iphdr *) pkt;
@@ -69,6 +73,17 @@ static jint get_session_uid(const struct arguments *args, int version, int proto
     for (struct ng_session *cur = args->ctx->ng_session; cur != NULL; cur = cur->next) {
         if (cur->protocol != protocol)
             continue;
+
+        if (protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6) {
+            const struct icmp *icmp = (struct icmp *) payload;
+            if (cur->icmp.version == version && cur->icmp.id == icmp->icmp_id &&
+                (version == 4
+                 ? cur->icmp.saddr.ip4 == ip4->saddr && cur->icmp.daddr.ip4 == ip4->daddr
+                 : memcmp(&cur->icmp.saddr.ip6, &ip6->ip6_src, 16) == 0 &&
+                   memcmp(&cur->icmp.daddr.ip6, &ip6->ip6_dst, 16) == 0))
+                return cur->icmp.uid;
+            continue;
+        }
 
         if (protocol == IPPROTO_UDP) {
             const struct udphdr *udphdr = (struct udphdr *) payload;
@@ -371,7 +386,13 @@ void handle_ip(const struct arguments *args,
     jint uid = -1;
     if (protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6 ||
         (protocol == IPPROTO_UDP && !has_udp_session(args, pkt, payload)) ||
-        (protocol == IPPROTO_TCP && syn && (dport != 443 || !is_play))) {
+        // SNI research mode lets a 443 SYN through without a UID so the
+        // ClientHello can be reassembled first. That is fine for the block
+        // decision, but the routing fork needs the UID now: with no UID and no
+        // session, the SYN falls to the global default and every later packet
+        // of that flow inherits the answer from it.
+        (protocol == IPPROTO_TCP && syn &&
+         (dport != 443 || !is_play || route_uid_relevant()))) {
             if (args->ctx->sdk <= 28) // Android 9 Pie
                 uid = get_uid(version, protocol, saddr, sport, daddr, dport);
             else
@@ -535,21 +556,33 @@ void handle_ip(const struct arguments *args,
         // everyone who has not opted in.
         int tunnel_uid;
         if (route_uid_relevant()) {
-            // Fall back to the session table rather than to the global default:
-            // defaulting would divert an already-NATted flow mid-stream. Never
-            // re-run the real lookup here — get_uid_q is a binder call.
-            //
-            // One case still lands on the default: the first TCP:443 SYN while
-            // SNI research mode is on, which has neither a uid nor a session.
-            jint route_uid = (uid >= 0
-                              ? uid
-                              : get_session_uid(args, version, protocol, pkt, payload));
-            tunnel_uid = is_tunnel_uid(route_uid);
+            // A flow keeps the verdict its first packet was given. Tunnelled
+            // flows never create an ng_session — the WireGuard write below
+            // returns first — so without this their later packets have nothing
+            // to resolve a UID from and would be re-decided on the global
+            // default, mid-stream.
+            if (!route_flow_lookup(version, protocol, saddr, sport, daddr, dport,
+                                   &tunnel_uid)) {
+                // Fall back to the session table rather than to the global
+                // default: defaulting would divert an already-NATted flow
+                // mid-stream. Never re-run the real lookup here — get_uid_q is
+                // a binder call.
+                jint route_uid = (uid >= 0
+                                  ? uid
+                                  : get_session_uid(args, version, protocol, pkt, payload));
+                tunnel_uid = is_tunnel_uid(route_uid);
+
+                // Only remember a verdict that was actually decided on a UID;
+                // caching a guessed default would pin it for the whole flow.
+                if (route_uid >= 0)
+                    route_flow_store(version, protocol, saddr, sport, daddr, dport,
+                                     tunnel_uid);
+            }
         } else
             tunnel_uid = route_default_is_tunnel();
 
         int wg_dest = route_wants_tunnel(is_local_dest(version, daddr), is_dns,
-                                         tunnel_uid, args->fwd53);
+                                         tunnel_uid, route_dns_direct());
 
         if (wg_dest) {
             ssize_t w;

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -526,30 +526,32 @@ void handle_ip(const struct arguments *args,
                       (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP));
         int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
 
-        // Which app this packet belongs to. The lookup above is deliberately
-        // skipped for established flows (existing UDP sessions, non-SYN TCP),
-        // so those arrive here with uid == -1. Fall back to the session table
-        // rather than to the global default: defaulting would divert an
-        // already-NATted flow mid-stream. Never re-run the real lookup here —
-        // get_uid_q is a binder call, and this is the per-packet path.
-        //
-        // One case still lands on the default: the first TCP:443 SYN while SNI
-        // research mode is on, which has neither a uid nor a session yet.
-        jint route_uid = (uid >= 0
-                          ? uid
-                          : get_session_uid(args, version, protocol, pkt, payload));
+        // Which app this packet belongs to — but only when that can change the
+        // answer. With no per-app override configured every UID routes the same
+        // way, and this is the per-packet path: resolving a UID there would
+        // cost a lock and, for the established flows that arrive with uid == -1
+        // (existing UDP sessions, non-SYN TCP, i.e. most packets), a walk of the
+        // whole session table, which grows with load. That is pure waste for
+        // everyone who has not opted in.
+        int tunnel_uid;
+        if (route_uid_relevant()) {
+            // Fall back to the session table rather than to the global default:
+            // defaulting would divert an already-NATted flow mid-stream. Never
+            // re-run the real lookup here — get_uid_q is a binder call.
+            //
+            // One case still lands on the default: the first TCP:443 SYN while
+            // SNI research mode is on, which has neither a uid nor a session.
+            jint route_uid = (uid >= 0
+                              ? uid
+                              : get_session_uid(args, version, protocol, pkt, payload));
+            tunnel_uid = is_tunnel_uid(route_uid);
+        } else
+            tunnel_uid = route_default_is_tunnel();
 
-        int tunnel_uid = is_tunnel_uid(route_uid);
-        enum route_decision decision = route_decide(
-                wireguard_active(), wg_is_required, is_local_dest(version, daddr),
-                is_dns, tunnel_uid, args->fwd53);
+        int wg_dest = route_wants_tunnel(is_local_dest(version, daddr), is_dns,
+                                         tunnel_uid, args->fwd53);
 
-        if (!tunnel_uid)
-            log_android(ANDROID_LOG_DEBUG,
-                        "Routing v%d p%d %s/%u uid %d direct (decision %d)",
-                        version, protocol, dest, dport, route_uid, decision);
-
-        if (decision == ROUTE_TUNNEL) {
+        if (wg_dest) {
             ssize_t w;
             int write_errno;
             if (write_wireguard_packet(pkt, length, &w, &write_errno)) {
@@ -567,10 +569,6 @@ void handle_ip(const struct arguments *args,
                 // Fail-closed: if the write fails, drop. Do not fall through to direct.
                 return;
             }
-            // The bridge stopped between the decision and the write; re-decide
-            // below with the tunnel known to be down.
-            decision = route_decide(0, wg_is_required, is_local_dest(version, daddr),
-                                    is_dns, tunnel_uid, args->fwd53);
         }
 
         // Fail closed while WG is required but not (yet) running — e.g. the
@@ -581,7 +579,7 @@ void handle_ip(const struct arguments *args,
         // (the resolver runs on the VPN network). This briefly exposes DNS
         // queries to the configured (WG/public fallback) DNS server over the
         // physical network, which is far less than leaking all traffic.
-        if (decision == ROUTE_DROP) {
+        if (wg_is_required && wg_dest && !is_dns) {
             long drops = atomic_fetch_add_explicit(
                     &wg_gap_drop_count, 1, memory_order_relaxed) + 1;
             if ((drops & 255L) == 1)

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -53,6 +53,47 @@ static int is_local_dest(int version, const void *daddr) {
     }
 }
 
+// The UID of an established flow, for packets that arrive without one.
+//
+// Packet 2+ of a direct flow reaches the routing fork with uid == -1: the
+// expensive lookup above is deliberately skipped for existing UDP sessions and
+// non-SYN TCP. The uid cache usually answers, but it expires and is evicted,
+// and defaulting on a miss would send the rest of an established, already-NATted
+// flow into the tunnel mid-stream. The session table is the authoritative and
+// free source, so consult it before giving up.
+static jint get_session_uid(const struct arguments *args, int version, int protocol,
+                            const uint8_t *pkt, const uint8_t *payload) {
+    const struct iphdr *ip4 = (struct iphdr *) pkt;
+    const struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
+
+    for (struct ng_session *cur = args->ctx->ng_session; cur != NULL; cur = cur->next) {
+        if (cur->protocol != protocol)
+            continue;
+
+        if (protocol == IPPROTO_UDP) {
+            const struct udphdr *udphdr = (struct udphdr *) payload;
+            if (cur->udp.version == version &&
+                cur->udp.source == udphdr->source && cur->udp.dest == udphdr->dest &&
+                (version == 4
+                 ? cur->udp.saddr.ip4 == ip4->saddr && cur->udp.daddr.ip4 == ip4->daddr
+                 : memcmp(&cur->udp.saddr.ip6, &ip6->ip6_src, 16) == 0 &&
+                   memcmp(&cur->udp.daddr.ip6, &ip6->ip6_dst, 16) == 0))
+                return cur->udp.uid;
+        } else if (protocol == IPPROTO_TCP) {
+            const struct tcphdr *tcphdr = (struct tcphdr *) payload;
+            if (cur->tcp.version == version &&
+                cur->tcp.source == tcphdr->source && cur->tcp.dest == tcphdr->dest &&
+                (version == 4
+                 ? cur->tcp.saddr.ip4 == ip4->saddr && cur->tcp.daddr.ip4 == ip4->daddr
+                 : memcmp(&cur->tcp.saddr.ip6, &ip6->ip6_src, 16) == 0 &&
+                   memcmp(&cur->tcp.daddr.ip6, &ip6->ip6_dst, 16) == 0))
+                return cur->tcp.uid;
+        }
+    }
+
+    return -1;
+}
+
 uint16_t get_mtu() {
     return 10000;
 }
@@ -484,9 +525,31 @@ void handle_ip(const struct arguments *args,
         int is_dns = (dport == 53 &&
                       (protocol == IPPROTO_UDP || protocol == IPPROTO_TCP));
         int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
-        int wg_dest = !is_local_dest(version, daddr) || is_dns;
 
-        if (wg_dest) {
+        // Which app this packet belongs to. The lookup above is deliberately
+        // skipped for established flows (existing UDP sessions, non-SYN TCP),
+        // so those arrive here with uid == -1. Fall back to the session table
+        // rather than to the global default: defaulting would divert an
+        // already-NATted flow mid-stream. Never re-run the real lookup here —
+        // get_uid_q is a binder call, and this is the per-packet path.
+        //
+        // One case still lands on the default: the first TCP:443 SYN while SNI
+        // research mode is on, which has neither a uid nor a session yet.
+        jint route_uid = (uid >= 0
+                          ? uid
+                          : get_session_uid(args, version, protocol, pkt, payload));
+
+        int tunnel_uid = is_tunnel_uid(route_uid);
+        enum route_decision decision = route_decide(
+                wireguard_active(), wg_is_required, is_local_dest(version, daddr),
+                is_dns, tunnel_uid, args->fwd53);
+
+        if (!tunnel_uid)
+            log_android(ANDROID_LOG_DEBUG,
+                        "Routing v%d p%d %s/%u uid %d direct (decision %d)",
+                        version, protocol, dest, dport, route_uid, decision);
+
+        if (decision == ROUTE_TUNNEL) {
             ssize_t w;
             int write_errno;
             if (write_wireguard_packet(pkt, length, &w, &write_errno)) {
@@ -504,6 +567,10 @@ void handle_ip(const struct arguments *args,
                 // Fail-closed: if the write fails, drop. Do not fall through to direct.
                 return;
             }
+            // The bridge stopped between the decision and the write; re-decide
+            // below with the tunnel known to be down.
+            decision = route_decide(0, wg_is_required, is_local_dest(version, daddr),
+                                    is_dns, tunnel_uid, args->fwd53);
         }
 
         // Fail closed while WG is required but not (yet) running — e.g. the
@@ -514,7 +581,7 @@ void handle_ip(const struct arguments *args,
         // (the resolver runs on the VPN network). This briefly exposes DNS
         // queries to the configured (WG/public fallback) DNS server over the
         // physical network, which is far less than leaking all traffic.
-        if (wg_is_required && wg_dest && !is_dns) {
+        if (decision == ROUTE_DROP) {
             long drops = atomic_fetch_add_explicit(
                     &wg_gap_drop_count, 1, memory_order_relaxed) + 1;
             if ((drops & 255L) == 1)

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -109,6 +109,20 @@ static jint get_session_uid(const struct arguments *args, int version, int proto
     return -1;
 }
 
+// Re-run the authoritative UID lookup only after both the flow cache and the
+// native session table miss. This is deliberately off the hot path: established
+// UDP/TCP packets normally hit the flow cache, while a miss can be caused by a
+// cache expiry or hash collision. Keep the Android <=28 procfs path identical
+// to the initial lookup and use ConnectivityManager on newer releases.
+static jint get_route_uid(const struct arguments *args, int version, int protocol,
+                          const void *saddr, uint16_t sport,
+                          const void *daddr, uint16_t dport,
+                          const char *source, const char *dest) {
+    if (args->ctx->sdk <= 28)
+        return get_uid(version, protocol, saddr, sport, daddr, dport);
+    return get_uid_q(args, version, protocol, source, sport, dest, dport);
+}
+
 uint16_t get_mtu() {
     return 10000;
 }
@@ -556,27 +570,50 @@ void handle_ip(const struct arguments *args,
         // everyone who has not opted in.
         int tunnel_uid;
         if (route_uid_relevant()) {
-            // A flow keeps the verdict its first packet was given. Tunnelled
-            // flows never create an ng_session — the WireGuard write below
-            // returns first — so without this their later packets have nothing
-            // to resolve a UID from and would be re-decided on the global
-            // default, mid-stream.
-            if (!route_flow_lookup(version, protocol, saddr, sport, daddr, dport,
-                                   &tunnel_uid)) {
-                // Fall back to the session table rather than to the global
-                // default: defaulting would divert an already-NATted flow
-                // mid-stream. Never re-run the real lookup here — get_uid_q is
-                // a binder call.
-                jint route_uid = (uid >= 0
-                                  ? uid
-                                  : get_session_uid(args, version, protocol, pkt, payload));
+            // A flow keeps the verdict its first packet was given. A fresh UID
+            // is authoritative even when a previous flow happened to reuse the
+            // same 5-tuple, so do not consult the flow cache in that case.
+            jint route_uid = uid;
+            if (route_uid >= 0) {
                 tunnel_uid = is_tunnel_uid(route_uid);
+                route_flow_store(version, protocol, saddr, sport, daddr, dport,
+                                 tunnel_uid);
+            } else if (route_flow_lookup(version, protocol, saddr, sport, daddr, dport,
+                                         &tunnel_uid)) {
+                // Established tunnelled flows never create an ng_session — the
+                // WireGuard write below returns first — so the cache preserves
+                // their first-packet answer without a per-packet UID lookup.
+            } else {
+                // A cache expiry or collision is rare, but falling back to the
+                // selected-mode default would divert an already-established
+                // tunnelled flow direct and can make TCP reset. Recover the UID
+                // from the native session table first, then from the
+                // authoritative Android/procfs lookup.
+                route_uid = get_session_uid(args, version, protocol, pkt, payload);
+                if (route_uid < 0)
+                    route_uid = get_route_uid(args, version, protocol,
+                                              saddr, sport, daddr, dport,
+                                              source, dest);
 
-                // Only remember a verdict that was actually decided on a UID;
-                // caching a guessed default would pin it for the whole flow.
-                if (route_uid >= 0)
+                if (route_uid >= 0) {
+                    tunnel_uid = is_tunnel_uid(route_uid);
                     route_flow_store(version, protocol, saddr, sport, daddr, dport,
                                      tunnel_uid);
+                } else {
+                    // Unknown ownership is privacy-sensitive: keep the packet
+                    // in the remote tunnel rather than fail-open to direct
+                    // routing in selected mode. Cache that explicit fail-closed
+                    // verdict so the rest of this flow does not repeat a Binder
+                    // or procfs lookup on every packet. A later flow with the
+                    // same tuple still wins because a freshly resolved UID is
+                    // handled before the cache above.
+                    tunnel_uid = 1;
+                    route_flow_store(version, protocol, saddr, sport, daddr, dport,
+                                     tunnel_uid);
+                    log_android(ANDROID_LOG_WARN,
+                                "Route UID unavailable for v%d p%d %s/%u > %s/%u; tunnelling",
+                                version, protocol, source, sport, dest, dport);
+                }
             }
         } else
             tunnel_uid = route_default_is_tunnel();

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -456,7 +456,8 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1required(JNIEnv *env, 
 JNIEXPORT void JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1route(JNIEnv *env, jobject instance,
                                                                 jintArray uids_,
-                                                                jboolean default_tunnel) {
+                                                                jboolean default_tunnel,
+                                                                jboolean dns_direct) {
     jint count = 0;
     jint *uids = NULL;
     if (uids_ != NULL) {
@@ -470,13 +471,14 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1route(JNIEnv *env, job
         }
     }
 
-    set_route_uids(uids, count, default_tunnel ? 1 : 0);
+    set_route_uids(uids, count, default_tunnel ? 1 : 0, dns_direct ? 1 : 0);
 
     if (uids != NULL)
         (*env)->ReleaseIntArrayElements(env, uids_, uids, JNI_ABORT);
 
-    log_android(ANDROID_LOG_WARN, "WireGuard routing: %d tunnelled uids, default %s",
-                count, default_tunnel ? "tunnel" : "direct");
+    log_android(ANDROID_LOG_WARN,
+                "WireGuard routing: default %s, %d uid overrides, direct DNS %s",
+                default_tunnel ? "tunnel" : "direct", count, dns_direct ? "on" : "off");
 }
 
 JNIEXPORT void JNICALL

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -423,6 +423,22 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1start(JNIEnv *env, job
     return sv[1];
 }
 
+// Whether the WireGuard bridge currently accepts packets. Only a hint: the
+// bridge can stop between this call and the write, which the caller re-decides
+// on. Kept separate from write_wireguard_packet so the routing decision can be
+// made before committing to a write.
+int wireguard_active() {
+    if (pthread_mutex_lock(&wg_outbound_lock))
+        return 0;
+
+    int active = (wg_outbound_fd >= 0);
+
+    if (pthread_mutex_unlock(&wg_outbound_lock))
+        log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed after probe");
+
+    return active;
+}
+
 int write_wireguard_packet(const void *packet, size_t length,
                            ssize_t *written, int *write_errno) {
     *written = -1;
@@ -451,6 +467,32 @@ JNIEXPORT void JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1required(JNIEnv *env, jobject instance,
                                                                    jboolean required) {
     atomic_store_explicit(&wg_required, required ? 1 : 0, memory_order_release);
+}
+
+JNIEXPORT void JNICALL
+Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1route(JNIEnv *env, jobject instance,
+                                                                jintArray uids_,
+                                                                jboolean default_tunnel) {
+    jint count = 0;
+    jint *uids = NULL;
+    if (uids_ != NULL) {
+        count = (*env)->GetArrayLength(env, uids_);
+        if (count > 0) {
+            uids = (*env)->GetIntArrayElements(env, uids_, NULL);
+            if (uids == NULL) {
+                log_android(ANDROID_LOG_ERROR, "wg route uids unavailable, keeping previous");
+                return;
+            }
+        }
+    }
+
+    set_route_uids(uids, count, default_tunnel ? 1 : 0);
+
+    if (uids != NULL)
+        (*env)->ReleaseIntArrayElements(env, uids_, uids, JNI_ABORT);
+
+    log_android(ANDROID_LOG_WARN, "WireGuard routing: %d tunnelled uids, default %s",
+                count, default_tunnel ? "tunnel" : "direct");
 }
 
 JNIEXPORT void JNICALL
@@ -489,6 +531,8 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1done(
         ng_free(uid_cache, __FILE__, __LINE__);
     uid_cache_size = 0;
     uid_cache = NULL;
+
+    clear_route_uids();
 
     ng_free(ctx, __FILE__, __LINE__);
 }

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -423,22 +423,6 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1wireguard_1start(JNIEnv *env, job
     return sv[1];
 }
 
-// Whether the WireGuard bridge currently accepts packets. Only a hint: the
-// bridge can stop between this call and the write, which the caller re-decides
-// on. Kept separate from write_wireguard_packet so the routing decision can be
-// made before committing to a write.
-int wireguard_active() {
-    if (pthread_mutex_lock(&wg_outbound_lock))
-        return 0;
-
-    int active = (wg_outbound_fd >= 0);
-
-    if (pthread_mutex_unlock(&wg_outbound_lock))
-        log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed after probe");
-
-    return active;
-}
-
 int write_wireguard_packet(const void *packet, size_t length,
                            ssize_t *written, int *write_errno) {
     *written = -1;

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -116,6 +116,10 @@ struct allowed {
 int write_wireguard_packet(const void *packet, size_t length,
                            ssize_t *written, int *write_errno);
 
+// Whether the WireGuard bridge is currently up. A hint only — see the comment
+// on the definition.
+int wireguard_active();
+
 struct segment {
     uint32_t seq;
     uint16_t len;
@@ -535,6 +539,23 @@ void dns_resolved(const struct arguments *args,
                   const char *qname, const char *aname, const char *resource, int ttl);
 
 jboolean is_domain_blocked(const struct arguments *args, const char *name);
+
+// Per-app remote routing (route.c). The UID set is pushed down from Java on
+// every reload; the packet path only reads it.
+enum route_decision {
+    ROUTE_TUNNEL,
+    ROUTE_DIRECT,
+    ROUTE_DROP
+};
+
+void set_route_uids(const jint *uids, int count, int default_tunnel);
+
+void clear_route_uids();
+
+int is_tunnel_uid(jint uid);
+
+enum route_decision route_decide(int wg_active, int wg_is_required, int local_dest,
+                                 int is_dns, int tunnel_uid, int dns_direct);
 
 jint get_uid_q(const struct arguments *args,
                jint version,

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -537,21 +537,37 @@ void dns_resolved(const struct arguments *args,
 
 jboolean is_domain_blocked(const struct arguments *args, const char *name);
 
-// Per-app remote routing (route.c). The UID set is pushed down from Java on
-// every reload; the packet path only reads it.
-void set_route_uids(const jint *uids, int count, int default_tunnel);
+// Per-app remote routing (route.c). Java pushes down only the UIDs whose
+// routing differs from the global default; the packet path only reads them.
+void set_route_uids(const jint *uids, int count, int default_tunnel, int dns_direct);
 
 void clear_route_uids();
 
 int is_tunnel_uid(jint uid);
 
-// Lock-free fast path: whether a UID lookup can change the answer at all, and
-// the answer everything gets when it cannot.
+// Lock-free fast path: whether a UID lookup can change the answer at all, the
+// answer everything gets when it cannot, and whether DNS follows that answer.
 int route_uid_relevant();
 
 int route_default_is_tunnel();
 
+int route_dns_direct();
+
 int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direct);
+
+// Per-flow verdict cache, so a flow that has already been routed keeps its
+// answer once its packets stop carrying a UID. Tunnel-thread only.
+int route_flow_lookup(int version, int protocol,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport,
+                      int *tunnel);
+
+void route_flow_store(int version, int protocol,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport,
+                      int tunnel);
+
+void route_flow_invalidate();
 
 jint get_uid_q(const struct arguments *args,
                jint version,

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -116,9 +116,6 @@ struct allowed {
 int write_wireguard_packet(const void *packet, size_t length,
                            ssize_t *written, int *write_errno);
 
-// Whether the WireGuard bridge is currently up. A hint only — see the comment
-// on the definition.
-int wireguard_active();
 
 struct segment {
     uint32_t seq;
@@ -542,20 +539,19 @@ jboolean is_domain_blocked(const struct arguments *args, const char *name);
 
 // Per-app remote routing (route.c). The UID set is pushed down from Java on
 // every reload; the packet path only reads it.
-enum route_decision {
-    ROUTE_TUNNEL,
-    ROUTE_DIRECT,
-    ROUTE_DROP
-};
-
 void set_route_uids(const jint *uids, int count, int default_tunnel);
 
 void clear_route_uids();
 
 int is_tunnel_uid(jint uid);
 
-enum route_decision route_decide(int wg_active, int wg_is_required, int local_dest,
-                                 int is_dns, int tunnel_uid, int dns_direct);
+// Lock-free fast path: whether a UID lookup can change the answer at all, and
+// the answer everything gets when it cannot.
+int route_uid_relevant();
+
+int route_default_is_tunnel();
+
+int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direct);
 
 jint get_uid_q(const struct arguments *args,
                jint version,

--- a/app/src/main/jni/netguard/route.c
+++ b/app/src/main/jni/netguard/route.c
@@ -17,23 +17,36 @@
 #include <stdlib.h>
 #include <stdatomic.h>
 
-// Sorted array of UIDs Java wants routed through the remote tunnel, plus the
-// default applied to every UID not in it. Written from the Java thread during
-// a reload and read by the tunnel thread on the packet path, so both sides
-// take route_lock. The packet path is otherwise single-threaded (one
-// tunnelThread runs jni_run), which is why nothing else here needs a lock.
+// Sorted array of the UIDs whose routing *differs* from the global default,
+// plus that default. Written from the Java thread during a reload and read by
+// the tunnel thread on the packet path, so both sides take route_lock. The
+// packet path is otherwise single-threaded (one tunnelThread runs jni_run),
+// which is why nothing else here needs a lock.
+//
+// Only the exceptions are pushed, never the whole tunnelled set. In the default
+// mode every applied app is tunnelled, so a "tunnelled UIDs" array held every
+// installed app and was indistinguishable from a heavily-overridden one — which
+// made route_uid_relevant() below always true and cost every user, WireGuard or
+// not, a per-packet lock and session-table walk.
 static pthread_mutex_t route_lock = PTHREAD_MUTEX_INITIALIZER;
 static jint *route_uids = NULL;
 static int route_uid_count = 0;
 static int route_default_tunnel = 1;
 
-// Fast-path mirrors of the two facts the packet path needs before it knows
-// whether resolving a UID is worth anything. Both are read per packet, so they
-// are atomics rather than lock-protected: with no per-app override configured
-// — the shipped default — every UID gets the same answer, and the packet path
+// Fast-path mirrors of the facts the packet path needs before it knows whether
+// resolving a UID is worth anything. All are read per packet, so they are
+// atomics rather than lock-protected: with no per-app override configured —
+// the shipped default — every UID gets the same answer, and the packet path
 // must not pay a mutex or a session-table walk to rediscover that.
 static _Atomic int route_has_overrides = 0;
 static _Atomic int route_default_tunnel_fast = 1;
+
+// Whether direct apps' DNS is redirected to the system resolver. Its own flag
+// rather than a reuse of args->fwd53: that one is also set by an unrelated
+// port-53 forward (Secure DNS runs one whenever WireGuard carries no DNS line
+// of its own), and borrowing it silently switched off the rule that every
+// resolver query takes the tunnel.
+static _Atomic int route_dns_direct_fast = 0;
 
 static int compare_uid(const void *a, const void *b) {
     jint ua = *(const jint *) a;
@@ -41,10 +54,14 @@ static int compare_uid(const void *a, const void *b) {
     return (ua > ub) - (ua < ub);
 }
 
-void set_route_uids(const jint *uids, int count, int default_tunnel) {
+void set_route_uids(const jint *uids, int count, int default_tunnel, int dns_direct) {
     jint *copy = NULL;
     if (count > 0) {
         copy = ng_malloc(sizeof(jint) * (size_t) count, "route uids");
+        if (copy == NULL) {
+            log_android(ANDROID_LOG_ERROR, "route uids alloc failed, keeping previous routing");
+            return;
+        }
         memcpy(copy, uids, sizeof(jint) * (size_t) count);
         qsort(copy, (size_t) count, sizeof(jint), compare_uid);
     }
@@ -63,16 +80,20 @@ void set_route_uids(const jint *uids, int count, int default_tunnel) {
 
     atomic_store_explicit(&route_has_overrides, count > 0 ? 1 : 0, memory_order_release);
     atomic_store_explicit(&route_default_tunnel_fast, default_tunnel, memory_order_release);
+    atomic_store_explicit(&route_dns_direct_fast, dns_direct, memory_order_release);
 
     if (pthread_mutex_unlock(&route_lock))
         log_android(ANDROID_LOG_ERROR, "route unlock failed");
+
+    // Verdicts cached against the previous rules must not survive them.
+    route_flow_invalidate();
 
     if (previous != NULL)
         ng_free(previous, __FILE__, __LINE__);
 }
 
 void clear_route_uids() {
-    set_route_uids(NULL, 0, 1);
+    set_route_uids(NULL, 0, 1, 0);
 }
 
 int is_tunnel_uid(jint uid) {
@@ -83,15 +104,18 @@ int is_tunnel_uid(jint uid) {
     }
 
     int tunnel;
-    // An unresolved UID has no per-app answer, and neither does system traffic
-    // that belongs to no installed app. Both follow the global default, which
-    // makes the default mode byte-identical to the behaviour before per-app
-    // routing existed.
+    // Only UIDs the user gave an explicit, differing answer for are listed.
+    // Everything else — an unresolved UID, system traffic, an app installed
+    // since the last reload — follows the global default, which is what makes
+    // the default mode identical to the behaviour before per-app routing
+    // existed.
     if (uid < 0 || route_uids == NULL)
         tunnel = route_default_tunnel;
+    else if (bsearch(&uid, route_uids, (size_t) route_uid_count, sizeof(jint), compare_uid)
+             != NULL)
+        tunnel = !route_default_tunnel;
     else
-        tunnel = bsearch(&uid, route_uids, (size_t) route_uid_count, sizeof(jint), compare_uid)
-                 != NULL;
+        tunnel = route_default_tunnel;
 
     if (pthread_mutex_unlock(&route_lock))
         log_android(ANDROID_LOG_ERROR, "route unlock failed");
@@ -114,6 +138,11 @@ int route_uid_relevant() {
 /** The answer every UID gets when no override is configured. */
 int route_default_is_tunnel() {
     return atomic_load_explicit(&route_default_tunnel_fast, memory_order_acquire);
+}
+
+/** Whether direct apps' DNS is redirected, in which case DNS follows the UID. */
+int route_dns_direct() {
+    return atomic_load_explicit(&route_dns_direct_fast, memory_order_acquire);
 }
 
 /**
@@ -140,4 +169,127 @@ int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direc
         return 1;
 
     return tunnel_uid;
+}
+
+// --- Per-flow verdict cache -------------------------------------------------
+//
+// A tunnelled packet is handed to WireGuard and returns before handle_tcp /
+// handle_udp run, so no ng_session is ever created for it. Meanwhile the UID
+// lookup upstream is skipped for non-SYN TCP and existing UDP, so packet 2+ of
+// a tunnelled flow arrives with uid == -1 and nothing left to resolve it from.
+// Falling back to the global default there is wrong in exactly the mode the
+// feature exists for: in "selected" mode the default is direct, so the rest of
+// a tunnelled TCP flow was routed direct and handle_tcp, finding no session for
+// a non-SYN segment, answered it with an RST.
+//
+// So remember the verdict per flow, keyed on the 5-tuple, and consult it before
+// giving up. Written and read only by the tunnel thread, which is why nothing
+// here takes a lock; a reload bumps route_flow_gen instead of clearing the
+// table, so entries decided under superseded rules simply stop matching.
+
+#define ROUTE_FLOW_SIZE 1024        // power of two; ~40 KB resident
+#define ROUTE_FLOW_MAX_AGE 300      // seconds idle before an entry is reusable
+
+struct route_flow_entry {
+    uint32_t gen;                   // 0 = free
+    uint8_t version;
+    uint8_t protocol;
+    uint8_t tunnel;
+    uint16_t sport;
+    uint16_t dport;
+    uint8_t saddr[16];
+    uint8_t daddr[16];
+    time_t time;
+};
+
+static struct route_flow_entry route_flows[ROUTE_FLOW_SIZE];
+static _Atomic uint32_t route_flow_gen = 1;
+
+void route_flow_invalidate() {
+    // Wrapping past 0 would resurrect free slots, so skip it.
+    uint32_t next = atomic_fetch_add_explicit(&route_flow_gen, 1, memory_order_release) + 1;
+    if (next == 0)
+        atomic_store_explicit(&route_flow_gen, 1, memory_order_release);
+}
+
+static size_t route_flow_slot(int version, int protocol,
+                              const void *saddr, uint16_t sport,
+                              const void *daddr, uint16_t dport) {
+    size_t alen = (version == 4 ? 4u : 16u);
+    // FNV-1a
+    uint32_t h = 2166136261u;
+    const uint8_t *s = saddr;
+    const uint8_t *d = daddr;
+    for (size_t i = 0; i < alen; i++) {
+        h = (h ^ s[i]) * 16777619u;
+        h = (h ^ d[i]) * 16777619u;
+    }
+    h = (h ^ (uint8_t) version) * 16777619u;
+    h = (h ^ (uint8_t) protocol) * 16777619u;
+    h = (h ^ (uint8_t) (sport & 0xff)) * 16777619u;
+    h = (h ^ (uint8_t) (sport >> 8)) * 16777619u;
+    h = (h ^ (uint8_t) (dport & 0xff)) * 16777619u;
+    h = (h ^ (uint8_t) (dport >> 8)) * 16777619u;
+    return (size_t) (h & (ROUTE_FLOW_SIZE - 1));
+}
+
+static int route_flow_matches(const struct route_flow_entry *e, uint32_t gen,
+                              int version, int protocol,
+                              const void *saddr, uint16_t sport,
+                              const void *daddr, uint16_t dport, time_t now) {
+    size_t alen = (version == 4 ? 4u : 16u);
+    return e->gen == gen &&
+           e->version == (uint8_t) version && e->protocol == (uint8_t) protocol &&
+           e->sport == sport && e->dport == dport &&
+           memcmp(e->saddr, saddr, alen) == 0 && memcmp(e->daddr, daddr, alen) == 0 &&
+           now - e->time <= ROUTE_FLOW_MAX_AGE;
+}
+
+/**
+ * The remembered verdict for this flow, if any.
+ *
+ * @return 1 when *tunnel was filled in, 0 on a miss.
+ */
+int route_flow_lookup(int version, int protocol,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport,
+                      int *tunnel) {
+    uint32_t gen = atomic_load_explicit(&route_flow_gen, memory_order_acquire);
+    struct route_flow_entry *e = &route_flows[route_flow_slot(
+            version, protocol, saddr, sport, daddr, dport)];
+
+    time_t now = time(NULL);
+    if (!route_flow_matches(e, gen, version, protocol, saddr, sport, daddr, dport, now))
+        return 0;
+
+    e->time = now;
+    *tunnel = e->tunnel;
+    return 1;
+}
+
+/**
+ * Remember this flow's verdict. One slot per hash, overwritten on collision —
+ * it is a cache, and a miss only costs the fallback path that ran before it
+ * existed. Never called for a packet whose UID was unknown: pinning a guessed
+ * default for the life of a flow is the failure this exists to prevent.
+ */
+void route_flow_store(int version, int protocol,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport,
+                      int tunnel) {
+    size_t alen = (version == 4 ? 4u : 16u);
+    struct route_flow_entry *e = &route_flows[route_flow_slot(
+            version, protocol, saddr, sport, daddr, dport)];
+
+    e->gen = atomic_load_explicit(&route_flow_gen, memory_order_acquire);
+    e->version = (uint8_t) version;
+    e->protocol = (uint8_t) protocol;
+    e->tunnel = (uint8_t) (tunnel ? 1 : 0);
+    e->sport = sport;
+    e->dport = dport;
+    memset(e->saddr, 0, sizeof(e->saddr));
+    memset(e->daddr, 0, sizeof(e->daddr));
+    memcpy(e->saddr, saddr, alen);
+    memcpy(e->daddr, daddr, alen);
+    e->time = time(NULL);
 }

--- a/app/src/main/jni/netguard/route.c
+++ b/app/src/main/jni/netguard/route.c
@@ -15,6 +15,7 @@
 #include "netguard.h"
 
 #include <stdlib.h>
+#include <stdatomic.h>
 
 // Sorted array of UIDs Java wants routed through the remote tunnel, plus the
 // default applied to every UID not in it. Written from the Java thread during
@@ -25,6 +26,14 @@ static pthread_mutex_t route_lock = PTHREAD_MUTEX_INITIALIZER;
 static jint *route_uids = NULL;
 static int route_uid_count = 0;
 static int route_default_tunnel = 1;
+
+// Fast-path mirrors of the two facts the packet path needs before it knows
+// whether resolving a UID is worth anything. Both are read per packet, so they
+// are atomics rather than lock-protected: with no per-app override configured
+// — the shipped default — every UID gets the same answer, and the packet path
+// must not pay a mutex or a session-table walk to rediscover that.
+static _Atomic int route_has_overrides = 0;
+static _Atomic int route_default_tunnel_fast = 1;
 
 static int compare_uid(const void *a, const void *b) {
     jint ua = *(const jint *) a;
@@ -51,6 +60,9 @@ void set_route_uids(const jint *uids, int count, int default_tunnel) {
     route_uids = copy;
     route_uid_count = count;
     route_default_tunnel = default_tunnel;
+
+    atomic_store_explicit(&route_has_overrides, count > 0 ? 1 : 0, memory_order_release);
+    atomic_store_explicit(&route_default_tunnel_fast, default_tunnel, memory_order_release);
 
     if (pthread_mutex_unlock(&route_lock))
         log_android(ANDROID_LOG_ERROR, "route unlock failed");
@@ -88,41 +100,44 @@ int is_tunnel_uid(jint uid) {
 }
 
 /**
- * The whole per-packet routing decision, kept free of I/O so it can be reasoned
- * about (and, unlike the rest of this directory, read straight through).
+ * Whether resolving this packet's UID can change the routing answer.
  *
- * @param wg_active      whether the WireGuard bridge currently accepts packets
- * @param wg_is_required whether egress must not fall back to the raw network
- * @param local_dest     loopback / link-local / multicast destination
- * @param is_dns         port 53, over UDP or TCP
- * @param tunnel_uid     whether this packet's UID is routed through the tunnel
- * @param dns_direct     whether direct apps' DNS is redirected to the system
- *                       resolver; while false, DNS always takes the tunnel
+ * With no per-app override configured, every UID resolves to the same global
+ * default, so the packet path can skip both the UID lookup and the lock. This
+ * is the shipped default, and keeping it free is what holds the per-packet cost
+ * at what it was before per-app routing existed.
  */
-enum route_decision route_decide(int wg_active, int wg_is_required, int local_dest,
-                                 int is_dns, int tunnel_uid, int dns_direct) {
+int route_uid_relevant() {
+    return atomic_load_explicit(&route_has_overrides, memory_order_acquire);
+}
+
+/** The answer every UID gets when no override is configured. */
+int route_default_is_tunnel() {
+    return atomic_load_explicit(&route_default_tunnel_fast, memory_order_acquire);
+}
+
+/**
+ * Whether this packet belongs in the tunnel. Pure, so the rule can be read
+ * straight through — the caller still decides what to do when the tunnel is
+ * down, because only the write attempt can say whether it is.
+ *
+ * @param local_dest loopback / link-local / multicast destination
+ * @param is_dns     port 53, over UDP or TCP
+ * @param tunnel_uid whether this packet's UID is routed through the tunnel
+ * @param dns_direct whether direct apps' DNS is redirected to the system
+ *                   resolver; while false, DNS always takes the tunnel
+ */
+int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direct) {
     // Destinations WireGuard cannot meaningfully forward never take the tunnel,
     // whichever app sent them.
     if (local_dest && !is_dns)
-        return ROUTE_DIRECT;
+        return 0;
 
-    // Until the DNS split ships, every resolver query takes the tunnel: sending
-    // it out directly would expose the user's physical network to the resolver.
-    int wants_tunnel = (is_dns && !dns_direct) ? 1 : tunnel_uid;
+    // Unless a direct app's DNS is being redirected, every resolver query takes
+    // the tunnel: sending it out directly would expose the user's physical
+    // network to the resolver.
+    if (is_dns && !dns_direct)
+        return 1;
 
-    if (!wants_tunnel)
-        return ROUTE_DIRECT;
-
-    if (wg_active)
-        return ROUTE_TUNNEL;
-
-    // WireGuard is required but not running — the window during a tunnel
-    // restart, or after a failed start. Falling through to direct here would
-    // leak this app's traffic onto the raw network. DNS stays exempt because
-    // recovery has to re-resolve the peer endpoint, and blocking DNS would
-    // deadlock that recovery.
-    if (wg_is_required && !is_dns)
-        return ROUTE_DROP;
-
-    return ROUTE_DIRECT;
+    return tunnel_uid;
 }

--- a/app/src/main/jni/netguard/route.c
+++ b/app/src/main/jni/netguard/route.c
@@ -1,0 +1,128 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+#include "netguard.h"
+
+#include <stdlib.h>
+
+// Sorted array of UIDs Java wants routed through the remote tunnel, plus the
+// default applied to every UID not in it. Written from the Java thread during
+// a reload and read by the tunnel thread on the packet path, so both sides
+// take route_lock. The packet path is otherwise single-threaded (one
+// tunnelThread runs jni_run), which is why nothing else here needs a lock.
+static pthread_mutex_t route_lock = PTHREAD_MUTEX_INITIALIZER;
+static jint *route_uids = NULL;
+static int route_uid_count = 0;
+static int route_default_tunnel = 1;
+
+static int compare_uid(const void *a, const void *b) {
+    jint ua = *(const jint *) a;
+    jint ub = *(const jint *) b;
+    return (ua > ub) - (ua < ub);
+}
+
+void set_route_uids(const jint *uids, int count, int default_tunnel) {
+    jint *copy = NULL;
+    if (count > 0) {
+        copy = ng_malloc(sizeof(jint) * (size_t) count, "route uids");
+        memcpy(copy, uids, sizeof(jint) * (size_t) count);
+        qsort(copy, (size_t) count, sizeof(jint), compare_uid);
+    }
+
+    if (pthread_mutex_lock(&route_lock)) {
+        log_android(ANDROID_LOG_ERROR, "route lock failed, keeping previous routing");
+        if (copy != NULL)
+            ng_free(copy, __FILE__, __LINE__);
+        return;
+    }
+
+    jint *previous = route_uids;
+    route_uids = copy;
+    route_uid_count = count;
+    route_default_tunnel = default_tunnel;
+
+    if (pthread_mutex_unlock(&route_lock))
+        log_android(ANDROID_LOG_ERROR, "route unlock failed");
+
+    if (previous != NULL)
+        ng_free(previous, __FILE__, __LINE__);
+}
+
+void clear_route_uids() {
+    set_route_uids(NULL, 0, 1);
+}
+
+int is_tunnel_uid(jint uid) {
+    if (pthread_mutex_lock(&route_lock)) {
+        // Fall back to the safest answer: keep the app in the tunnel.
+        log_android(ANDROID_LOG_ERROR, "route lock failed, tunnelling uid %d", uid);
+        return 1;
+    }
+
+    int tunnel;
+    // An unresolved UID has no per-app answer, and neither does system traffic
+    // that belongs to no installed app. Both follow the global default, which
+    // makes the default mode byte-identical to the behaviour before per-app
+    // routing existed.
+    if (uid < 0 || route_uids == NULL)
+        tunnel = route_default_tunnel;
+    else
+        tunnel = bsearch(&uid, route_uids, (size_t) route_uid_count, sizeof(jint), compare_uid)
+                 != NULL;
+
+    if (pthread_mutex_unlock(&route_lock))
+        log_android(ANDROID_LOG_ERROR, "route unlock failed");
+
+    return tunnel;
+}
+
+/**
+ * The whole per-packet routing decision, kept free of I/O so it can be reasoned
+ * about (and, unlike the rest of this directory, read straight through).
+ *
+ * @param wg_active      whether the WireGuard bridge currently accepts packets
+ * @param wg_is_required whether egress must not fall back to the raw network
+ * @param local_dest     loopback / link-local / multicast destination
+ * @param is_dns         port 53, over UDP or TCP
+ * @param tunnel_uid     whether this packet's UID is routed through the tunnel
+ * @param dns_direct     whether direct apps' DNS is redirected to the system
+ *                       resolver; while false, DNS always takes the tunnel
+ */
+enum route_decision route_decide(int wg_active, int wg_is_required, int local_dest,
+                                 int is_dns, int tunnel_uid, int dns_direct) {
+    // Destinations WireGuard cannot meaningfully forward never take the tunnel,
+    // whichever app sent them.
+    if (local_dest && !is_dns)
+        return ROUTE_DIRECT;
+
+    // Until the DNS split ships, every resolver query takes the tunnel: sending
+    // it out directly would expose the user's physical network to the resolver.
+    int wants_tunnel = (is_dns && !dns_direct) ? 1 : tunnel_uid;
+
+    if (!wants_tunnel)
+        return ROUTE_DIRECT;
+
+    if (wg_active)
+        return ROUTE_TUNNEL;
+
+    // WireGuard is required but not running — the window during a tunnel
+    // restart, or after a failed start. Falling through to direct here would
+    // leak this app's traffic onto the raw network. DNS stays exempt because
+    // recovery has to re-resolve the peer endpoint, and blocking DNS would
+    // deadlock that recovery.
+    if (wg_is_required && !is_dns)
+        return ROUTE_DROP;
+
+    return ROUTE_DIRECT;
+}

--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -289,4 +289,85 @@
 
     </androidx.cardview.widget.CardView>
 
+    <!-- Remote VPN routing: independent of the protection state above -->
+    <androidx.cardview.widget.CardView
+        android:id="@+id/cardAppRoute"
+        android:layout_marginBottom="8dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        app:cardCornerRadius="4dp"
+        app:cardElevation="1dp"
+        app:cardMaxElevation="@dimen/z_card">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:id="@+id/tvAppRouteHeading"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_route_heading"
+                android:textColor="?android:textColorPrimary"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvAppRouteUnavailable"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
+                android:visibility="gone" />
+
+            <RadioGroup
+                android:id="@+id/rgAppRoute"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <RadioButton
+                    android:id="@+id/rbRouteTunnel"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_route_through"
+                    android:text="@string/app_route_through"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvRouteTunnelDesc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:layout_marginBottom="12dp"
+                    android:text="@string/app_route_through_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+                <RadioButton
+                    android:id="@+id/rbRouteDirect"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="4dp"
+                    android:contentDescription="@string/app_route_direct"
+                    android:text="@string/app_route_direct"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvRouteDirectDesc"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="32dp"
+                    android:text="@string/app_route_direct_explanation"
+                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+            </RadioGroup>
+
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
 </LinearLayout>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -388,4 +388,18 @@
     <string name="app_state_no_internet_shared_uid">ينطبق أيضًا على %1$s، الذي يشارك هذا التطبيق مُعرِّف مستخدم أندرويد.</string>
     <string name="app_state_bypassed">تجاوز TrackerControl</string>
     <string name="app_state_bypassed_explanation">يتصل التطبيق مباشرةً، خارج TrackerControl. لا تتم مراقبة أو حظر أي شيء له. استخدم هذا كملاذ أخير إذا كان التطبيق لا يزال لا يعمل.\n\nملاحظة: يجب تعطيل \"حظر الاتصالات بدون VPN\" في إعدادات VPN بنظام أندرويد حتى يعمل هذا.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">التوجيه عبر VPN البعيد</string>
+    <string name="summary_wg_route_mode">أي التطبيقات تُمرَّر عبر VPN البعيد. التطبيقات التي لا تُمرَّر تبقى مراقَبة ومُرشَّحة بالكامل — لكنها تتصل من شبكة هذا الجهاز.</string>
+    <string name="wg_route_mode_all">كل التطبيقات</string>
+    <string name="wg_route_mode_selected">التطبيقات المحددة فقط</string>
+    <string name="app_route_heading">VPN البعيد</string>
+    <string name="app_route_through">عبر VPN البعيد</string>
+    <string name="app_route_through_explanation">يتصل هذا التطبيق عبر VPN البعيد الخاص بك، الذي يرى حركته بدلاً من شبكتك.</string>
+    <string name="app_route_direct">مباشرةً من هذا الجهاز</string>
+    <string name="app_route_direct_explanation">يتصل هذا التطبيق من شبكتك. تظل مراقبة أدوات التتبع وحظرها سارية. تذهب استعلامات DNS الخاصة به إلى محلل شبكتك بدلاً من محلل VPN، ويرى العنوان الحقيقي لهذا الجهاز — بعض التطبيقات تحتاج ذلك، مثلاً للوصول إلى الأجهزة المحلية أو فحص بوابة الاتصال.</string>
+    <string name="app_route_unavailable_no_vpn">لا يوجد VPN بعيد مُعد، لذا فإن كل الحركة تغادر هذا الجهاز مباشرةً بالفعل.</string>
+    <string name="app_route_unavailable_bypassed">يتجاوز هذا التطبيق TrackerControl تمامًا، لذا لا توجد حركة لتوجيهها.</string>
+    <string name="app_route_unavailable_partial_routes">لا ينقل VPN البعيد كل الحركة (قيمة AllowedIPs لديه ليست نفقًا كاملاً). يتطلب التوجيه لكل تطبيق نفقًا كاملاً، لأن المسارات مشتركة بين كل التطبيقات.</string>
 </resources>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -71,4 +71,18 @@
     <string name="app_state_no_internet_shared_uid">%1$s-এর ক্ষেত্রেও প্রযোজ্য, যেটি এই অ্যাপের সঙ্গে একই Android ব্যবহারকারী আইডি ভাগ করে।</string>
     <string name="app_state_bypassed">TrackerControl এড়িয়ে যান</string>
     <string name="app_state_bypassed_explanation">অ্যাপটি TrackerControl-এর বাইরে সরাসরি সংযোগ করে। এর জন্য কিছুই পর্যবেক্ষণ বা ব্লক করা হয় না। অ্যাপ তবুও কাজ না করলে শেষ উপায় হিসেবে এটি ব্যবহার করুন।\n\nদ্রষ্টব্য: এটি কাজ করতে হলে Android-এর VPN সেটিংসে \"VPN ছাড়া সংযোগ ব্লক করুন\" বন্ধ থাকতে হবে।</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">দূরবর্তী VPN দিয়ে পাঠান</string>
+    <string name="summary_wg_route_mode">কোন অ্যাপগুলি দূরবর্তী VPN দিয়ে যাবে। যেগুলি যায় না সেগুলিতেও ট্র্যাকার পর্যবেক্ষণ ও ব্লকিং পুরোপুরি চলে — সেগুলি কেবল এই ডিভাইসের নিজের নেটওয়ার্ক থেকে সংযোগ করে।</string>
+    <string name="wg_route_mode_all">সব অ্যাপ</string>
+    <string name="wg_route_mode_selected">শুধু নির্বাচিত অ্যাপ</string>
+    <string name="app_route_heading">দূরবর্তী VPN</string>
+    <string name="app_route_through">দূরবর্তী VPN দিয়ে</string>
+    <string name="app_route_through_explanation">এই অ্যাপটি আপনার দূরবর্তী VPN দিয়ে সংযোগ করে, যা আপনার নেটওয়ার্কের বদলে এর ট্রাফিক দেখে।</string>
+    <string name="app_route_direct">সরাসরি এই ডিভাইস থেকে</string>
+    <string name="app_route_direct_explanation">এই অ্যাপটি আপনার নিজের নেটওয়ার্ক থেকে সংযোগ করে। ট্র্যাকার পর্যবেক্ষণ ও ব্লকিং তবুও প্রযোজ্য। এর DNS অনুরোধ VPN-এর বদলে আপনার নেটওয়ার্কের রিজলভারে যায় এবং এটি এই ডিভাইসের প্রকৃত ঠিকানা দেখে — কিছু অ্যাপের এটি দরকার, যেমন স্থানীয় ডিভাইসে পৌঁছাতে বা ক্যাপটিভ পোর্টাল যাচাই করতে।</string>
+    <string name="app_route_unavailable_no_vpn">কোনও দূরবর্তী VPN সেট করা নেই, তাই সব ট্রাফিক ইতিমধ্যেই সরাসরি এই ডিভাইস থেকে যাচ্ছে।</string>
+    <string name="app_route_unavailable_bypassed">এই অ্যাপটি TrackerControl সম্পূর্ণ এড়িয়ে যায়, তাই পাঠানোর মতো কোনও ট্রাফিক নেই।</string>
+    <string name="app_route_unavailable_partial_routes">আপনার দূরবর্তী VPN সব ট্রাফিক বহন করে না (এর AllowedIPs পূর্ণ টানেল নয়)। অ্যাপভিত্তিক রাউটিংয়ের জন্য পূর্ণ টানেল দরকার, কারণ রুটগুলি সব অ্যাপ ভাগ করে নেয়।</string>
 </resources>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -404,4 +404,18 @@ Privátní DNS musí být vypnutá.</string>
     <string name="app_state_no_internet_shared_uid">Platí i pro %1$s, která s touto aplikací sdílí uživatelské ID systému Android.</string>
     <string name="app_state_bypassed">Obejít TrackerControl</string>
     <string name="app_state_bypassed_explanation">Aplikace se připojuje přímo, mimo TrackerControl. Nic se pro ni nesleduje ani neblokuje. Použijte jako poslední možnost, pokud aplikace stále nefunguje.\n\nPoznámka: Aby to fungovalo, musí být volba \"Blokovat připojení bez VPN\" v nastavení VPN systému Android VYPNUTA.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Směrovat přes vzdálenou VPN</string>
+    <string name="summary_wg_route_mode">Které aplikace se přeposílají přes vzdálenou VPN. Ostatní zůstávají plně sledované a filtrované — jen se připojují ze sítě tohoto zařízení.</string>
+    <string name="wg_route_mode_all">Všechny aplikace</string>
+    <string name="wg_route_mode_selected">Jen vybrané aplikace</string>
+    <string name="app_route_heading">Vzdálená VPN</string>
+    <string name="app_route_through">Přes vzdálenou VPN</string>
+    <string name="app_route_through_explanation">Tato aplikace se připojuje přes vaši vzdálenou VPN, která místo vaší sítě vidí její provoz.</string>
+    <string name="app_route_direct">Přímo z tohoto zařízení</string>
+    <string name="app_route_direct_explanation">Tato aplikace se připojuje z vaší vlastní sítě. Sledování a blokování trackerů dál platí. Její DNS dotazy míří na resolver vaší sítě místo na VPN a aplikace vidí skutečnou adresu tohoto zařízení — některé aplikace to potřebují, třeba k dosažení místních zařízení nebo kontrole captive portálu.</string>
+    <string name="app_route_unavailable_no_vpn">Není nastavena žádná vzdálená VPN, takže veškerý provoz už z tohoto zařízení odchází přímo.</string>
+    <string name="app_route_unavailable_bypassed">Tato aplikace TrackerControl zcela obchází, takže není co směrovat.</string>
+    <string name="app_route_unavailable_partial_routes">Vaše vzdálená VPN nepřenáší veškerý provoz (její AllowedIPs netvoří úplný tunel). Směrování po aplikacích vyžaduje úplný tunel, protože trasy sdílejí všechny aplikace.</string>
 </resources>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -126,4 +126,18 @@
     <string name="app_state_no_internet_shared_uid">Gælder også %1$s, som deler et Android-bruger-id med denne app.</string>
     <string name="app_state_bypassed">Omgå TrackerControl</string>
     <string name="app_state_bypassed_explanation">Appen forbinder direkte, uden om TrackerControl. Intet overvåges eller blokeres for den. Brug dette som sidste udvej, hvis appen stadig ikke virker.\n\nBemærk: \"Bloker forbindelser uden VPN\" i Androids VPN-indstillinger skal være DEAKTIVERET, for at dette virker.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Send gennem fjern-VPN</string>
+    <string name="summary_wg_route_mode">Hvilke apps der sendes gennem fjern-VPN\'et. De øvrige overvåges og filtreres fortsat fuldt ud — de forbinder blot fra enhedens eget netværk.</string>
+    <string name="wg_route_mode_all">Alle apps</string>
+    <string name="wg_route_mode_selected">Kun valgte apps</string>
+    <string name="app_route_heading">Fjern-VPN</string>
+    <string name="app_route_through">Gennem fjern-VPN\'et</string>
+    <string name="app_route_through_explanation">Denne app forbinder gennem dit fjern-VPN, som ser dens trafik i stedet for dit netværk.</string>
+    <string name="app_route_direct">Direkte fra denne enhed</string>
+    <string name="app_route_direct_explanation">Denne app forbinder fra dit eget netværk. Sporingsovervågning og -blokering gælder stadig. Dens DNS-forespørgsler går til dit netværks resolver i stedet for VPN\'ets, og appen ser enhedens rigtige adresse — nogle apps har brug for det, for eksempel for at nå lokale enheder eller tjekke en captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Der er ikke opsat noget fjern-VPN, så al trafik forlader allerede enheden direkte.</string>
+    <string name="app_route_unavailable_bypassed">Denne app omgår TrackerControl helt, så der er ingen trafik at sende.</string>
+    <string name="app_route_unavailable_partial_routes">Dit fjern-VPN bærer ikke al trafik (dets AllowedIPs er ikke en fuld tunnel). Routing pr. app kræver en fuld tunnel, fordi ruter deles af alle apps.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -353,4 +353,18 @@
     <string name="app_state_no_internet_shared_uid">Gilt auch für %1$s, da diese App sich eine Android-Benutzer-ID mit dieser App teilt.</string>
     <string name="app_state_bypassed">TrackerControl umgehen</string>
     <string name="app_state_bypassed_explanation">Die App verbindet sich direkt, außerhalb von TrackerControl. Nichts wird für sie überwacht oder blockiert. Nutze dies als letzten Ausweg, wenn die App weiterhin nicht funktioniert.\n\nHinweis: \"Verbindungen ohne VPN blockieren\" in den Android-VPN-Einstellungen muss DEAKTIVIERT sein, damit dies funktioniert.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Über Remote-VPN leiten</string>
+    <string name="summary_wg_route_mode">Welche Apps über das Remote-VPN geleitet werden. Apps, die es nicht sind, werden weiterhin vollständig auf Tracker überwacht und gefiltert — sie verbinden sich nur über das eigene Netzwerk dieses Geräts.</string>
+    <string name="wg_route_mode_all">Alle Apps</string>
+    <string name="wg_route_mode_selected">Nur ausgewählte Apps</string>
+    <string name="app_route_heading">Remote-VPN</string>
+    <string name="app_route_through">Über das Remote-VPN</string>
+    <string name="app_route_through_explanation">Diese App verbindet sich über dein Remote-VPN, das ihren Datenverkehr anstelle deines Netzwerks sieht.</string>
+    <string name="app_route_direct">Direkt von diesem Gerät</string>
+    <string name="app_route_direct_explanation">Diese App verbindet sich über dein eigenes Netzwerk. Tracker-Überwachung und -Blockierung gelten weiterhin. Ihre DNS-Anfragen gehen an den Resolver deines Netzwerks statt an den des VPNs, und sie sieht die echte Adresse dieses Geräts — manche Apps brauchen das, etwa für lokale Geräte oder die Prüfung eines Captive Portals.</string>
+    <string name="app_route_unavailable_no_vpn">Es ist kein Remote-VPN eingerichtet, daher verlässt bereits der gesamte Verkehr dieses Gerät direkt.</string>
+    <string name="app_route_unavailable_bypassed">Diese App umgeht TrackerControl vollständig, daher gibt es keinen Verkehr zu leiten.</string>
+    <string name="app_route_unavailable_partial_routes">Dein Remote-VPN überträgt nicht den gesamten Verkehr (seine AllowedIPs bilden keinen vollständigen Tunnel). Per-App-Routing benötigt einen vollständigen Tunnel, da Routen von allen Apps geteilt werden.</string>
 </resources>

--- a/app/src/main/res/values-el-rGR/strings.xml
+++ b/app/src/main/res/values-el-rGR/strings.xml
@@ -330,4 +330,18 @@
     <string name="app_state_no_internet_shared_uid">Ισχύει και για το %1$s, το οποίο μοιράζεται αναγνωριστικό χρήστη Android με αυτήν την εφαρμογή.</string>
     <string name="app_state_bypassed">Παράκαμψη του TrackerControl</string>
     <string name="app_state_bypassed_explanation">Η εφαρμογή συνδέεται απευθείας, εκτός του TrackerControl. Τίποτα δεν παρακολουθείται ούτε αποκλείεται για αυτήν. Χρησιμοποιήστε το ως έσχατη λύση αν η εφαρμογή εξακολουθεί να μη λειτουργεί.\n\nΣημείωση: Η επιλογή \"Αποκλεισμός συνδέσεων χωρίς VPN\" στις ρυθμίσεις VPN του Android πρέπει να είναι ΑΠΕΝΕΡΓΟΠΟΙΗΜΕΝΗ για να λειτουργήσει αυτό.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Δρομολόγηση μέσω απομακρυσμένου VPN</string>
+    <string name="summary_wg_route_mode">Ποιες εφαρμογές προωθούνται μέσω του απομακρυσμένου VPN. Όσες δεν προωθούνται παραμένουν πλήρως παρακολουθούμενες και φιλτραρισμένες — απλώς συνδέονται από το δίκτυο αυτής της συσκευής.</string>
+    <string name="wg_route_mode_all">Όλες οι εφαρμογές</string>
+    <string name="wg_route_mode_selected">Μόνο επιλεγμένες εφαρμογές</string>
+    <string name="app_route_heading">Απομακρυσμένο VPN</string>
+    <string name="app_route_through">Μέσω του απομακρυσμένου VPN</string>
+    <string name="app_route_through_explanation">Αυτή η εφαρμογή συνδέεται μέσω του απομακρυσμένου VPN σας, το οποίο βλέπει την κίνησή της αντί για το δίκτυό σας.</string>
+    <string name="app_route_direct">Απευθείας από αυτήν τη συσκευή</string>
+    <string name="app_route_direct_explanation">Αυτή η εφαρμογή συνδέεται από το δικό σας δίκτυο. Η παρακολούθηση και ο αποκλεισμός ιχνηλατών εξακολουθούν να ισχύουν. Τα ερωτήματα DNS της πηγαίνουν στον resolver του δικτύου σας αντί του VPN, και βλέπει την πραγματική διεύθυνση της συσκευής — ορισμένες εφαρμογές το χρειάζονται, π.χ. για πρόσβαση σε τοπικές συσκευές ή έλεγχο captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Δεν έχει ρυθμιστεί απομακρυσμένο VPN, οπότε όλη η κίνηση φεύγει ήδη απευθείας από αυτήν τη συσκευή.</string>
+    <string name="app_route_unavailable_bypassed">Αυτή η εφαρμογή παρακάμπτει πλήρως το TrackerControl, οπότε δεν υπάρχει κίνηση προς δρομολόγηση.</string>
+    <string name="app_route_unavailable_partial_routes">Το απομακρυσμένο VPN σας δεν μεταφέρει όλη την κίνηση (τα AllowedIPs του δεν είναι πλήρης σήραγγα). Η δρομολόγηση ανά εφαρμογή απαιτεί πλήρη σήραγγα, καθώς οι διαδρομές είναι κοινές για όλες τις εφαρμογές.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -405,4 +405,18 @@ Atentamente,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">También se aplica a %1$s, que comparte un ID de usuario de Android con esta aplicación.</string>
     <string name="app_state_bypassed">Omitir TrackerControl</string>
     <string name="app_state_bypassed_explanation">La aplicación se conecta directamente, fuera de TrackerControl. No se supervisa ni se bloquea nada para ella. Usa esto como último recurso si la aplicación sigue sin funcionar.\n\nNota: \"Bloquear conexiones sin VPN\" en los ajustes de VPN de Android debe estar DESACTIVADO para que esto funcione.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Enrutar por el VPN remoto</string>
+    <string name="summary_wg_route_mode">Qué aplicaciones se envían a través del VPN remoto. Las que no lo hacen siguen totalmente supervisadas y filtradas — simplemente se conectan desde la red de este dispositivo.</string>
+    <string name="wg_route_mode_all">Todas las aplicaciones</string>
+    <string name="wg_route_mode_selected">Solo aplicaciones seleccionadas</string>
+    <string name="app_route_heading">VPN remoto</string>
+    <string name="app_route_through">A través del VPN remoto</string>
+    <string name="app_route_through_explanation">Esta aplicación se conecta a través de tu VPN remoto, que ve su tráfico en lugar de tu red.</string>
+    <string name="app_route_direct">Directamente desde este dispositivo</string>
+    <string name="app_route_direct_explanation">Esta aplicación se conecta desde tu propia red. La supervisión y el bloqueo de rastreadores siguen aplicándose. Sus consultas DNS van al resolutor de tu red en lugar del VPN, y ve la dirección real de este dispositivo — algunas aplicaciones lo necesitan, por ejemplo para llegar a dispositivos locales o comprobar un portal cautivo.</string>
+    <string name="app_route_unavailable_no_vpn">No hay ningún VPN remoto configurado, así que todo el tráfico ya sale directamente de este dispositivo.</string>
+    <string name="app_route_unavailable_bypassed">Esta aplicación omite TrackerControl por completo, así que no hay tráfico que enrutar.</string>
+    <string name="app_route_unavailable_partial_routes">Tu VPN remoto no transporta todo el tráfico (sus AllowedIPs no forman un túnel completo). El enrutamiento por aplicación necesita un túnel completo, porque las rutas las comparten todas las aplicaciones.</string>
 </resources>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -248,4 +248,18 @@
     <string name="app_state_no_internet_shared_uid">Kehtib ka rakendusele %1$s, mis jagab selle rakendusega Androidi kasutaja-ID-d.</string>
     <string name="app_state_bypassed">TrackerControlist mööda</string>
     <string name="app_state_bypassed_explanation">Rakendus ühendub otse, TrackerControlist mööda. Tema jaoks ei jälgita ega blokeerita midagi. Kasuta seda viimase abinõuna, kui rakendus ikka ei tööta.\n\nMärkus: Androidi VPN-i sätetes peab \"Blokeeri ühendused ilma VPN-ita\" olema VÄLJA LÜLITATUD, et see toimiks.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Suuna läbi kaug-VPN-i</string>
+    <string name="summary_wg_route_mode">Millised rakendused suunatakse läbi kaug-VPN-i. Ülejäänud jäävad täielikult jälgituks ja filtreerituks — nad lihtsalt ühenduvad selle seadme enda võrgust.</string>
+    <string name="wg_route_mode_all">Kõik rakendused</string>
+    <string name="wg_route_mode_selected">Ainult valitud rakendused</string>
+    <string name="app_route_heading">Kaug-VPN</string>
+    <string name="app_route_through">Läbi kaug-VPN-i</string>
+    <string name="app_route_through_explanation">See rakendus ühendub sinu kaug-VPN-i kaudu, mis näeb selle liiklust sinu võrgu asemel.</string>
+    <string name="app_route_direct">Otse sellest seadmest</string>
+    <string name="app_route_direct_explanation">See rakendus ühendub sinu enda võrgust. Jälitajate seire ja blokeerimine kehtivad edasi. Selle DNS-päringud lähevad sinu võrgu nimeserverisse, mitte VPN-i omasse, ja rakendus näeb seadme tegelikku aadressi — mõni rakendus vajab seda, näiteks kohalike seadmete jaoks või captive portali kontrolliks.</string>
+    <string name="app_route_unavailable_no_vpn">Kaug-VPN-i pole seadistatud, seega kogu liiklus lahkub juba otse sellest seadmest.</string>
+    <string name="app_route_unavailable_bypassed">See rakendus möödub TrackerControlist täielikult, seega pole liiklust, mida suunata.</string>
+    <string name="app_route_unavailable_partial_routes">Sinu kaug-VPN ei kanna kogu liiklust (selle AllowedIPs pole täistunnel). Rakendusepõhine suunamine vajab täistunnelit, sest marsruudid on kõigil rakendustel ühised.</string>
 </resources>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -369,4 +369,18 @@ Sareko trafikoan antzematen diren aztarnariak TrackerControl-ekin blokeatu daite
     <string name="app_state_no_internet_shared_uid">%1$s aplikazioari ere aplikatzen zaio, Android erabiltzaile-ID bera partekatzen baitu honekin.</string>
     <string name="app_state_bypassed">Saihestu TrackerControl</string>
     <string name="app_state_bypassed_explanation">Aplikazioa zuzenean konektatzen da, TrackerControletik kanpo. Ez zaio ezer monitorizatzen ez blokeatzen. Erabili hau azken aukera gisa aplikazioak oraindik funtzionatzen ez badu.\n\nOharra: Androiden VPN ezarpenetako \"Blokeatu VPNrik gabeko konexioak\" DESAKTIBATUTA egon behar da hau funtziona dezan.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Urruneko VPN bidez bideratu</string>
+    <string name="summary_wg_route_mode">Zein aplikazio bidaltzen diren urruneko VPN bidez. Gainerakoak guztiz monitorizatuta eta iragazita jarraitzen dute — gailu honen sare propiotik konektatzen dira, besterik ez.</string>
+    <string name="wg_route_mode_all">Aplikazio guztiak</string>
+    <string name="wg_route_mode_selected">Hautatutako aplikazioak bakarrik</string>
+    <string name="app_route_heading">Urruneko VPNa</string>
+    <string name="app_route_through">Urruneko VPN bidez</string>
+    <string name="app_route_through_explanation">Aplikazio hau zure urruneko VPN bidez konektatzen da, eta hark ikusten du bere trafikoa zure sarearen ordez.</string>
+    <string name="app_route_direct">Zuzenean gailu honetatik</string>
+    <string name="app_route_direct_explanation">Aplikazio hau zure sare propiotik konektatzen da. Jarraitzaileen monitorizazioa eta blokeoa indarrean daude oraindik. Bere DNS kontsultak zure sarearen ebazlera doaz, ez VPNarenera, eta gailu honen benetako helbidea ikusten du — aplikazio batzuek hori behar dute, adibidez tokiko gailuetara iristeko edo captive portal bat egiaztatzeko.</string>
+    <string name="app_route_unavailable_no_vpn">Ez dago urruneko VPNrik konfiguratuta, beraz trafiko guztia dagoeneko zuzenean ateratzen da gailu honetatik.</string>
+    <string name="app_route_unavailable_bypassed">Aplikazio honek TrackerControl guztiz saihesten du, beraz ez dago bideratzeko trafikorik.</string>
+    <string name="app_route_unavailable_partial_routes">Zure urruneko VPNak ez du trafiko guztia garraiatzen (bere AllowedIPs ez da tunel osoa). Aplikazioz aplikazioko bideratzeak tunel osoa behar du, ibilbideak aplikazio guztien artean partekatzen baitira.</string>
 </resources>

--- a/app/src/main/res/values-fa-rIR/strings.xml
+++ b/app/src/main/res/values-fa-rIR/strings.xml
@@ -28,4 +28,18 @@
     <string name="app_state_no_internet_shared_uid">برای %1$s نیز اعمال می‌شود، که شناسهٔ کاربری اندروید را با این برنامه به اشتراک می‌گذارد.</string>
     <string name="app_state_bypassed">دور زدن TrackerControl</string>
     <string name="app_state_bypassed_explanation">برنامه مستقیماً و خارج از TrackerControl متصل می‌شود. هیچ چیزی برای آن پایش یا مسدود نمی‌شود. اگر برنامه هنوز کار نمی‌کند، این را به‌عنوان آخرین راه‌حل استفاده کنید.\n\nتوجه: گزینهٔ \"مسدودسازی اتصال‌های بدون VPN\" در تنظیمات VPN اندروید باید غیرفعال باشد تا این کار کند.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">مسیریابی از طریق VPN راه دور</string>
+    <string name="summary_wg_route_mode">کدام برنامه‌ها از طریق VPN راه دور فرستاده شوند. برنامه‌هایی که فرستاده نمی‌شوند همچنان به‌طور کامل پایش و فیلتر می‌شوند — فقط از شبکهٔ خودِ این دستگاه متصل می‌شوند.</string>
+    <string name="wg_route_mode_all">همهٔ برنامه‌ها</string>
+    <string name="wg_route_mode_selected">فقط برنامه‌های انتخاب‌شده</string>
+    <string name="app_route_heading">VPN راه دور</string>
+    <string name="app_route_through">از طریق VPN راه دور</string>
+    <string name="app_route_through_explanation">این برنامه از طریق VPN راه دور شما متصل می‌شود، که به‌جای شبکهٔ شما ترافیک آن را می‌بیند.</string>
+    <string name="app_route_direct">مستقیم از این دستگاه</string>
+    <string name="app_route_direct_explanation">این برنامه از شبکهٔ خودتان متصل می‌شود. پایش و مسدودسازی ردیاب‌ها همچنان اعمال می‌شود. پرس‌وجوهای DNS آن به‌جای VPN به حل‌کنندهٔ شبکهٔ شما می‌رود و برنامه نشانی واقعی این دستگاه را می‌بیند — برخی برنامه‌ها به این نیاز دارند، مثلاً برای دسترسی به دستگاه‌های محلی یا بررسی captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">هیچ VPN راه دوری تنظیم نشده است، بنابراین همهٔ ترافیک از پیش مستقیماً این دستگاه را ترک می‌کند.</string>
+    <string name="app_route_unavailable_bypassed">این برنامه به‌طور کامل TrackerControl را دور می‌زند، بنابراین ترافیکی برای مسیریابی وجود ندارد.</string>
+    <string name="app_route_unavailable_partial_routes">VPN راه دور شما همهٔ ترافیک را حمل نمی‌کند (AllowedIPs آن تونل کامل نیست). مسیریابی جداگانه برای هر برنامه به تونل کامل نیاز دارد، چون مسیرها میان همهٔ برنامه‌ها مشترک است.</string>
 </resources>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -458,4 +458,18 @@ Ystävällisin terveisin,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Koskee myös sovellusta %1$s, jolla on sama Android-käyttäjätunnus kuin tällä sovelluksella.</string>
     <string name="app_state_bypassed">Ohita TrackerControl</string>
     <string name="app_state_bypassed_explanation">Sovellus muodostaa yhteyden suoraan, TrackerControlin ohi. Sille ei valvota eikä estetä mitään. Käytä tätä viimeisenä keinona, jos sovellus ei vieläkään toimi.\n\nHuomaa: Androidin VPN-asetusten kohdan \"Estä yhteydet ilman VPN:ää\" on oltava POIS KÄYTÖSTÄ, jotta tämä toimii.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Reititä etä-VPN:n kautta</string>
+    <string name="summary_wg_route_mode">Mitkä sovellukset kulkevat etä-VPN:n kautta. Muita valvotaan ja suodatetaan edelleen täysin — ne vain yhdistävät tämän laitteen omasta verkosta.</string>
+    <string name="wg_route_mode_all">Kaikki sovellukset</string>
+    <string name="wg_route_mode_selected">Vain valitut sovellukset</string>
+    <string name="app_route_heading">Etä-VPN</string>
+    <string name="app_route_through">Etä-VPN:n kautta</string>
+    <string name="app_route_through_explanation">Tämä sovellus yhdistää etä-VPN:si kautta, joka näkee sen liikenteen verkkosi sijaan.</string>
+    <string name="app_route_direct">Suoraan tästä laitteesta</string>
+    <string name="app_route_direct_explanation">Tämä sovellus yhdistää omasta verkostasi. Seuraimien valvonta ja esto ovat edelleen voimassa. Sen DNS-kyselyt menevät verkkosi nimipalvelimelle VPN:n sijaan, ja sovellus näkee laitteen todellisen osoitteen — jotkin sovellukset tarvitsevat sitä, esimerkiksi paikallisten laitteiden tavoittamiseen tai captive portalin tarkistamiseen.</string>
+    <string name="app_route_unavailable_no_vpn">Etä-VPN:ää ei ole määritetty, joten kaikki liikenne lähtee jo suoraan tästä laitteesta.</string>
+    <string name="app_route_unavailable_bypassed">Tämä sovellus ohittaa TrackerControlin kokonaan, joten reititettävää liikennettä ei ole.</string>
+    <string name="app_route_unavailable_partial_routes">Etä-VPN:si ei kuljeta kaikkea liikennettä (sen AllowedIPs ei ole täysi tunneli). Sovelluskohtainen reititys vaatii täyden tunnelin, koska reitit ovat kaikille sovelluksille yhteiset.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -586,4 +586,18 @@ Cordialement,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">S\'applique également à %1$s, qui partage un identifiant utilisateur Android avec cette application.</string>
     <string name="app_state_bypassed">Contourner TrackerControl</string>
     <string name="app_state_bypassed_explanation">L\'application se connecte directement, en dehors de TrackerControl. Rien n\'est surveillé ni bloqué pour elle. À utiliser en dernier recours si l\'application ne fonctionne toujours pas.\n\nRemarque : \"Bloquer les connexions sans VPN\" doit être DÉSACTIVÉ dans les paramètres VPN d\'Android pour que cela fonctionne.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Faire passer par le VPN distant</string>
+    <string name="summary_wg_route_mode">Quelles applications sont acheminées via le VPN distant. Celles qui ne le sont pas restent entièrement surveillées et filtrées — elles se connectent simplement depuis le réseau de cet appareil.</string>
+    <string name="wg_route_mode_all">Toutes les applications</string>
+    <string name="wg_route_mode_selected">Seulement les applications sélectionnées</string>
+    <string name="app_route_heading">VPN distant</string>
+    <string name="app_route_through">Via le VPN distant</string>
+    <string name="app_route_through_explanation">Cette application se connecte via votre VPN distant, qui voit son trafic à la place de votre réseau.</string>
+    <string name="app_route_direct">Directement depuis cet appareil</string>
+    <string name="app_route_direct_explanation">Cette application se connecte depuis votre propre réseau. La surveillance et le blocage des traqueurs continuent de s\'appliquer. Ses requêtes DNS vont au résolveur de votre réseau plutôt qu\'à celui du VPN, et elle voit l\'adresse réelle de cet appareil — certaines applications en ont besoin, par exemple pour joindre des appareils locaux ou vérifier un portail captif.</string>
+    <string name="app_route_unavailable_no_vpn">Aucun VPN distant n\'est configuré, tout le trafic quitte donc déjà cet appareil directement.</string>
+    <string name="app_route_unavailable_bypassed">Cette application contourne entièrement TrackerControl, il n\'y a donc aucun trafic à acheminer.</string>
+    <string name="app_route_unavailable_partial_routes">Votre VPN distant ne transporte pas tout le trafic (ses AllowedIPs ne forment pas un tunnel complet). Le routage par application nécessite un tunnel complet, car les routes sont partagées par toutes les applications.</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -91,4 +91,18 @@ O seu tráfico de internet non será enviado a ningún servidor VPN remoto.</str
     <string name="app_state_no_internet_shared_uid">Tamén se aplica a %1$s, que comparte un ID de usuario de Android con esta aplicación.</string>
     <string name="app_state_bypassed">Omitir TrackerControl</string>
     <string name="app_state_bypassed_explanation">A aplicación conéctase directamente, fóra de TrackerControl. Non se supervisa nin se bloquea nada para ela. Usa isto como último recurso se a aplicación segue sen funcionar.\n\nNota: \"Bloquear conexións sen VPN\" nos axustes de VPN de Android debe estar DESACTIVADO para que isto funcione.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Encamiñar polo VPN remoto</string>
+    <string name="summary_wg_route_mode">Que aplicacións se envían a través do VPN remoto. As que non seguen totalmente supervisadas e filtradas — simplemente conéctanse desde a rede deste dispositivo.</string>
+    <string name="wg_route_mode_all">Todas as aplicacións</string>
+    <string name="wg_route_mode_selected">Só aplicacións seleccionadas</string>
+    <string name="app_route_heading">VPN remoto</string>
+    <string name="app_route_through">A través do VPN remoto</string>
+    <string name="app_route_through_explanation">Esta aplicación conéctase a través do teu VPN remoto, que ve o seu tráfico no canto da túa rede.</string>
+    <string name="app_route_direct">Directamente desde este dispositivo</string>
+    <string name="app_route_direct_explanation">Esta aplicación conéctase desde a túa propia rede. A supervisión e o bloqueo de rastrexadores seguen a aplicarse. As súas consultas DNS van ao resolvedor da túa rede no canto do VPN, e ve o enderezo real deste dispositivo — algunhas aplicacións precísano, por exemplo para chegar a dispositivos locais ou comprobar un portal cativo.</string>
+    <string name="app_route_unavailable_no_vpn">Non hai ningún VPN remoto configurado, así que todo o tráfico xa sae directamente deste dispositivo.</string>
+    <string name="app_route_unavailable_bypassed">Esta aplicación omite TrackerControl por completo, así que non hai tráfico que encamiñar.</string>
+    <string name="app_route_unavailable_partial_routes">O teu VPN remoto non transporta todo o tráfico (os seus AllowedIPs non forman un túnel completo). O encamiñamento por aplicación precisa un túnel completo, porque as rutas compártenas todas as aplicacións.</string>
 </resources>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -368,4 +368,18 @@ Tisztelettel,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Erre is vonatkozik: %1$s, amely Android-felhasználóazonosítón osztozik ezzel az alkalmazással.</string>
     <string name="app_state_bypassed">TrackerControl megkerülése</string>
     <string name="app_state_bypassed_explanation">Az alkalmazás közvetlenül, a TrackerControlon kívül csatlakozik. Semmit sem figyel és blokkol nála. Végső megoldásként használja, ha az alkalmazás továbbra sem működik.\n\nMegjegyzés: az Android VPN-beállításaiban a \"Kapcsolatok blokkolása VPN nélkül\" beállításnak KIKAPCSOLVA kell lennie, hogy ez működjön.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Átirányítás a távoli VPN-en</string>
+    <string name="summary_wg_route_mode">Mely alkalmazások haladnak át a távoli VPN-en. A többi továbbra is teljesen felügyelt és szűrt — csak az eszköz saját hálózatáról csatlakoznak.</string>
+    <string name="wg_route_mode_all">Minden alkalmazás</string>
+    <string name="wg_route_mode_selected">Csak a kiválasztott alkalmazások</string>
+    <string name="app_route_heading">Távoli VPN</string>
+    <string name="app_route_through">A távoli VPN-en át</string>
+    <string name="app_route_through_explanation">Ez az alkalmazás a távoli VPN-en át csatlakozik, amely a hálózata helyett látja a forgalmát.</string>
+    <string name="app_route_direct">Közvetlenül erről az eszközről</string>
+    <string name="app_route_direct_explanation">Ez az alkalmazás a saját hálózatáról csatlakozik. A követők felügyelete és blokkolása továbbra is érvényes. DNS-kérései a VPN helyett a hálózat feloldójához mennek, és az alkalmazás látja az eszköz valódi címét — egyes alkalmazásoknak erre szükségük van, például helyi eszközök eléréséhez vagy captive portal ellenőrzéséhez.</string>
+    <string name="app_route_unavailable_no_vpn">Nincs beállítva távoli VPN, így minden forgalom már közvetlenül hagyja el az eszközt.</string>
+    <string name="app_route_unavailable_bypassed">Ez az alkalmazás teljesen megkerüli a TrackerControlt, így nincs mit átirányítani.</string>
+    <string name="app_route_unavailable_partial_routes">A távoli VPN nem viszi az összes forgalmat (az AllowedIPs nem teljes alagút). Az alkalmazásonkénti átirányításhoz teljes alagút kell, mert az útvonalakat minden alkalmazás megosztja.</string>
 </resources>

--- a/app/src/main/res/values-is-rIS/strings.xml
+++ b/app/src/main/res/values-is-rIS/strings.xml
@@ -15,4 +15,18 @@
     <string name="app_state_no_internet_shared_uid">Á einnig við um %1$s, sem deilir Android-notandaauðkenni með þessu forriti.</string>
     <string name="app_state_bypassed">Sniðganga TrackerControl</string>
     <string name="app_state_bypassed_explanation">Forritið tengist beint, utan TrackerControl. Ekkert er vaktað eða útilokað fyrir það. Notaðu þetta sem síðasta úrræði ef forritið virkar enn ekki.\n\nAthugið: \"Loka á tengingar án VPN\" í VPN-stillingum Android verður að vera SLÖKKT til að þetta virki.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Beina um fjartengt VPN</string>
+    <string name="summary_wg_route_mode">Hvaða forrit fara um fjartengda VPN-ið. Þau sem gera það ekki eru áfram að fullu vöktuð og síuð — þau tengjast einfaldlega um net þessa tækis.</string>
+    <string name="wg_route_mode_all">Öll forrit</string>
+    <string name="wg_route_mode_selected">Aðeins valin forrit</string>
+    <string name="app_route_heading">Fjartengt VPN</string>
+    <string name="app_route_through">Um fjartengda VPN-ið</string>
+    <string name="app_route_through_explanation">Þetta forrit tengist um fjartengda VPN-ið þitt, sem sér umferð þess í stað netsins þíns.</string>
+    <string name="app_route_direct">Beint frá þessu tæki</string>
+    <string name="app_route_direct_explanation">Þetta forrit tengist um þitt eigið net. Vöktun og útilokun rekjara gilda áfram. DNS-fyrirspurnir þess fara á nafnaþjón netsins þíns í stað VPN-sins og forritið sér raunverulegt vistfang tækisins — sum forrit þurfa það, til dæmis til að ná í staðbundin tæki eða athuga captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Ekkert fjartengt VPN er uppsett, svo öll umferð fer nú þegar beint frá þessu tæki.</string>
+    <string name="app_route_unavailable_bypassed">Þetta forrit sniðgengur TrackerControl algjörlega, svo það er engin umferð til að beina.</string>
+    <string name="app_route_unavailable_partial_routes">Fjartengda VPN-ið þitt ber ekki alla umferð (AllowedIPs þess er ekki full göng). Beining eftir forriti krefst fullra ganga því allar leiðir eru sameiginlegar öllum forritum.</string>
 </resources>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -365,4 +365,18 @@ Cordiali saluti,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Vale anche per %1$s, che condivide un ID utente Android con questa app.</string>
     <string name="app_state_bypassed">Ignora TrackerControl</string>
     <string name="app_state_bypassed_explanation">L\'app si connette direttamente, al di fuori di TrackerControl. Per essa non viene monitorato né bloccato nulla. Usa questa opzione come ultima risorsa se l\'app continua a non funzionare.\n\nNota: \"Blocca connessioni senza VPN\" nelle impostazioni VPN di Android deve essere DISATTIVATO perché funzioni.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Instrada tramite VPN remota</string>
+    <string name="summary_wg_route_mode">Quali app vengono inoltrate attraverso la VPN remota. Quelle che non lo sono restano completamente monitorate e filtrate — si connettono semplicemente dalla rete di questo dispositivo.</string>
+    <string name="wg_route_mode_all">Tutte le app</string>
+    <string name="wg_route_mode_selected">Solo le app selezionate</string>
+    <string name="app_route_heading">VPN remota</string>
+    <string name="app_route_through">Tramite la VPN remota</string>
+    <string name="app_route_through_explanation">Questa app si connette tramite la tua VPN remota, che vede il suo traffico al posto della tua rete.</string>
+    <string name="app_route_direct">Direttamente da questo dispositivo</string>
+    <string name="app_route_direct_explanation">Questa app si connette dalla tua rete. Il monitoraggio e il blocco dei tracker continuano ad applicarsi. Le sue richieste DNS vanno al resolver della tua rete anziché a quello della VPN, e l\'app vede l\'indirizzo reale di questo dispositivo — alcune app ne hanno bisogno, per esempio per raggiungere dispositivi locali o verificare un captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Non è configurata alcuna VPN remota, quindi tutto il traffico esce già direttamente da questo dispositivo.</string>
+    <string name="app_route_unavailable_bypassed">Questa app ignora completamente TrackerControl, quindi non c\'è traffico da instradare.</string>
+    <string name="app_route_unavailable_partial_routes">La tua VPN remota non trasporta tutto il traffico (i suoi AllowedIPs non formano un tunnel completo). L\'instradamento per app richiede un tunnel completo, perché le rotte sono condivise da tutte le app.</string>
 </resources>

--- a/app/src/main/res/values-iw-rIL/strings.xml
+++ b/app/src/main/res/values-iw-rIL/strings.xml
@@ -349,4 +349,18 @@
     <string name="app_state_no_internet_shared_uid">חל גם על %1$s, שחולקת מזהה משתמש של Android עם אפליקציה זו.</string>
     <string name="app_state_bypassed">עקיפת TrackerControl</string>
     <string name="app_state_bypassed_explanation">האפליקציה מתחברת ישירות, מחוץ ל-TrackerControl. דבר אינו מנוטר או נחסם עבורה. השתמשו בכך כמוצא אחרון אם האפליקציה עדיין לא עובדת.\n\nהערה: האפשרות \"חסום חיבורים ללא VPN\" בהגדרות ה-VPN של Android חייבת להיות מושבתת כדי שזה יעבוד.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">ניתוב דרך VPN מרוחק</string>
+    <string name="summary_wg_route_mode">אילו אפליקציות מועברות דרך ה-VPN המרוחק. אלה שלא, ממשיכות להיות מנוטרות ומסוננות במלואן — הן פשוט מתחברות מהרשת של המכשיר הזה.</string>
+    <string name="wg_route_mode_all">כל האפליקציות</string>
+    <string name="wg_route_mode_selected">רק אפליקציות נבחרות</string>
+    <string name="app_route_heading">VPN מרוחק</string>
+    <string name="app_route_through">דרך ה-VPN המרוחק</string>
+    <string name="app_route_through_explanation">אפליקציה זו מתחברת דרך ה-VPN המרוחק שלך, שרואה את התעבורה שלה במקום הרשת שלך.</string>
+    <string name="app_route_direct">ישירות מהמכשיר הזה</string>
+    <string name="app_route_direct_explanation">אפליקציה זו מתחברת מהרשת שלך. ניטור וחסימה של רכיבי מעקב ממשיכים לחול. שאילתות ה-DNS שלה הולכות לפותר של הרשת שלך במקום של ה-VPN, והיא רואה את הכתובת האמיתית של המכשיר — חלק מהאפליקציות זקוקות לכך, למשל כדי להגיע למכשירים מקומיים או לבדוק captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">לא מוגדר VPN מרוחק, ולכן כל התעבורה כבר יוצאת ישירות מהמכשיר הזה.</string>
+    <string name="app_route_unavailable_bypassed">אפליקציה זו עוקפת את TrackerControl לחלוטין, ולכן אין תעבורה לנתב.</string>
+    <string name="app_route_unavailable_partial_routes">ה-VPN המרוחק שלך אינו נושא את כל התעבורה (ה-AllowedIPs שלו אינו מנהרה מלאה). ניתוב לכל אפליקציה דורש מנהרה מלאה, מכיוון שהנתיבים משותפים לכל האפליקציות.</string>
 </resources>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -325,4 +325,18 @@
     <string name="app_state_no_internet_shared_uid">このアプリと Android のユーザー ID を共有する %1$s にも適用されます。</string>
     <string name="app_state_bypassed">TrackerControl を迂回</string>
     <string name="app_state_bypassed_explanation">アプリは TrackerControl を経由せず直接接続します。監視もブロックも行われません。アプリがそれでも動作しない場合の最終手段として使用してください。\n\n注意: これを機能させるには、Android の VPN 設定で \"VPN なしの接続をブロック\" を無効にする必要があります。</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">リモート VPN 経由で通す</string>
+    <string name="summary_wg_route_mode">どのアプリをリモート VPN 経由で通すか。通さないアプリも引き続き完全に監視・ブロックされ、この端末自身のネットワークから接続するだけです。</string>
+    <string name="wg_route_mode_all">すべてのアプリ</string>
+    <string name="wg_route_mode_selected">選択したアプリのみ</string>
+    <string name="app_route_heading">リモート VPN</string>
+    <string name="app_route_through">リモート VPN 経由</string>
+    <string name="app_route_through_explanation">このアプリはリモート VPN 経由で接続し、あなたのネットワークではなく VPN が通信内容を見ます。</string>
+    <string name="app_route_direct">この端末から直接</string>
+    <string name="app_route_direct_explanation">このアプリはあなた自身のネットワークから接続します。トラッカーの監視とブロックは引き続き適用されます。DNS クエリは VPN ではなくネットワークのリゾルバに送られ、アプリはこの端末の実際のアドレスを見ます。ローカル機器への接続やキャプティブポータルの確認など、これを必要とするアプリもあります。</string>
+    <string name="app_route_unavailable_no_vpn">リモート VPN が設定されていないため、すべての通信はすでにこの端末から直接出ています。</string>
+    <string name="app_route_unavailable_bypassed">このアプリは TrackerControl を完全に迂回するため、通すべき通信がありません。</string>
+    <string name="app_route_unavailable_partial_routes">リモート VPN がすべての通信を運んでいません（AllowedIPs がフルトンネルではありません）。経路はすべてのアプリで共有されるため、アプリ単位の切り替えにはフルトンネルが必要です。</string>
 </resources>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -100,4 +100,18 @@
     <string name="app_state_no_internet_shared_uid">이 앱과 Android 사용자 ID를 공유하는 %1$s에도 적용됩니다.</string>
     <string name="app_state_bypassed">TrackerControl 우회</string>
     <string name="app_state_bypassed_explanation">앱이 TrackerControl을 거치지 않고 직접 연결합니다. 이 앱에 대해서는 아무것도 감시하거나 차단하지 않습니다. 앱이 여전히 동작하지 않을 때 최후의 수단으로 사용하세요.\n\n참고: 이 기능이 동작하려면 Android VPN 설정에서 \"VPN 없이 연결 차단\"이 사용 중지되어 있어야 합니다.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">원격 VPN으로 보내기</string>
+    <string name="summary_wg_route_mode">어떤 앱을 원격 VPN으로 보낼지 정합니다. 보내지 않는 앱도 트래커 감시와 차단은 그대로 적용되며, 이 기기의 네트워크로 직접 연결할 뿐입니다.</string>
+    <string name="wg_route_mode_all">모든 앱</string>
+    <string name="wg_route_mode_selected">선택한 앱만</string>
+    <string name="app_route_heading">원격 VPN</string>
+    <string name="app_route_through">원격 VPN을 통해</string>
+    <string name="app_route_through_explanation">이 앱은 원격 VPN을 통해 연결하며, 내 네트워크 대신 VPN이 트래픽을 봅니다.</string>
+    <string name="app_route_direct">이 기기에서 직접</string>
+    <string name="app_route_direct_explanation">이 앱은 내 네트워크로 연결합니다. 트래커 감시와 차단은 계속 적용됩니다. DNS 질의는 VPN이 아니라 내 네트워크의 리졸버로 가고, 앱은 이 기기의 실제 주소를 봅니다. 로컬 기기 접근이나 캡티브 포털 확인처럼 이것이 필요한 앱도 있습니다.</string>
+    <string name="app_route_unavailable_no_vpn">설정된 원격 VPN이 없어 모든 트래픽이 이미 이 기기에서 직접 나갑니다.</string>
+    <string name="app_route_unavailable_bypassed">이 앱은 TrackerControl을 완전히 우회하므로 보낼 트래픽이 없습니다.</string>
+    <string name="app_route_unavailable_partial_routes">원격 VPN이 모든 트래픽을 나르지 않습니다(AllowedIPs가 전체 터널이 아닙니다). 경로는 모든 앱이 공유하므로 앱별 라우팅에는 전체 터널이 필요합니다.</string>
 </resources>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -472,4 +472,18 @@ Het internetverkeer wordt niet naar een externe VPN-server gestuurd.</string>
     <string name="app_state_no_internet_shared_uid">Geldt ook voor %1$s, die een Android-gebruikers-ID deelt met deze app.</string>
     <string name="app_state_bypassed">TrackerControl omzeilen</string>
     <string name="app_state_bypassed_explanation">De app maakt rechtstreeks verbinding, buiten TrackerControl om. Er wordt niets voor gecontroleerd of geblokkeerd. Gebruik dit als laatste redmiddel als de app nog steeds niet werkt.\n\nLet op: \"Verbindingen zonder VPN blokkeren\" in de Android-VPN-instellingen moet UITGESCHAKELD zijn om dit te laten werken.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Via externe VPN leiden</string>
+    <string name="summary_wg_route_mode">Welke apps via de externe VPN worden geleid. Apps die dat niet doen blijven volledig gecontroleerd en gefilterd — ze verbinden gewoon via het eigen netwerk van dit apparaat.</string>
+    <string name="wg_route_mode_all">Alle apps</string>
+    <string name="wg_route_mode_selected">Alleen geselecteerde apps</string>
+    <string name="app_route_heading">Externe VPN</string>
+    <string name="app_route_through">Via de externe VPN</string>
+    <string name="app_route_through_explanation">Deze app verbindt via je externe VPN, die het verkeer ziet in plaats van je netwerk.</string>
+    <string name="app_route_direct">Rechtstreeks vanaf dit apparaat</string>
+    <string name="app_route_direct_explanation">Deze app verbindt via je eigen netwerk. Trackercontrole en -blokkering blijven gelden. De DNS-aanvragen gaan naar de resolver van je netwerk in plaats van die van de VPN, en de app ziet het echte adres van dit apparaat — sommige apps hebben dat nodig, bijvoorbeeld om lokale apparaten te bereiken of een captive portal te controleren.</string>
+    <string name="app_route_unavailable_no_vpn">Er is geen externe VPN ingesteld, dus al het verkeer verlaat dit apparaat al rechtstreeks.</string>
+    <string name="app_route_unavailable_bypassed">Deze app omzeilt TrackerControl volledig, dus er is geen verkeer om te leiden.</string>
+    <string name="app_route_unavailable_partial_routes">Je externe VPN draagt niet al het verkeer (de AllowedIPs vormen geen volledige tunnel). Routering per app vereist een volledige tunnel, omdat routes door alle apps worden gedeeld.</string>
 </resources>

--- a/app/src/main/res/values-no-rNO/strings.xml
+++ b/app/src/main/res/values-no-rNO/strings.xml
@@ -365,4 +365,18 @@ Vennlig hilsen,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Gjelder også %1$s, som deler en Android-bruker-ID med denne appen.</string>
     <string name="app_state_bypassed">Omgå TrackerControl</string>
     <string name="app_state_bypassed_explanation">Appen kobler til direkte, utenfor TrackerControl. Ingenting overvåkes eller blokkeres for den. Bruk dette som siste utvei hvis appen fortsatt ikke virker.\n\nMerk: \"Blokker tilkoblinger uten VPN\" i Androids VPN-innstillinger må være DEAKTIVERT for at dette skal virke.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Send gjennom ekstern VPN</string>
+    <string name="summary_wg_route_mode">Hvilke apper som sendes gjennom den eksterne VPN-en. De øvrige overvåkes og filtreres fortsatt fullt ut — de kobler bare til fra enhetens eget nettverk.</string>
+    <string name="wg_route_mode_all">Alle apper</string>
+    <string name="wg_route_mode_selected">Bare valgte apper</string>
+    <string name="app_route_heading">Ekstern VPN</string>
+    <string name="app_route_through">Gjennom den eksterne VPN-en</string>
+    <string name="app_route_through_explanation">Denne appen kobler til gjennom din eksterne VPN, som ser trafikken dens i stedet for nettverket ditt.</string>
+    <string name="app_route_direct">Direkte fra denne enheten</string>
+    <string name="app_route_direct_explanation">Denne appen kobler til fra ditt eget nettverk. Sporerovervåking og blokkering gjelder fortsatt. DNS-forespørslene går til nettverkets resolver i stedet for VPN-ens, og appen ser enhetens virkelige adresse — noen apper trenger det, for eksempel for å nå lokale enheter eller sjekke en captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Ingen ekstern VPN er satt opp, så all trafikk forlater allerede enheten direkte.</string>
+    <string name="app_route_unavailable_bypassed">Denne appen omgår TrackerControl helt, så det finnes ingen trafikk å sende.</string>
+    <string name="app_route_unavailable_partial_routes">Den eksterne VPN-en bærer ikke all trafikk (AllowedIPs er ikke en full tunnel). Ruting per app krever en full tunnel, siden ruter deles av alle apper.</string>
 </resources>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -373,4 +373,18 @@ Z poważaniem,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Dotyczy też %1$s, która współdzieli z tą aplikacją identyfikator użytkownika Androida.</string>
     <string name="app_state_bypassed">Pomiń TrackerControl</string>
     <string name="app_state_bypassed_explanation">Aplikacja łączy się bezpośrednio, poza TrackerControl. Nic nie jest dla niej monitorowane ani blokowane. Użyj tego w ostateczności, jeśli aplikacja nadal nie działa.\n\nUwaga: opcja \"Blokuj połączenia bez VPN\" w ustawieniach VPN Androida musi być WYŁĄCZONA, aby to zadziałało.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Kieruj przez zdalny VPN</string>
+    <string name="summary_wg_route_mode">Które aplikacje są przekazywane przez zdalny VPN. Pozostałe nadal są w pełni monitorowane i filtrowane — po prostu łączą się przez sieć tego urządzenia.</string>
+    <string name="wg_route_mode_all">Wszystkie aplikacje</string>
+    <string name="wg_route_mode_selected">Tylko wybrane aplikacje</string>
+    <string name="app_route_heading">Zdalny VPN</string>
+    <string name="app_route_through">Przez zdalny VPN</string>
+    <string name="app_route_through_explanation">Ta aplikacja łączy się przez Twój zdalny VPN, który widzi jej ruch zamiast Twojej sieci.</string>
+    <string name="app_route_direct">Bezpośrednio z tego urządzenia</string>
+    <string name="app_route_direct_explanation">Ta aplikacja łączy się przez Twoją własną sieć. Monitorowanie i blokowanie trackerów nadal działa. Jej zapytania DNS trafiają do resolwera Twojej sieci zamiast do VPN, a aplikacja widzi prawdziwy adres tego urządzenia — niektóre aplikacje tego potrzebują, na przykład by dotrzeć do urządzeń lokalnych lub sprawdzić captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Nie skonfigurowano zdalnego VPN, więc cały ruch już wychodzi bezpośrednio z tego urządzenia.</string>
+    <string name="app_route_unavailable_bypassed">Ta aplikacja całkowicie pomija TrackerControl, więc nie ma ruchu do kierowania.</string>
+    <string name="app_route_unavailable_partial_routes">Twój zdalny VPN nie przenosi całego ruchu (jego AllowedIPs nie tworzy pełnego tunelu). Kierowanie na poziomie aplikacji wymaga pełnego tunelu, ponieważ trasy są wspólne dla wszystkich aplikacji.</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -461,4 +461,18 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <string name="app_state_no_internet_shared_uid">Também se aplica a %1$s, que compartilha um ID de usuário do Android com este aplicativo.</string>
     <string name="app_state_bypassed">Ignorar o TrackerControl</string>
     <string name="app_state_bypassed_explanation">O aplicativo se conecta diretamente, fora do TrackerControl. Nada é monitorado nem bloqueado para ele. Use isto como último recurso se o aplicativo ainda não funcionar.\n\nObservação: \"Bloquear conexões sem VPN\" nas configurações de VPN do Android precisa estar DESATIVADO para que isto funcione.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Rotear pela VPN remota</string>
+    <string name="summary_wg_route_mode">Quais aplicativos são encaminhados pela VPN remota. Os que não são continuam totalmente monitorados e filtrados — apenas se conectam pela rede deste dispositivo.</string>
+    <string name="wg_route_mode_all">Todos os aplicativos</string>
+    <string name="wg_route_mode_selected">Somente aplicativos selecionados</string>
+    <string name="app_route_heading">VPN remota</string>
+    <string name="app_route_through">Pela VPN remota</string>
+    <string name="app_route_through_explanation">Este aplicativo se conecta pela sua VPN remota, que vê o tráfego dele no lugar da sua rede.</string>
+    <string name="app_route_direct">Diretamente deste dispositivo</string>
+    <string name="app_route_direct_explanation">Este aplicativo se conecta pela sua própria rede. O monitoramento e o bloqueio de rastreadores continuam valendo. As consultas DNS vão para o resolvedor da sua rede em vez do da VPN, e ele vê o endereço real deste dispositivo — alguns aplicativos precisam disso, por exemplo para alcançar dispositivos locais ou verificar um portal cativo.</string>
+    <string name="app_route_unavailable_no_vpn">Nenhuma VPN remota está configurada, então todo o tráfego já sai diretamente deste dispositivo.</string>
+    <string name="app_route_unavailable_bypassed">Este aplicativo ignora o TrackerControl por completo, então não há tráfego a rotear.</string>
+    <string name="app_route_unavailable_partial_routes">Sua VPN remota não transporta todo o tráfego (os AllowedIPs dela não formam um túnel completo). O roteamento por aplicativo exige um túnel completo, porque as rotas são compartilhadas por todos os aplicativos.</string>
 </resources>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -341,4 +341,18 @@ disso,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Aplica-se também a %1$s, que partilha um ID de utilizador Android com esta aplicação.</string>
     <string name="app_state_bypassed">Ignorar o TrackerControl</string>
     <string name="app_state_bypassed_explanation">A aplicação liga-se diretamente, fora do TrackerControl. Nada é monitorizado nem bloqueado para ela. Utilize isto como último recurso se a aplicação continuar a não funcionar.\n\nNota: \"Bloquear ligações sem VPN\" nas definições de VPN do Android tem de estar DESATIVADO para que isto funcione.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Encaminhar pela VPN remota</string>
+    <string name="summary_wg_route_mode">Que aplicações são encaminhadas pela VPN remota. As que não são continuam totalmente monitorizadas e filtradas — apenas se ligam pela rede deste dispositivo.</string>
+    <string name="wg_route_mode_all">Todas as aplicações</string>
+    <string name="wg_route_mode_selected">Apenas aplicações selecionadas</string>
+    <string name="app_route_heading">VPN remota</string>
+    <string name="app_route_through">Pela VPN remota</string>
+    <string name="app_route_through_explanation">Esta aplicação liga-se pela sua VPN remota, que vê o tráfego dela em vez da sua rede.</string>
+    <string name="app_route_direct">Diretamente deste dispositivo</string>
+    <string name="app_route_direct_explanation">Esta aplicação liga-se pela sua própria rede. A monitorização e o bloqueio de rastreadores continuam a aplicar-se. As consultas DNS vão para o resolvedor da sua rede em vez do da VPN, e a aplicação vê o endereço real deste dispositivo — algumas aplicações precisam disso, por exemplo para alcançar dispositivos locais ou verificar um portal cativo.</string>
+    <string name="app_route_unavailable_no_vpn">Não está configurada nenhuma VPN remota, por isso todo o tráfego já sai diretamente deste dispositivo.</string>
+    <string name="app_route_unavailable_bypassed">Esta aplicação ignora o TrackerControl por completo, por isso não há tráfego a encaminhar.</string>
+    <string name="app_route_unavailable_partial_routes">A sua VPN remota não transporta todo o tráfego (os AllowedIPs dela não formam um túnel completo). O encaminhamento por aplicação exige um túnel completo, porque as rotas são partilhadas por todas as aplicações.</string>
 </resources>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -85,4 +85,18 @@
     <string name="app_state_no_internet_shared_uid">Se aplică și pentru %1$s, care împarte un ID de utilizator Android cu această aplicație.</string>
     <string name="app_state_bypassed">Ocolește TrackerControl</string>
     <string name="app_state_bypassed_explanation">Aplicația se conectează direct, în afara TrackerControl. Nimic nu este monitorizat sau blocat pentru ea. Folosiți această opțiune ca ultimă soluție dacă aplicația tot nu funcționează.\n\nNotă: \"Blochează conexiunile fără VPN\" din setările VPN Android trebuie să fie DEZACTIVAT pentru ca aceasta să funcționeze.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Rutează prin VPN-ul la distanță</string>
+    <string name="summary_wg_route_mode">Care aplicații sunt trimise prin VPN-ul la distanță. Celelalte rămân complet monitorizate și filtrate — doar se conectează din rețeaua acestui dispozitiv.</string>
+    <string name="wg_route_mode_all">Toate aplicațiile</string>
+    <string name="wg_route_mode_selected">Doar aplicațiile selectate</string>
+    <string name="app_route_heading">VPN la distanță</string>
+    <string name="app_route_through">Prin VPN-ul la distanță</string>
+    <string name="app_route_through_explanation">Această aplicație se conectează prin VPN-ul dvs. la distanță, care îi vede traficul în locul rețelei dvs.</string>
+    <string name="app_route_direct">Direct de pe acest dispozitiv</string>
+    <string name="app_route_direct_explanation">Această aplicație se conectează din propria rețea. Monitorizarea și blocarea urmăritorilor rămân valabile. Interogările ei DNS merg la rezolvatorul rețelei dvs., nu la cel al VPN-ului, iar aplicația vede adresa reală a dispozitivului — unele aplicații au nevoie de asta, de exemplu pentru a ajunge la dispozitive locale sau a verifica un captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Nu este configurat niciun VPN la distanță, așa că tot traficul iese deja direct de pe acest dispozitiv.</string>
+    <string name="app_route_unavailable_bypassed">Această aplicație ocolește complet TrackerControl, deci nu există trafic de rutat.</string>
+    <string name="app_route_unavailable_partial_routes">VPN-ul dvs. la distanță nu transportă tot traficul (AllowedIPs nu formează un tunel complet). Rutarea per aplicație necesită un tunel complet, deoarece rutele sunt partajate de toate aplicațiile.</string>
 </resources>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -498,4 +498,18 @@
     <string name="app_state_no_internet_shared_uid">Относится и к %1$s: это приложение использует общий с ним идентификатор пользователя Android.</string>
     <string name="app_state_bypassed">В обход TrackerControl</string>
     <string name="app_state_bypassed_explanation">Приложение подключается напрямую, минуя TrackerControl. Для него ничего не отслеживается и не блокируется. Используйте это как крайнюю меру, если приложение по-прежнему не работает.\n\nПримечание: параметр \"Блокировать соединения без VPN\" в настройках VPN Android должен быть ОТКЛЮЧЁН, чтобы это работало.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Направлять через удалённый VPN</string>
+    <string name="summary_wg_route_mode">Какие приложения направляются через удалённый VPN. Остальные по-прежнему полностью отслеживаются и фильтруются — они просто подключаются через сеть этого устройства.</string>
+    <string name="wg_route_mode_all">Все приложения</string>
+    <string name="wg_route_mode_selected">Только выбранные приложения</string>
+    <string name="app_route_heading">Удалённый VPN</string>
+    <string name="app_route_through">Через удалённый VPN</string>
+    <string name="app_route_through_explanation">Это приложение подключается через ваш удалённый VPN, который видит его трафик вместо вашей сети.</string>
+    <string name="app_route_direct">Напрямую с этого устройства</string>
+    <string name="app_route_direct_explanation">Это приложение подключается через вашу собственную сеть. Отслеживание и блокировка трекеров по-прежнему действуют. Его DNS-запросы идут к резолверу вашей сети, а не VPN, и оно видит настоящий адрес устройства — некоторым приложениям это нужно, например для доступа к локальным устройствам или проверки captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Удалённый VPN не настроен, поэтому весь трафик и так уходит напрямую с этого устройства.</string>
+    <string name="app_route_unavailable_bypassed">Это приложение полностью обходит TrackerControl, поэтому направлять нечего.</string>
+    <string name="app_route_unavailable_partial_routes">Ваш удалённый VPN передаёт не весь трафик (его AllowedIPs не образует полный туннель). Маршрутизация по приложениям требует полного туннеля, так как маршруты общие для всех приложений.</string>
 </resources>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -620,4 +620,18 @@ Vaš internetni promet se ne pošilja na oddaljeni strežnik VPN.</string>
     <string name="app_state_no_internet_shared_uid">Velja tudi za %1$s, ki si s to aplikacijo deli Androidov ID uporabnika.</string>
     <string name="app_state_bypassed">Obidi TrackerControl</string>
     <string name="app_state_bypassed_explanation">Aplikacija se poveže neposredno, mimo TrackerControla. Zanjo se nič ne spremlja in nič ne blokira. Uporabite to kot zadnjo možnost, če aplikacija še vedno ne deluje.\n\nOpomba: možnost \"Blokiraj povezave brez VPN\" v Androidovih nastavitvah VPN mora biti IZKLOPLJENA, da to deluje.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Usmeri prek oddaljenega VPN</string>
+    <string name="summary_wg_route_mode">Katere aplikacije gredo prek oddaljenega VPN. Preostale so še naprej v celoti nadzorovane in filtrirane — le povežejo se prek omrežja te naprave.</string>
+    <string name="wg_route_mode_all">Vse aplikacije</string>
+    <string name="wg_route_mode_selected">Samo izbrane aplikacije</string>
+    <string name="app_route_heading">Oddaljeni VPN</string>
+    <string name="app_route_through">Prek oddaljenega VPN</string>
+    <string name="app_route_through_explanation">Ta aplikacija se poveže prek vašega oddaljenega VPN, ki namesto vašega omrežja vidi njen promet.</string>
+    <string name="app_route_direct">Neposredno s te naprave</string>
+    <string name="app_route_direct_explanation">Ta aplikacija se poveže iz vašega omrežja. Nadzor in blokiranje sledilnikov še naprej veljata. Njene poizvedbe DNS gredo na razreševalnik vašega omrežja namesto na VPN, aplikacija pa vidi pravi naslov te naprave — nekatere aplikacije to potrebujejo, na primer za dostop do lokalnih naprav ali preverjanje captive portala.</string>
+    <string name="app_route_unavailable_no_vpn">Oddaljeni VPN ni nastavljen, zato ves promet že zdaj odhaja neposredno s te naprave.</string>
+    <string name="app_route_unavailable_bypassed">Ta aplikacija povsem obide TrackerControl, zato ni prometa za usmerjanje.</string>
+    <string name="app_route_unavailable_partial_routes">Vaš oddaljeni VPN ne prenaša vsega prometa (njegov AllowedIPs ni poln predor). Usmerjanje po aplikacijah zahteva poln predor, ker si poti delijo vse aplikacije.</string>
 </resources>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -15,4 +15,18 @@
     <string name="app_state_no_internet_shared_uid">Gäller även %1$s, som delar ett Android-användar-ID med den här appen.</string>
     <string name="app_state_bypassed">Förbigå TrackerControl</string>
     <string name="app_state_bypassed_explanation">Appen ansluter direkt, utanför TrackerControl. Ingenting övervakas eller blockeras för den. Använd detta som sista utväg om appen fortfarande inte fungerar.\n\nObs: \"Blockera anslutningar utan VPN\" i Androids VPN-inställningar måste vara INAKTIVERAT för att detta ska fungera.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Dirigera via fjärr-VPN</string>
+    <string name="summary_wg_route_mode">Vilka appar som skickas genom fjärr-VPN:et. De som inte gör det övervakas och filtreras fortfarande fullt ut — de ansluter bara från enhetens eget nätverk.</string>
+    <string name="wg_route_mode_all">Alla appar</string>
+    <string name="wg_route_mode_selected">Endast valda appar</string>
+    <string name="app_route_heading">Fjärr-VPN</string>
+    <string name="app_route_through">Via fjärr-VPN:et</string>
+    <string name="app_route_through_explanation">Den här appen ansluter via ditt fjärr-VPN, som ser dess trafik i stället för ditt nätverk.</string>
+    <string name="app_route_direct">Direkt från den här enheten</string>
+    <string name="app_route_direct_explanation">Den här appen ansluter från ditt eget nätverk. Spårarövervakning och blockering gäller fortfarande. Dess DNS-frågor går till nätverkets resolver i stället för VPN:ets, och appen ser enhetens riktiga adress — vissa appar behöver det, till exempel för att nå lokala enheter eller kontrollera en captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Inget fjärr-VPN är konfigurerat, så all trafik lämnar redan enheten direkt.</string>
+    <string name="app_route_unavailable_bypassed">Den här appen förbigår TrackerControl helt, så det finns ingen trafik att dirigera.</string>
+    <string name="app_route_unavailable_partial_routes">Ditt fjärr-VPN bär inte all trafik (dess AllowedIPs är inte en full tunnel). Dirigering per app kräver en full tunnel, eftersom rutter delas av alla appar.</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -24,4 +24,18 @@
     <string name="app_state_no_internet_shared_uid">இந்த ஆப்ஸுடன் Android பயனர் ஐடியைப் பகிர்ந்துகொள்ளும் %1$s-க்கும் இது பொருந்தும்.</string>
     <string name="app_state_bypassed">TrackerControl-ஐத் தவிர்</string>
     <string name="app_state_bypassed_explanation">ஆப்ஸ் TrackerControl-ஐத் தவிர்த்து நேரடியாக இணைகிறது. அதற்காக எதுவும் கண்காணிக்கப்படுவதோ தடுக்கப்படுவதோ இல்லை. ஆப்ஸ் இன்னும் வேலை செய்யாவிட்டால் கடைசி வழியாக இதைப் பயன்படுத்தவும்.\n\nகுறிப்பு: இது வேலை செய்ய Android VPN அமைப்புகளில் \"VPN இல்லாத இணைப்புகளைத் தடு\" முடக்கப்பட்டிருக்க வேண்டும்.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">தொலைநிலை VPN வழியாக அனுப்பு</string>
+    <string name="summary_wg_route_mode">எந்த ஆப்ஸ் தொலைநிலை VPN வழியாகச் செல்லும். செல்லாதவையும் முழுமையாகக் கண்காணிக்கப்பட்டு தடுக்கப்படுகின்றன — அவை இந்தச் சாதனத்தின் சொந்த நெட்வொர்க்கிலிருந்து இணைகின்றன.</string>
+    <string name="wg_route_mode_all">எல்லா ஆப்ஸும்</string>
+    <string name="wg_route_mode_selected">தேர்ந்தெடுத்த ஆப்ஸ் மட்டும்</string>
+    <string name="app_route_heading">தொலைநிலை VPN</string>
+    <string name="app_route_through">தொலைநிலை VPN வழியாக</string>
+    <string name="app_route_through_explanation">இந்த ஆப்ஸ் உங்கள் தொலைநிலை VPN வழியாக இணைகிறது; உங்கள் நெட்வொர்க்குக்குப் பதிலாக VPN அதன் போக்குவரத்தைப் பார்க்கிறது.</string>
+    <string name="app_route_direct">இந்தச் சாதனத்திலிருந்து நேரடியாக</string>
+    <string name="app_route_direct_explanation">இந்த ஆப்ஸ் உங்கள் சொந்த நெட்வொர்க்கிலிருந்து இணைகிறது. டிராக்கர் கண்காணிப்பும் தடுப்பும் தொடர்ந்து பொருந்தும். அதன் DNS வினவல்கள் VPN-க்குப் பதிலாக உங்கள் நெட்வொர்க்கின் தீர்ப்பானுக்குச் செல்கின்றன, மேலும் அது இந்தச் சாதனத்தின் உண்மையான முகவரியைப் பார்க்கிறது — சில ஆப்ஸுக்கு இது தேவை, எடுத்துக்காட்டாக உள்ளூர் சாதனங்களை அணுகவோ captive portal-ஐச் சரிபார்க்கவோ.</string>
+    <string name="app_route_unavailable_no_vpn">தொலைநிலை VPN எதுவும் அமைக்கப்படவில்லை, எனவே எல்லாப் போக்குவரத்தும் ஏற்கெனவே நேரடியாக இந்தச் சாதனத்திலிருந்து செல்கிறது.</string>
+    <string name="app_route_unavailable_bypassed">இந்த ஆப்ஸ் TrackerControl-ஐ முழுமையாகத் தவிர்க்கிறது, எனவே அனுப்ப எந்தப் போக்குவரத்தும் இல்லை.</string>
+    <string name="app_route_unavailable_partial_routes">உங்கள் தொலைநிலை VPN எல்லாப் போக்குவரத்தையும் எடுத்துச் செல்வதில்லை (அதன் AllowedIPs முழு சுரங்கம் அல்ல). வழிகள் எல்லா ஆப்ஸாலும் பகிரப்படுவதால், ஆப்ஸ்வாரி வழியமைப்புக்கு முழு சுரங்கம் தேவை.</string>
 </resources>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -24,4 +24,18 @@
     <string name="app_state_no_internet_shared_uid">ఈ యాప్‌తో Android వినియోగదారు ID‌ను పంచుకునే %1$sకు కూడా ఇది వర్తిస్తుంది.</string>
     <string name="app_state_bypassed">TrackerControlను దాటవేయి</string>
     <string name="app_state_bypassed_explanation">యాప్ TrackerControl వెలుపల నేరుగా కనెక్ట్ అవుతుంది. దాని కోసం ఏదీ పర్యవేక్షించబడదు లేదా నిరోధించబడదు. యాప్ ఇప్పటికీ పని చేయకపోతే చివరి ప్రయత్నంగా దీన్ని ఉపయోగించండి.\n\nగమనిక: ఇది పని చేయాలంటే Android VPN సెట్టింగ్‌లలో \"VPN లేకుండా కనెక్షన్‌లను నిరోధించు\" నిలిపివేయబడాలి.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">రిమోట్ VPN ద్వారా పంపు</string>
+    <string name="summary_wg_route_mode">ఏ యాప్‌లు రిమోట్ VPN ద్వారా వెళ్తాయో నిర్ణయిస్తుంది. వెళ్లని యాప్‌లు కూడా పూర్తిగా పర్యవేక్షించబడతాయి, నిరోధించబడతాయి — అవి ఈ పరికరం సొంత నెట్‌వర్క్ నుండి కనెక్ట్ అవుతాయి.</string>
+    <string name="wg_route_mode_all">అన్ని యాప్‌లు</string>
+    <string name="wg_route_mode_selected">ఎంచుకున్న యాప్‌లు మాత్రమే</string>
+    <string name="app_route_heading">రిమోట్ VPN</string>
+    <string name="app_route_through">రిమోట్ VPN ద్వారా</string>
+    <string name="app_route_through_explanation">ఈ యాప్ మీ రిమోట్ VPN ద్వారా కనెక్ట్ అవుతుంది; మీ నెట్‌వర్క్ బదులు VPN దాని ట్రాఫిక్‌ను చూస్తుంది.</string>
+    <string name="app_route_direct">ఈ పరికరం నుండి నేరుగా</string>
+    <string name="app_route_direct_explanation">ఈ యాప్ మీ సొంత నెట్‌వర్క్ నుండి కనెక్ట్ అవుతుంది. ట్రాకర్ పర్యవేక్షణ, నిరోధం ఇంకా వర్తిస్తాయి. దాని DNS ప్రశ్నలు VPN బదులు మీ నెట్‌వర్క్ రిజాల్వర్‌కు వెళ్తాయి, అలాగే అది ఈ పరికరం అసలు చిరునామాను చూస్తుంది — కొన్ని యాప్‌లకు ఇది అవసరం, ఉదాహరణకు స్థానిక పరికరాలను చేరుకోవడానికి లేదా captive portal తనిఖీకి.</string>
+    <string name="app_route_unavailable_no_vpn">రిమోట్ VPN ఏదీ సెటప్ చేయలేదు, కాబట్టి మొత్తం ట్రాఫిక్ ఇప్పటికే నేరుగా ఈ పరికరం నుండి వెళ్తోంది.</string>
+    <string name="app_route_unavailable_bypassed">ఈ యాప్ TrackerControlను పూర్తిగా దాటవేస్తుంది, కాబట్టి పంపడానికి ట్రాఫిక్ లేదు.</string>
+    <string name="app_route_unavailable_partial_routes">మీ రిమోట్ VPN మొత్తం ట్రాఫిక్‌ను మోయదు (దాని AllowedIPs పూర్తి టన్నెల్ కాదు). మార్గాలను అన్ని యాప్‌లు పంచుకుంటాయి కాబట్టి యాప్‌వారీ రూటింగ్‌కు పూర్తి టన్నెల్ అవసరం.</string>
 </resources>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -367,4 +367,18 @@ Saygılarımla,\n\n]]></string>
     <string name="app_state_no_internet_shared_uid">Bu uygulamayla Android kullanıcı kimliğini paylaşan %1$s için de geçerlidir.</string>
     <string name="app_state_bypassed">TrackerControl\'ü atla</string>
     <string name="app_state_bypassed_explanation">Uygulama, TrackerControl dışında doğrudan bağlanır. Onun için hiçbir şey izlenmez veya engellenmez. Uygulama hâlâ çalışmıyorsa son çare olarak bunu kullanın.\n\nNot: Bunun çalışması için Android VPN ayarlarındaki \"VPN olmadan bağlantıları engelle\" seçeneği KAPALI olmalıdır.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Uzak VPN üzerinden yönlendir</string>
+    <string name="summary_wg_route_mode">Hangi uygulamaların uzak VPN üzerinden iletileceği. İletilmeyenler yine tümüyle izlenir ve filtrelenir — yalnızca bu cihazın kendi ağından bağlanırlar.</string>
+    <string name="wg_route_mode_all">Tüm uygulamalar</string>
+    <string name="wg_route_mode_selected">Yalnızca seçili uygulamalar</string>
+    <string name="app_route_heading">Uzak VPN</string>
+    <string name="app_route_through">Uzak VPN üzerinden</string>
+    <string name="app_route_through_explanation">Bu uygulama, trafiğini ağınız yerine gören uzak VPN\'iniz üzerinden bağlanır.</string>
+    <string name="app_route_direct">Doğrudan bu cihazdan</string>
+    <string name="app_route_direct_explanation">Bu uygulama kendi ağınızdan bağlanır. İzleyici izleme ve engelleme geçerliliğini korur. DNS sorguları VPN yerine ağınızın çözücüsüne gider ve uygulama bu cihazın gerçek adresini görür — bazı uygulamalar buna ihtiyaç duyar, örneğin yerel cihazlara erişmek veya bir captive portal denetlemek için.</string>
+    <string name="app_route_unavailable_no_vpn">Kurulu bir uzak VPN yok, bu yüzden tüm trafik zaten doğrudan bu cihazdan çıkıyor.</string>
+    <string name="app_route_unavailable_bypassed">Bu uygulama TrackerControl\'ü tamamen atlıyor, dolayısıyla yönlendirilecek trafik yok.</string>
+    <string name="app_route_unavailable_partial_routes">Uzak VPN\'iniz tüm trafiği taşımıyor (AllowedIPs değeri tam tünel değil). Uygulama başına yönlendirme tam tünel gerektirir, çünkü rotalar tüm uygulamalarca paylaşılır.</string>
 </resources>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -651,4 +651,18 @@
     <string name="app_state_no_internet_shared_uid">Стосується також %1$s, який має спільний із цим застосунком ідентифікатор користувача Android.</string>
     <string name="app_state_bypassed">Обійти TrackerControl</string>
     <string name="app_state_bypassed_explanation">Застосунок з\'єднується напряму, поза TrackerControl. Для нього нічого не відстежується й не блокується. Використовуйте це як останній засіб, якщо застосунок і далі не працює.\n\nПримітка: параметр \"Блокувати з\'єднання без VPN\" у налаштуваннях VPN Android має бути ВИМКНЕНИЙ, щоб це працювало.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Спрямовувати через віддалений VPN</string>
+    <string name="summary_wg_route_mode">Які застосунки спрямовуються через віддалений VPN. Решта й далі повністю відстежується та фільтрується — вони просто з\'єднуються через мережу цього пристрою.</string>
+    <string name="wg_route_mode_all">Усі застосунки</string>
+    <string name="wg_route_mode_selected">Лише вибрані застосунки</string>
+    <string name="app_route_heading">Віддалений VPN</string>
+    <string name="app_route_through">Через віддалений VPN</string>
+    <string name="app_route_through_explanation">Цей застосунок з\'єднується через ваш віддалений VPN, який бачить його трафік замість вашої мережі.</string>
+    <string name="app_route_direct">Напряму з цього пристрою</string>
+    <string name="app_route_direct_explanation">Цей застосунок з\'єднується через вашу власну мережу. Відстеження й блокування трекерів і далі діють. Його DNS-запити йдуть до резолвера вашої мережі, а не VPN, і він бачить справжню адресу пристрою — деяким застосункам це потрібно, наприклад для доступу до локальних пристроїв або перевірки captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Віддалений VPN не налаштовано, тож увесь трафік і так виходить напряму з цього пристрою.</string>
+    <string name="app_route_unavailable_bypassed">Цей застосунок повністю обходить TrackerControl, тож спрямовувати нічого.</string>
+    <string name="app_route_unavailable_partial_routes">Ваш віддалений VPN передає не весь трафік (його AllowedIPs не утворює повний тунель). Маршрутизація за застосунками потребує повного тунелю, бо маршрути спільні для всіх застосунків.</string>
 </resources>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -386,4 +386,18 @@
     <string name="app_state_no_internet_shared_uid">Cũng áp dụng cho %1$s, ứng dụng dùng chung ID người dùng Android với ứng dụng này.</string>
     <string name="app_state_bypassed">Bỏ qua TrackerControl</string>
     <string name="app_state_bypassed_explanation">Ứng dụng kết nối trực tiếp, bên ngoài TrackerControl. Không có gì được giám sát hay chặn cho nó. Hãy dùng tuỳ chọn này như biện pháp cuối cùng nếu ứng dụng vẫn không hoạt động.\n\nLưu ý: \"Chặn kết nối khi không có VPN\" trong cài đặt VPN của Android phải được TẮT thì tuỳ chọn này mới hoạt động.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Định tuyến qua VPN từ xa</string>
+    <string name="summary_wg_route_mode">Những ứng dụng nào được chuyển tiếp qua VPN từ xa. Các ứng dụng còn lại vẫn được giám sát và chặn đầy đủ — chúng chỉ kết nối từ mạng của chính thiết bị này.</string>
+    <string name="wg_route_mode_all">Mọi ứng dụng</string>
+    <string name="wg_route_mode_selected">Chỉ ứng dụng đã chọn</string>
+    <string name="app_route_heading">VPN từ xa</string>
+    <string name="app_route_through">Qua VPN từ xa</string>
+    <string name="app_route_through_explanation">Ứng dụng này kết nối qua VPN từ xa của bạn, và VPN thấy lưu lượng của nó thay vì mạng của bạn.</string>
+    <string name="app_route_direct">Trực tiếp từ thiết bị này</string>
+    <string name="app_route_direct_explanation">Ứng dụng này kết nối từ mạng của bạn. Việc giám sát và chặn trình theo dõi vẫn được áp dụng. Truy vấn DNS của nó đi tới bộ phân giải của mạng bạn thay vì của VPN, và nó thấy địa chỉ thật của thiết bị — một số ứng dụng cần điều đó, ví dụ để truy cập thiết bị nội bộ hoặc kiểm tra captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">Chưa thiết lập VPN từ xa nào, nên toàn bộ lưu lượng vốn đã rời thiết bị này trực tiếp.</string>
+    <string name="app_route_unavailable_bypassed">Ứng dụng này bỏ qua hoàn toàn TrackerControl, nên không có lưu lượng để định tuyến.</string>
+    <string name="app_route_unavailable_partial_routes">VPN từ xa của bạn không mang toàn bộ lưu lượng (AllowedIPs của nó không phải đường hầm đầy đủ). Định tuyến theo ứng dụng cần đường hầm đầy đủ, vì các tuyến được mọi ứng dụng dùng chung.</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -646,4 +646,18 @@
     <string name="app_state_no_internet_shared_uid">同样适用于 %1$s，它与此应用共用同一个 Android 用户 ID。</string>
     <string name="app_state_bypassed">绕过 TrackerControl</string>
     <string name="app_state_bypassed_explanation">应用将绕过 TrackerControl 直接联网，不会对其进行任何监测或拦截。仅在应用仍然无法使用时作为最后手段使用。\n\n注意：必须在 Android 的 VPN 设置中停用\"屏蔽不使用 VPN 的连接\"，此项才能生效。</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">通过远程 VPN 转发</string>
+    <string name="summary_wg_route_mode">哪些应用经远程 VPN 转发。未转发的应用仍然受到完整的跟踪器监测与拦截，只是改从本机自己的网络连接。</string>
+    <string name="wg_route_mode_all">所有应用</string>
+    <string name="wg_route_mode_selected">仅所选应用</string>
+    <string name="app_route_heading">远程 VPN</string>
+    <string name="app_route_through">经远程 VPN</string>
+    <string name="app_route_through_explanation">此应用经你的远程 VPN 连接，由 VPN 而非你的网络看到它的流量。</string>
+    <string name="app_route_direct">直接从本机连接</string>
+    <string name="app_route_direct_explanation">此应用从你自己的网络连接。跟踪器监测与拦截依然生效。它的 DNS 查询会发往你网络的解析器而非 VPN 的，并且它看到的是本机的真实地址——某些应用需要这样，例如访问局域网设备或检测强制门户。</string>
+    <string name="app_route_unavailable_no_vpn">尚未设置远程 VPN，因此所有流量已经直接从本机发出。</string>
+    <string name="app_route_unavailable_bypassed">此应用完全绕过 TrackerControl，因此没有可转发的流量。</string>
+    <string name="app_route_unavailable_partial_routes">你的远程 VPN 并未承载全部流量（其 AllowedIPs 不是全隧道）。路由由所有应用共享，因此按应用分流需要全隧道。</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -176,4 +176,18 @@
     <string name="app_state_no_internet_shared_uid">同樣適用於 %1$s，它與此應用程式共用同一個 Android 使用者 ID。</string>
     <string name="app_state_bypassed">略過 TrackerControl</string>
     <string name="app_state_bypassed_explanation">應用程式會略過 TrackerControl 直接連線，不會對其進行任何監控或封鎖。僅在應用程式仍無法使用時作為最後手段使用。\n\n注意：必須在 Android 的 VPN 設定中停用\"封鎖不使用 VPN 的連線\"，此項才會生效。</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">透過遠端 VPN 轉送</string>
+    <string name="summary_wg_route_mode">哪些應用程式經遠端 VPN 轉送。未轉送的應用程式仍受到完整的追蹤器監控與封鎖，只是改從本機自己的網路連線。</string>
+    <string name="wg_route_mode_all">所有應用程式</string>
+    <string name="wg_route_mode_selected">僅所選應用程式</string>
+    <string name="app_route_heading">遠端 VPN</string>
+    <string name="app_route_through">經遠端 VPN</string>
+    <string name="app_route_through_explanation">此應用程式經你的遠端 VPN 連線，由 VPN 而非你的網路看到它的流量。</string>
+    <string name="app_route_direct">直接從本機連線</string>
+    <string name="app_route_direct_explanation">此應用程式從你自己的網路連線。追蹤器監控與封鎖仍然生效。它的 DNS 查詢會送往你網路的解析器而非 VPN 的，而且它看到的是本機的真實位址——某些應用程式需要這樣，例如存取區域網路裝置或偵測強制網路入口。</string>
+    <string name="app_route_unavailable_no_vpn">尚未設定遠端 VPN，因此所有流量已經直接從本機送出。</string>
+    <string name="app_route_unavailable_bypassed">此應用程式完全略過 TrackerControl，因此沒有可轉送的流量。</string>
+    <string name="app_route_unavailable_partial_routes">你的遠端 VPN 並未承載全部流量（其 AllowedIPs 不是全隧道）。路由由所有應用程式共用，因此依應用程式分流需要全隧道。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -458,6 +458,16 @@ Your internet traffic is not being sent to a remote VPN server.</string>
         <item>strict</item>
     </string-array>
 
+    <string-array name="wgRouteModeNames" translatable="false">
+        <item>@string/wg_route_mode_all</item>
+        <item>@string/wg_route_mode_selected</item>
+    </string-array>
+
+    <string-array name="wgRouteModeValues" translatable="false">
+        <item>all</item>
+        <item>selected</item>
+    </string-array>
+
     <string-array name="logLevelNames" translatable="false">
         <item>Verbose</item>
         <item>Debug</item>
@@ -630,6 +640,21 @@ Sincerely,\n\n]]></string>
     <string name="onboarding_blockingmode_strict_desc">Blocks everything including essential services and ambiguous domains. Significant app breakage — many apps will need to be manually excluded.</string>
     <string name="onboarding_blockingmode_research_label">Research</string>
     <string name="onboarding_blockingmode_research_desc">No tracker blocking. Logs transmissions to ADB and enables SNI extraction for better hostname detection. Research only: this leaks your IP address to tracker servers.</string>
+
+    <!-- Per-app remote VPN routing -->
+    <string name="setting_wg_route_mode">Route through remote VPN</string>
+    <string name="summary_wg_route_mode">Which apps are forwarded through the remote VPN. Apps that are not still get full tracker monitoring and blocking — they simply connect from this device\'s own network.</string>
+    <string name="wg_route_mode_all">All apps</string>
+    <string name="wg_route_mode_selected">Only selected apps</string>
+
+    <string name="app_route_heading">Remote VPN</string>
+    <string name="app_route_through">Through the remote VPN</string>
+    <string name="app_route_through_explanation">This app connects through your remote VPN, which sees its traffic instead of your network.</string>
+    <string name="app_route_direct">Directly from this device</string>
+    <string name="app_route_direct_explanation">This app connects from your own network. Tracker monitoring and blocking still apply. Its DNS queries go to your network\'s resolver rather than the VPN\'s, and it sees this device\'s real address — some apps need that, for example to reach local devices or check a captive portal.</string>
+    <string name="app_route_unavailable_no_vpn">No remote VPN is set up, so all traffic already leaves from this device.</string>
+    <string name="app_route_unavailable_bypassed">This app bypasses TrackerControl entirely, so there is no traffic to route.</string>
+    <string name="app_route_unavailable_partial_routes">Your remote VPN does not carry all traffic (its AllowedIPs is not a full tunnel). Per-app routing needs a full tunnel, because routes are shared by every app.</string>
 
     <!-- Per-app protection state -->
     <string name="app_state_heading">Protection</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -219,6 +219,13 @@
                 android:key="wg_profile_manage"
                 android:summary="@string/summary_wg_profile_manage"
                 android:title="@string/setting_wg_profile_manage" />
+            <ListPreference
+                android:defaultValue="all"
+                android:entries="@array/wgRouteModeNames"
+                android:entryValues="@array/wgRouteModeValues"
+                android:key="wg_route_mode"
+                android:summary="@string/summary_wg_route_mode"
+                android:title="@string/setting_wg_route_mode" />
             <eu.faircode.netguard.SwitchPreference
                 android:defaultValue="false"
                 android:key="wg_keepalive_when_screen_off"

--- a/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
@@ -1,0 +1,102 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class RemoteRoutingLogicTest {
+
+    /**
+     * The shipped default has to leave the pre-feature behaviour untouched:
+     * everything tunnels, including unknown-UID and system traffic.
+     */
+    @Test
+    public void defaultModeTunnelsEverything() {
+        assertEquals(RemoteRoutingLogic.MODE_ALL, RemoteRoutingLogic.getDefaultMode());
+        assertTrue(RemoteRoutingLogic.defaultTunnel(RemoteRoutingLogic.MODE_ALL));
+        assertTrue(RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_ALL, null, true));
+    }
+
+    @Test
+    public void selectedModeKeepsUnconfiguredAppsDirect() {
+        assertFalse(RemoteRoutingLogic.defaultTunnel(RemoteRoutingLogic.MODE_SELECTED));
+        assertFalse(RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_SELECTED, null, true));
+        assertTrue(RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_SELECTED, Boolean.TRUE, true));
+    }
+
+    @Test
+    public void overrideWinsOverModeInBothDirections() {
+        assertFalse(RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_ALL, Boolean.FALSE, true));
+        assertTrue(RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_SELECTED, Boolean.TRUE, true));
+    }
+
+    /**
+     * A bypassed app never reaches the tun, so it can never be tunnelled —
+     * whatever its stale override says.
+     */
+    @Test
+    public void bypassedAppNeverTunnels() {
+        for (String mode : new String[] { RemoteRoutingLogic.MODE_ALL,
+                RemoteRoutingLogic.MODE_SELECTED })
+            for (Boolean override : new Boolean[] { null, Boolean.TRUE, Boolean.FALSE })
+                assertFalse(RemoteRoutingLogic.routesThroughTunnel(mode, override, false));
+    }
+
+    @Test
+    public void unknownModeFallsBackToTheDefault() {
+        assertEquals(RemoteRoutingLogic.MODE_ALL, RemoteRoutingLogic.normalizeMode(null));
+        assertEquals(RemoteRoutingLogic.MODE_ALL, RemoteRoutingLogic.normalizeMode("nonsense"));
+        assertTrue(RemoteRoutingLogic.defaultTunnel("nonsense"));
+    }
+
+    @Test
+    public void controlNeedsRemoteVpnDefaultRoutesAndANonBypassedApp() {
+        assertTrue(RemoteRoutingLogic.isControlAvailable(true, true, true));
+        assertFalse(RemoteRoutingLogic.isControlAvailable(false, true, true));
+        assertFalse(RemoteRoutingLogic.isControlAvailable(true, false, true));
+        assertFalse(RemoteRoutingLogic.isControlAvailable(true, true, false));
+    }
+
+    @Test
+    public void unavailableReasonNamesTheBlockingCondition() {
+        assertEquals(RemoteRoutingLogic.Unavailable.NO_REMOTE_VPN,
+                RemoteRoutingLogic.getUnavailableReason(false, true, true));
+        assertEquals(RemoteRoutingLogic.Unavailable.BYPASSED,
+                RemoteRoutingLogic.getUnavailableReason(true, true, false));
+        assertEquals(RemoteRoutingLogic.Unavailable.PARTIAL_ROUTES,
+                RemoteRoutingLogic.getUnavailableReason(true, false, true));
+        assertNull(RemoteRoutingLogic.getUnavailableReason(true, true, true));
+    }
+
+    /**
+     * The DNS redirect costs a UID lookup, a JNI upcall and a UDP session per
+     * query, so users of the default mode must not pay for it.
+     */
+    @Test
+    public void dnsRedirectOnlyInSelectedMode() {
+        assertFalse(RemoteRoutingLogic.redirectDirectDns(RemoteRoutingLogic.MODE_ALL));
+        assertTrue(RemoteRoutingLogic.redirectDirectDns(RemoteRoutingLogic.MODE_SELECTED));
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
@@ -92,11 +92,35 @@ public class RemoteRoutingLogicTest {
 
     /**
      * The DNS redirect costs a UID lookup, a JNI upcall and a UDP session per
-     * query, so users of the default mode must not pay for it.
+     * query, so nobody pays for it until an app is actually routed direct.
+     * Keying this off the mode instead was wrong: a per-app override sends an
+     * app direct in "All apps" too, and that app then tunnelled its DNS while
+     * its traffic went direct — the very split the redirect exists to avoid.
      */
     @Test
-    public void dnsRedirectOnlyInSelectedMode() {
-        assertFalse(RemoteRoutingLogic.redirectDirectDns(RemoteRoutingLogic.MODE_ALL));
-        assertTrue(RemoteRoutingLogic.redirectDirectDns(RemoteRoutingLogic.MODE_SELECTED));
+    public void dnsRedirectFollowsActualDirectApps() {
+        assertFalse(RemoteRoutingLogic.redirectDirectDns(false));
+        assertTrue(RemoteRoutingLogic.redirectDirectDns(true));
+
+        boolean overriddenDirectInAllMode = !RemoteRoutingLogic.routesThroughTunnel(
+                RemoteRoutingLogic.MODE_ALL, Boolean.FALSE, true);
+        assertTrue(RemoteRoutingLogic.redirectDirectDns(overriddenDirectInAllMode));
+    }
+
+    /**
+     * Unknown and system UIDs have no rule, so they must follow the global
+     * default rather than being read as "not tunnelled".
+     */
+    @Test
+    public void unknownUidFollowsTheDefaultRatherThanGoingDirect() {
+        assertFalse(RemoteRoutingLogic.routesDirect(false, false, true));
+        assertTrue(RemoteRoutingLogic.routesDirect(false, false, false));
+    }
+
+    @Test
+    public void knownUidOutsideTheTunnelSetGoesDirect() {
+        assertTrue(RemoteRoutingLogic.routesDirect(false, true, true));
+        assertFalse(RemoteRoutingLogic.routesDirect(true, true, false));
+        assertFalse(RemoteRoutingLogic.routesDirect(true, true, true));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
@@ -108,19 +108,42 @@ public class RemoteRoutingLogicTest {
     }
 
     /**
-     * Unknown and system UIDs have no rule, so they must follow the global
-     * default rather than being read as "not tunnelled".
+     * An app is only ever pushed into the override set when its routing
+     * actually differs from the global default; matching the default in
+     * either direction is not an override.
      */
     @Test
-    public void unknownUidFollowsTheDefaultRatherThanGoingDirect() {
-        assertFalse(RemoteRoutingLogic.routesDirect(false, false, true));
-        assertTrue(RemoteRoutingLogic.routesDirect(false, false, false));
+    public void isRouteOverrideOnlyWhenTunnelledDiffersFromDefault() {
+        assertFalse(RemoteRoutingLogic.isRouteOverride(true, true));
+        assertFalse(RemoteRoutingLogic.isRouteOverride(false, false));
+        assertTrue(RemoteRoutingLogic.isRouteOverride(true, false));
+        assertTrue(RemoteRoutingLogic.isRouteOverride(false, true));
     }
 
+    /**
+     * In the shipped default mode ("all", so defaultTunnel is true) with no
+     * per-app override configured, nothing is an override. That is the
+     * property that keeps the pushed set empty and lets the native fast path
+     * engage for everyone who never touches per-app routing.
+     */
     @Test
-    public void knownUidOutsideTheTunnelSetGoesDirect() {
-        assertTrue(RemoteRoutingLogic.routesDirect(false, true, true));
-        assertFalse(RemoteRoutingLogic.routesDirect(true, true, false));
-        assertFalse(RemoteRoutingLogic.routesDirect(true, true, true));
+    public void defaultModeWithNoOverrideProducesNoOverride() {
+        assertFalse(RemoteRoutingLogic.isRouteOverride(true, true));
+    }
+
+    /**
+     * routesDirect mirrors the native is_tunnel_uid: a UID absent from the
+     * override set follows the global default in both directions, and a UID
+     * present in the set always gets the opposite of the default.
+     */
+    @Test
+    public void routesDirectCoversAllFourCombinations() {
+        // Not in the override set: follows the default, whatever it is.
+        assertFalse(RemoteRoutingLogic.routesDirect(false, true));
+        assertTrue(RemoteRoutingLogic.routesDirect(false, false));
+
+        // In the override set: inverts the default.
+        assertTrue(RemoteRoutingLogic.routesDirect(true, true));
+        assertFalse(RemoteRoutingLogic.routesDirect(true, false));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/RemoteRoutingLogicTest.java
@@ -92,19 +92,25 @@ public class RemoteRoutingLogicTest {
 
     /**
      * The DNS redirect costs a UID lookup, a JNI upcall and a UDP session per
-     * query, so nobody pays for it until an app is actually routed direct.
-     * Keying this off the mode instead was wrong: a per-app override sends an
-     * app direct in "All apps" too, and that app then tunnelled its DNS while
-     * its traffic went direct — the very split the redirect exists to avoid.
+     * query, so nobody pays for it until an app is actually routed direct and
+     * an underlying resolver target exists. Keying this off the mode instead
+     * was wrong: a per-app override sends an app direct in "All apps" too, and
+     * that app then tunnelled its DNS while its traffic went direct — the very
+     * split the redirect exists to avoid.
      */
     @Test
     public void dnsRedirectFollowsActualDirectApps() {
-        assertFalse(RemoteRoutingLogic.redirectDirectDns(false));
-        assertTrue(RemoteRoutingLogic.redirectDirectDns(true));
+        assertFalse(RemoteRoutingLogic.redirectDirectDns(false, true));
+        assertTrue(RemoteRoutingLogic.redirectDirectDns(true, true));
+
+        // A direct route is not enough by itself: without an underlying
+        // resolver target, enabling fwd53 would only redirect queries into a
+        // null destination.
+        assertFalse(RemoteRoutingLogic.redirectDirectDns(true, false));
 
         boolean overriddenDirectInAllMode = !RemoteRoutingLogic.routesThroughTunnel(
                 RemoteRoutingLogic.MODE_ALL, Boolean.FALSE, true);
-        assertTrue(RemoteRoutingLogic.redirectDirectDns(overriddenDirectInAllMode));
+        assertTrue(RemoteRoutingLogic.redirectDirectDns(overriddenDirectInAllMode, true));
     }
 
     /**

--- a/wgbridge-rs/README.md
+++ b/wgbridge-rs/README.md
@@ -158,3 +158,13 @@ hostnames, and re-resolves them on network changes via `updateEndpoint`).
   and end in one sequence-aligned segment. Rewriting a frame split across
   packets needs buffering plus TCP sequence translation; continuation segments
   are deliberately forwarded unchanged until that exists.
+- **DNS upstream privacy**: app DNS packets to port 53 go through WireGuard
+  whenever the tunnel is up — `ip.c` forces them into it regardless of
+  destination, because an unprotected query would expose the user's physical
+  network to the resolver. The one exception is an app the user has routed
+  around the tunnel: its queries are redirected to the system resolver
+  (see `RemoteRoutingLogic`), which is the cost of letting that app keep
+  working when the tunnel drops. The remaining gap is that TrackerControl's
+  own DoH proxy is not yet advertised as the sole resolver, which would let
+  interception and upstream privacy hold at the same time without the
+  redirect.


### PR DESCRIPTION
Remote WireGuard egress applied globally: the only way to keep an app
off the remote tunnel was "Exclude from VPN", which also dropped local
monitoring and blocking. Whether an app is filtered and whether it is
forwarded through the remote VPN are independent choices, and #723 is
what happens when they are collapsed into one.

Add a global "Route through remote VPN" mode (All apps / Only selected
apps) plus a per-app override, orthogonal to the protection state. The
default is All apps, which is byte-identical to the behaviour before
this existed — unknown UIDs and system traffic follow that same default,
so nothing changes for anyone who does not opt in.

The fork is one expression in ip.c, now route_wants_tunnel(): pure, so
the decision table can be read straight through, with the caller still
deciding what to do when the tunnel is down, because only the write
attempt can say whether it is. RemoteRoutingLogic mirrors it on the Java
side so both halves are JVM-testable; the stacked follow-up #737 moves
the decision itself into wgbridge-rs/src/policy.rs, where CI already
runs cargo test, and reduces the C to a caller.

Java pushes down only the UIDs whose routing *differs* from the global
default, through a new jni_wireguard_route. Pushing the whole tunnelled
set instead looked reasonable and was not: in the default mode every
applied app is tunnelled, so the set held every installed app and was
indistinguishable from a heavily-overridden one. The packet path could
no longer tell that nobody had opted in, and paid a mutex and a
session-table walk per packet to rediscover it — for every user,
WireGuard enabled or not. With overrides the set is empty until someone
sets one, so the common case reads two lock-free atomics and stops.
Absence from the set means "follow the default", which is what makes the
default mode identical to the behaviour before this existed.

Resolving the UID at the fork needed more care than expected. Packet 2+
of an established flow arrives with uid == -1, since the expensive
lookup is deliberately skipped for existing UDP sessions and non-SYN
TCP, and get_uid_q is never re-run here: it is a binder call. The
session table answers for direct flows, but not for tunnelled ones —
those are handed to WireGuard and return before handle_tcp/handle_udp,
so no ng_session is ever created for them. Falling back to the global
default there is wrong in exactly the mode this feature exists for: in
"Only selected apps" the default is direct, so the rest of a tunnelled
TCP flow was routed direct and handle_tcp, finding no session for a
non-SYN segment, answered it with an RST. A per-flow verdict cache,
keyed on the 5-tuple and invalidated by generation on every reload,
keeps a flow on the answer its first packet was given; the session table
remains the fallback behind it.

DNS is the crux, and a privacy decision rather than plumbing. Forcing
every query into the tunnel is what stops the resolver seeing the user's
physical network, but it also breaks a directly-routed app whenever the
tunnel drops. Direct apps' DNS is therefore redirected to the system
resolver through the existing Allowed(raddr, rport) mechanism, which is
transparent — replies are rebuilt from the session's original addresses.
That costs a UID lookup, a JNI upcall and a real UDP session per query,
because port 53 is the only UDP traffic that skips all three today, so
it is only enabled once some app actually is routed direct — a property
of the resolved rules, not of the mode, since an override sends an app
direct in either one. Users of the default keep the current zero-cost
DNS path. The packet path learns this through its own flag rather than
by reading fwd53, which is also set by an unrelated port-53 forward:
Secure DNS installs one whenever the WireGuard config carries no DNS
line, and borrowing it silently switched off the rule that every
resolver query takes the tunnel. The reduced DNS privacy and the fact
that a direct app sees this device's real address are both stated in the
control's own copy.

Routes are the remaining constraint: they belong to the single tun every
app shares, so a narrower AllowedIPs would shrink them for tunnelled
apps too. gotatun silently drops packets matching no peer's AllowedIPs
(device/mod.rs), so this would blackhole rather than fail visibly. v1
therefore gates the control on a default-route tunnel and explains why
when it is unavailable.

Also adds the new wg_route store to uninstall cleanup and to XML
export/import, which the other per-package stores already had, and
corrects the wgbridge-rs README item claiming app DNS stays on the local
NetGuard path — ip.c has forced it into WireGuard since the DNS change.

Reconciling the native fork with its Java mirror also surfaced three
bugs that predate this work and are not fixed here, all one root cause:
handle_ip diverts to WireGuard before the DNS and session machinery
runs, so everything that machinery provides disappears while the tunnel
is on. Filed as #734, #735 and #736, independent of this stack.

Not device-tested yet.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
