### PR TITLE
Collapse the per-app controls into rows that open on demand

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
@@ -40,6 +40,7 @@ public class TrackersFragment extends Fragment {
     private int mAppUid;
 
     private SwipeRefreshLayout swipeRefresh;
+    private RecyclerView recyclerView;
     private TrackersListAdapter adapter;
 
     private boolean running = false;
@@ -79,7 +80,7 @@ public class TrackersFragment extends Fragment {
 
         Context c = v.getContext();
         trackerList = TrackerList.getInstance(c);
-        RecyclerView recyclerView = v.findViewById(R.id.transmissions_list);
+        recyclerView = v.findViewById(R.id.transmissions_list);
         recyclerView.setLayoutManager(new LinearLayoutManager(c));
         adapter = new TrackersListAdapter(getActivity(), recyclerView, mAppUid, mAppId);
         recyclerView.setAdapter(adapter);
@@ -212,10 +213,19 @@ public class TrackersFragment extends Fragment {
 
     @Override
     public void onDestroyView() {
-        super.onDestroyView();
+        // Explicitly detach the adapter while the RecyclerView still exists.
+        // This invokes onDetachedFromRecyclerView(), which dismisses any open
+        // BottomSheetDialog before the view's Activity context can be retained.
+        if (recyclerView != null) {
+            recyclerView.setAdapter(null);
+            recyclerView = null;
+        }
+        adapter = null;
+
         // Avoid leaking the SwipeRefreshLayout (and its Activity context) beyond
         // the view's lifecycle when the Fragment instance is retained.
         swipeRefresh = null;
+        super.onDestroyView();
     }
 
     @Override

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -37,6 +37,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.RadioGroup;
+import com.google.android.material.bottomsheet.BottomSheetDialog;
 import com.google.android.material.materialswitch.MaterialSwitch;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -93,6 +94,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     private View mLayoutProgress;
     private TextView mTvAnalysisProgress;
     private ProgressBar mPbTrackerDetection;
+
+    // At most one of the app-controls bottom sheets is open at a time.
+    private BottomSheetDialog mOpenSheet;
 
     public TrackersListAdapter(Context c,
             RecyclerView v,
@@ -455,29 +459,8 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             holder.mLibraryExplanation.setText(R.string.trackers_static_explanation);
 
-            // The internet block is keyed by UID, so it necessarily covers every
-            // package sharing that UID. Say so rather than letting it surprise.
-            String relatedApps = getRelatedApps();
-            if (relatedApps == null) {
-                holder.mNoInternetExplanation.setText(R.string.app_state_no_internet_explanation);
-            } else {
-                String explanation = mContext.getString(R.string.app_state_no_internet_explanation_shared,
-                        mContext.getString(R.string.app_state_no_internet_explanation),
-                        mContext.getString(R.string.app_state_no_internet_shared_uid, relatedApps));
-                holder.mNoInternetExplanation.setText(explanation);
-            }
-
-            AppProtectionState state = currentState(w);
-            holder.mAppState.setOnCheckedChangeListener(null);
-            holder.mAppState.check(radioIdFor(state));
-            holder.mAppState.setOnCheckedChangeListener((group, checkedId) -> {
-                AppProtectionState selected = stateForRadioId(checkedId);
-                if (selected == null || selected == currentState(w))
-                    return;
-
-                applyState(selected, w);
-                notifyDataSetChanged();
-            });
+            holder.mAppStateValue.setText(stateLabelRes(currentState(w)));
+            holder.mRowAppState.setOnClickListener(v -> showProtectionSheet(w));
 
             bindRemoteRouting(holder);
         }
@@ -498,34 +481,129 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         RemoteRoutingLogic.Unavailable unavailable =
                 RemoteRoutingLogic.getUnavailableReason(wgEnabled, defaultRoutes, applyApp);
         if (unavailable != null) {
-            holder.mAppRoute.setVisibility(View.GONE);
-            holder.mAppRouteUnavailable.setVisibility(View.VISIBLE);
-            holder.mAppRouteUnavailable.setText(explainUnavailable(unavailable));
+            holder.mRowAppRoute.setOnClickListener(null);
+            holder.mRowAppRoute.setClickable(false);
+            holder.mRowAppRoute.setEnabled(false);
+            holder.mAppRouteChevron.setVisibility(View.GONE);
+            holder.mAppRouteValue.setText(explainUnavailable(unavailable));
             return;
         }
-
-        holder.mAppRouteUnavailable.setVisibility(View.GONE);
-        holder.mAppRoute.setVisibility(View.VISIBLE);
 
         String mode = RemoteRoutingLogic.normalizeMode(
                 prefs.getString(Rule.PREF_WG_ROUTE_MODE, RemoteRoutingLogic.getDefaultMode()));
         boolean tunnelled = RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true);
 
-        holder.mAppRoute.setOnCheckedChangeListener(null);
-        holder.mAppRoute.check(tunnelled ? R.id.rbRouteTunnel : R.id.rbRouteDirect);
-        holder.mAppRoute.setOnCheckedChangeListener((group, checkedId) -> {
-            boolean wantsTunnel = (checkedId == R.id.rbRouteTunnel);
-            if (wantsTunnel == RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true))
-                return;
+        holder.mRowAppRoute.setEnabled(true);
+        holder.mRowAppRoute.setClickable(true);
+        holder.mAppRouteChevron.setVisibility(View.VISIBLE);
+        holder.mAppRouteValue.setText(tunnelled ? R.string.app_route_through : R.string.app_route_direct);
+        holder.mRowAppRoute.setOnClickListener(v -> showRouteSheet());
+    }
 
-            mContext.getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE)
-                    .edit().putBoolean(mAppId, wantsTunnel).apply();
+    /**
+     * Shows the protection-state bottom sheet, wiring the shared-UID
+     * No-Internet explanation into the sheet's own description view.
+     */
+    private void showProtectionSheet(InternetBlocklist w) {
+        BottomSheetDialog sheet = new BottomSheetDialog(mContext);
+        View view = LayoutInflater.from(mContext).inflate(R.layout.bottom_sheet_app_state, null);
+        sheet.setContentView(view);
 
-            AsyncTask.execute(() -> {
-                Rule.clearCache(mContext);
-                ServiceSinkhole.reload("app routing changed", mContext, false);
-            });
+        // The internet block is keyed by UID, so it necessarily covers every
+        // package sharing that UID. Say so rather than letting it surprise.
+        TextView noInternetDesc = view.findViewById(R.id.tvStateNoInternetDesc);
+        String relatedApps = getRelatedApps();
+        if (relatedApps == null) {
+            noInternetDesc.setText(R.string.app_state_no_internet_explanation);
+        } else {
+            String explanation = mContext.getString(R.string.app_state_no_internet_explanation_shared,
+                    mContext.getString(R.string.app_state_no_internet_explanation),
+                    mContext.getString(R.string.app_state_no_internet_shared_uid, relatedApps));
+            noInternetDesc.setText(explanation);
+        }
+
+        RadioGroup rgAppState = view.findViewById(R.id.rgAppState);
+        rgAppState.check(radioIdFor(currentState(w)));
+        rgAppState.setOnCheckedChangeListener((group, checkedId) -> {
+            AppProtectionState selected = stateForRadioId(checkedId);
+
+            // Dismiss first: applyState() may trigger a reload, and the sheet
+            // shouldn't linger on screen while that happens.
+            sheet.dismiss();
+
+            if (selected != null && selected != currentState(w)) {
+                applyState(selected, w);
+                notifyDataSetChanged();
+            }
         });
+
+        showSheet(sheet);
+    }
+
+    /**
+     * Shows the remote-routing bottom sheet, recomputing the current mode the
+     * same way {@link #bindRemoteRouting(VHHeader)} does.
+     */
+    private void showRouteSheet() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(mContext);
+        String mode = RemoteRoutingLogic.normalizeMode(
+                prefs.getString(Rule.PREF_WG_ROUTE_MODE, RemoteRoutingLogic.getDefaultMode()));
+        boolean tunnelled = RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true);
+
+        BottomSheetDialog sheet = new BottomSheetDialog(mContext);
+        View view = LayoutInflater.from(mContext).inflate(R.layout.bottom_sheet_app_route, null);
+        sheet.setContentView(view);
+
+        RadioGroup rgAppRoute = view.findViewById(R.id.rgAppRoute);
+        rgAppRoute.check(tunnelled ? R.id.rbRouteTunnel : R.id.rbRouteDirect);
+        rgAppRoute.setOnCheckedChangeListener((group, checkedId) -> {
+            boolean wantsTunnel = (checkedId == R.id.rbRouteTunnel);
+
+            // Dismiss first: the reload triggered below shouldn't hold the
+            // sheet open while it runs.
+            sheet.dismiss();
+
+            if (wantsTunnel != RemoteRoutingLogic.routesThroughTunnel(mode, getRouteOverride(), true)) {
+                mContext.getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE)
+                        .edit().putBoolean(mAppId, wantsTunnel).apply();
+
+                AsyncTask.execute(() -> {
+                    Rule.clearCache(mContext);
+                    ServiceSinkhole.reload("app routing changed", mContext, false);
+                });
+
+                // The row subtitle now depends on this value.
+                notifyDataSetChanged();
+            }
+        });
+
+        showSheet(sheet);
+    }
+
+    /**
+     * Only one sheet should be open at a time, and it must not outlive the
+     * RecyclerView that hosts the row that opened it.
+     */
+    private void showSheet(BottomSheetDialog sheet) {
+        if (mOpenSheet != null)
+            mOpenSheet.dismiss();
+
+        mOpenSheet = sheet;
+        sheet.setOnDismissListener(d -> {
+            if (mOpenSheet == d)
+                mOpenSheet = null;
+        });
+        sheet.show();
+    }
+
+    @Override
+    public void onDetachedFromRecyclerView(@NonNull RecyclerView recyclerView) {
+        super.onDetachedFromRecyclerView(recyclerView);
+
+        if (mOpenSheet != null) {
+            mOpenSheet.dismiss();
+            mOpenSheet = null;
+        }
     }
 
     @Nullable
@@ -657,6 +735,20 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         return null;
     }
 
+    private static int stateLabelRes(AppProtectionState state) {
+        switch (state) {
+            case TRACKERS_ALLOWED:
+                return R.string.app_state_trackers_allowed;
+            case NO_INTERNET:
+                return R.string.app_state_no_internet;
+            case BYPASSED:
+                return R.string.app_state_bypassed;
+            case PROTECTED:
+            default:
+                return R.string.app_state_protected;
+        }
+    }
+
     @Override
     public int getItemCount() {
         return mValues.size() + 1;
@@ -698,21 +790,21 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     static class VHHeader extends RecyclerView.ViewHolder {
         final TextView mLibraryExplanation;
         final TextView mLibraryDisclaimer;
-        final RadioGroup mAppState;
-        final TextView mNoInternetExplanation;
-        final View mAppRouteCard;
-        final RadioGroup mAppRoute;
-        final TextView mAppRouteUnavailable;
+        final View mRowAppState;
+        final TextView mAppStateValue;
+        final View mRowAppRoute;
+        final TextView mAppRouteValue;
+        final View mAppRouteChevron;
 
         VHHeader(View view) {
             super(view);
             mLibraryExplanation = view.findViewById(R.id.tvLibraryExplanation);
             mLibraryDisclaimer = view.findViewById(R.id.tvLibraryDisclaimer);
-            mAppState = view.findViewById(R.id.rgAppState);
-            mNoInternetExplanation = view.findViewById(R.id.tvStateNoInternetDesc);
-            mAppRouteCard = view.findViewById(R.id.cardAppRoute);
-            mAppRoute = view.findViewById(R.id.rgAppRoute);
-            mAppRouteUnavailable = view.findViewById(R.id.tvAppRouteUnavailable);
+            mRowAppState = view.findViewById(R.id.rowAppState);
+            mAppStateValue = view.findViewById(R.id.tvAppStateValue);
+            mRowAppRoute = view.findViewById(R.id.rowAppRoute);
+            mAppRouteValue = view.findViewById(R.id.tvAppRouteValue);
+            mAppRouteChevron = view.findViewById(R.id.ivAppRouteChevron);
         }
     }
 }

--- a/app/src/main/res/drawable/ic_chevron_right.xml
+++ b/app/src/main/res/drawable/ic_chevron_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/app/src/main/res/layout/bottom_sheet_app_route.xml
+++ b/app/src/main/res/layout/bottom_sheet_app_route.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp">
+
+        <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:text="@string/app_route_heading"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <RadioGroup
+            android:id="@+id/rgAppRoute"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:id="@+id/rbRouteTunnel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_route_through"
+                android:text="@string/app_route_through"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvRouteTunnelDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_route_through_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+            <RadioButton
+                android:id="@+id/rbRouteDirect"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_route_direct"
+                android:text="@string/app_route_direct"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvRouteDirectDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:text="@string/app_route_direct_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+        </RadioGroup>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/bottom_sheet_app_state.xml
+++ b/app/src/main/res/layout/bottom_sheet_app_state.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:paddingBottom="24dp">
+
+        <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:text="@string/app_state_heading"
+            android:textColor="?android:textColorPrimary"
+            android:textSize="18sp"
+            android:textStyle="bold" />
+
+        <RadioGroup
+            android:id="@+id/rgAppState"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <RadioButton
+                android:id="@+id/rbStateProtected"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_state_protected"
+                android:text="@string/app_state_protected"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvStateProtectedDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_state_protected_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+            <RadioButton
+                android:id="@+id/rbStateTrackersAllowed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_state_trackers_allowed"
+                android:text="@string/app_state_trackers_allowed"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvStateTrackersAllowedDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_state_trackers_allowed_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+            <RadioButton
+                android:id="@+id/rbStateNoInternet"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_state_no_internet"
+                android:text="@string/app_state_no_internet"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvStateNoInternetDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:layout_marginBottom="12dp"
+                android:text="@string/app_state_no_internet_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+            <RadioButton
+                android:id="@+id/rbStateBypassed"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:contentDescription="@string/app_state_bypassed"
+                android:text="@string/app_state_bypassed"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/tvStateBypassedDesc"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="32dp"
+                android:text="@string/app_state_bypassed_explanation"
+                android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+        </RadioGroup>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -180,11 +180,12 @@
 
     </androidx.cardview.widget.CardView>
 
-    <!-- App Protection Card - one state, four mutually exclusive options -->
+    <!-- App controls: tap a row to change protection state or remote VPN routing -->
     <androidx.cardview.widget.CardView
-        android:layout_marginBottom="8dp"
+        android:id="@+id/cardAppControls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
         android:clipToPadding="false"
         app:cardCornerRadius="4dp"
         app:cardElevation="1dp"
@@ -193,178 +194,115 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp">
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/tvAppStateHeading"
+            <LinearLayout
+                android:id="@+id/rowAppState"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:text="@string/app_state_heading"
-                android:textColor="?android:textColorPrimary"
-                android:textSize="18sp"
-                android:textStyle="bold" />
+                android:minHeight="56dp"
+                android:gravity="center_vertical"
+                android:background="?android:attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="horizontal"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp">
 
-            <RadioGroup
-                android:id="@+id/rgAppState"
+                <LinearLayout
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/tvAppStateTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/app_state_heading"
+                        android:textColor="?android:textColorPrimary"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/tvAppStateValue"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:textColor="?android:textColorSecondary"
+                        android:textSize="13sp" />
+
+                </LinearLayout>
+
+                <ImageView
+                    android:id="@+id/ivAppStateChevron"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="8dp"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_chevron_right"
+                    app:tint="?android:attr/textColorSecondary" />
+
+            </LinearLayout>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginStart="16dp"
+                android:background="?android:attr/listDivider" />
+
+            <LinearLayout
+                android:id="@+id/rowAppRoute"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:minHeight="56dp"
+                android:gravity="center_vertical"
+                android:background="?android:attr/selectableItemBackground"
+                android:clickable="true"
+                android:focusable="true"
+                android:orientation="horizontal"
+                android:paddingStart="16dp"
+                android:paddingEnd="16dp"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp">
 
-                <RadioButton
-                    android:id="@+id/rbStateProtected"
-                    android:layout_width="match_parent"
+                <LinearLayout
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_state_protected"
-                    android:text="@string/app_state_protected"
-                    android:textStyle="bold" />
+                    android:layout_weight="1"
+                    android:orientation="vertical">
 
-                <TextView
-                    android:id="@+id/tvStateProtectedDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:layout_marginBottom="12dp"
-                    android:text="@string/app_state_protected_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+                    <TextView
+                        android:id="@+id/tvAppRouteTitle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/app_route_heading"
+                        android:textColor="?android:textColorPrimary"
+                        android:textSize="15sp"
+                        android:textStyle="bold" />
 
-                <RadioButton
-                    android:id="@+id/rbStateTrackersAllowed"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_state_trackers_allowed"
-                    android:text="@string/app_state_trackers_allowed"
-                    android:textStyle="bold" />
+                    <TextView
+                        android:id="@+id/tvAppRouteValue"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:textColor="?android:textColorSecondary"
+                        android:textSize="13sp" />
 
-                <TextView
-                    android:id="@+id/tvStateTrackersAllowedDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:layout_marginBottom="12dp"
-                    android:text="@string/app_state_trackers_allowed_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+                </LinearLayout>
 
-                <RadioButton
-                    android:id="@+id/rbStateNoInternet"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_state_no_internet"
-                    android:text="@string/app_state_no_internet"
-                    android:textStyle="bold" />
+                <ImageView
+                    android:id="@+id/ivAppRouteChevron"
+                    android:layout_width="24dp"
+                    android:layout_height="24dp"
+                    android:layout_marginStart="8dp"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_chevron_right"
+                    app:tint="?android:attr/textColorSecondary" />
 
-                <TextView
-                    android:id="@+id/tvStateNoInternetDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:layout_marginBottom="12dp"
-                    android:text="@string/app_state_no_internet_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
-
-                <RadioButton
-                    android:id="@+id/rbStateBypassed"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_state_bypassed"
-                    android:text="@string/app_state_bypassed"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/tvStateBypassedDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:text="@string/app_state_bypassed_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
-
-            </RadioGroup>
-
-        </LinearLayout>
-
-    </androidx.cardview.widget.CardView>
-
-    <!-- Remote VPN routing: independent of the protection state above -->
-    <androidx.cardview.widget.CardView
-        android:id="@+id/cardAppRoute"
-        android:layout_marginBottom="8dp"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:clipToPadding="false"
-        app:cardCornerRadius="4dp"
-        app:cardElevation="1dp"
-        app:cardMaxElevation="@dimen/z_card">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="16dp">
-
-            <TextView
-                android:id="@+id/tvAppRouteHeading"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="12dp"
-                android:text="@string/app_route_heading"
-                android:textColor="?android:textColorPrimary"
-                android:textSize="18sp"
-                android:textStyle="bold" />
-
-            <TextView
-                android:id="@+id/tvAppRouteUnavailable"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textAppearance="@style/TextAppearance.Material3.LabelSmall"
-                android:visibility="gone" />
-
-            <RadioGroup
-                android:id="@+id/rgAppRoute"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical">
-
-                <RadioButton
-                    android:id="@+id/rbRouteTunnel"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_route_through"
-                    android:text="@string/app_route_through"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/tvRouteTunnelDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:layout_marginBottom="12dp"
-                    android:text="@string/app_route_through_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
-
-                <RadioButton
-                    android:id="@+id/rbRouteDirect"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="4dp"
-                    android:contentDescription="@string/app_route_direct"
-                    android:text="@string/app_route_direct"
-                    android:textStyle="bold" />
-
-                <TextView
-                    android:id="@+id/tvRouteDirectDesc"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="32dp"
-                    android:text="@string/app_route_direct_explanation"
-                    android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
-
-            </RadioGroup>
+            </LinearLayout>
 
         </LinearLayout>
 


### PR DESCRIPTION
Protection and Remote VPN each showed every option's full explanation at all
times: eight paragraphs of copy between the tab bar and the first tracker, so
the list the screen exists for started two and a half screens down. The
explanations are worth their length — "Trackers allowed" versus "Bypass
TrackerControl" is not a choice anyone should make from the label alone — but
paying for them on every visit is what pushed the trackers off the screen.

Each control is now a row carrying its current value ("Protection —
Protected"), and the radio list with the full explanations lives in a bottom
sheet behind it. Comparing the options before choosing still works, because the
sheet shows all of them together with their copy intact; it just no longer
happens by default. The tracker categories are back on the first screen.

The remote-routing row states its own unavailability instead of hiding: when
there is no remote VPN, the app bypasses TrackerControl, or the tunnel carries
only part of the traffic, the reason sits where the value would be and the row
does not open.

Nothing about the underlying state changes. `resolve`/`applyState`, the reload
gating, and the per-app `wg_route` write are the same calls in the same order —
the diff is the view layer, and `AppProtectionStateTest` and
`RemoteRoutingLogicTest` still cover the logic unchanged. No new strings, so no
locale file is touched, and no new JVM test: this adds no logic class, only
binding plus a `stateLabelRes` switch mirroring the existing `radioIdFor`.

Two details the radio groups did not have to handle. The sheet dismisses before
the state is applied, because `applyState` triggers a rebind and the old
`isPressed()` guard against programmatic re-checks has no equivalent here. And
the sheet is dropped in `onDetachedFromRecyclerView`, so a details screen torn
down with one open does not leak its window.

Verified on an emulator (fdroid debug): rows render with their current values,
the sheet opens with the right option checked, selecting one applies it and
updates the row, and the Remote VPN row shows `app_route_unavailable_no_vpn`
with no chevron when nothing is configured. `:app:testGithubDebugUnitTest` and
`:app:lintGithubDebug` pass.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
