### PR TITLE
Dedup DNS attribution rows in one pass, not per candidate row

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -1166,7 +1166,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             SQLiteDatabase db = readableDb;
             String escapedIp = ip.replace("'", "''");
             String aliveFilter = alive
-                    ? " AND (%1$s.time IS NULL OR %1$s.time + %1$s.ttl >= " + now + ")"
+                    ? " AND (d.time IS NULL OR d.time + d.ttl >= " + now + ")"
                     : "";
             // There is a segmented index on resource. A shared IP can carry
             // DNS evidence for several qnames; keep only the most recently
@@ -1174,17 +1174,20 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             // the freshest resolution — most likely tied to the connection
             // that's actually being made now — is attributed first instead
             // of an alphabetically-first but possibly stale one.
-            String query = "SELECT d.qname, d.aname, d.time, d.ttl" +
+            //
+            // The dedup deliberately uses a single MAX(time) aggregate: with
+            // exactly one min/max aggregate, SQLite takes the bare columns
+            // from the row that supplied the maximum, so this is one index
+            // range scan over the IP's rows. A correlated per-row subquery
+            // here re-scans the IP's rows once per candidate row — O(n²) —
+            // and this query runs for every new connection (log() and
+            // blockKnownTracker()), where it grows with DNS history until
+            // it shows up as battery drain and heat.
+            String query = "SELECT d.qname, d.aname, d.time, d.ttl, MAX(d.time)" +
                     " FROM dns AS d" +
                     " WHERE d.resource = '" + escapedIp + "'" +
-                    String.format(aliveFilter, "d") +
-                    " AND d.ID = (" +
-                    "   SELECT d2.ID FROM dns AS d2" +
-                    "   WHERE d2.resource = d.resource AND d2.qname = d.qname" +
-                    String.format(aliveFilter, "d2") +
-                    "   ORDER BY d2.time DESC, d2.ID DESC" +
-                    "   LIMIT 1" +
-                    " )" +
+                    aliveFilter +
+                    " GROUP BY d.qname" +
                     " ORDER BY d.time DESC, d.ID DESC";
             return db.rawQuery(query, new String[] {});
         } finally {

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
@@ -59,6 +59,33 @@ public class DatabaseHelperDnsAttributionTest {
         }
     }
 
+    @Test
+    public void aliveFilterAppliesBeforeDedup() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        String ip = "203.0.113.30";
+        // The freshest observation has already expired; an older one is still
+        // alive. With alive=true the expired row must not shadow the alive one.
+        // Rows are inserted directly because insertDns() clamps the TTL to the
+        // "ttl" preference floor, which would keep the fresh row alive.
+        long now = System.currentTimeMillis();
+        dh.getWritableDatabase().execSQL(
+                "INSERT INTO dns (time, qname, aname, resource, ttl) VALUES ("
+                        + (now - 10_000) + ", 't2.example.com', 'alive-cname.example.com', '"
+                        + ip + "', 3600000)");
+        dh.getWritableDatabase().execSQL(
+                "INSERT INTO dns (time, qname, aname, resource, ttl) VALUES ("
+                        + (now - 5_000) + ", 't2.example.com', 'expired-cname.example.com', '"
+                        + ip + "', 1000)");
+
+        try (Cursor c = dh.getQAName(-1, ip, true)) {
+            assertEquals(1, c.getCount());
+            assertTrue(c.moveToFirst());
+            assertEquals("alive-cname.example.com", c.getString(c.getColumnIndexOrThrow("aname")));
+        }
+    }
+
     private static ResourceRecord rr(long time, String qname, String aname, String resource, int ttl) {
         ResourceRecord rr = new ResourceRecord();
         rr.Time = time;


### PR DESCRIPTION
## Summary

Root-causes the battery/heat regression attributed to "DNS deduping". The culprit is not #739 (the DNS response-rewriting dedup — reviewed below), but the qname dedup that #690 added to `DatabaseHelper.getQAName()`.

#690 deduplicates a shared IP's DNS evidence with a **correlated scalar subquery**: for every candidate row of the IP, SQLite re-searches `idx_dns_resource` across *all* of that IP's rows and sorts them in a temp B-tree to pick the freshest row per qname (`EXPLAIN QUERY PLAN`: `CORRELATED SCALAR SUBQUERY` → `SEARCH d2 USING INDEX idx_dns_resource (resource=?)` → `USE TEMP B-TREE FOR ORDER BY`, executed once per outer row). That is O(n²) row visits plus one sort per row, where n is the number of dns rows sharing the IP.

Two things make this a *battery/heat* issue rather than a slow query:

- **It runs for every new connection.** `ServiceSinkhole.log()` calls `getQAName(uid, daddr, false)` for every logged packet event — with the alive filter off, so n includes the full accumulated history for that IP. `blockKnownTracker()` runs it again (alive=true) on every `ipToHost` cache miss, inside the `is_address_allowed` JNI upcall from the native packet path.
- **It grows over time.** `insertDns()` clamps TTL to the "ttl" preference floor (3 days by default) and expired rows are only removed by cleanup, so hot CDN/tracker IPs steadily accumulate qname rows. The regression creeps in as the table fills — matching a heat report that surfaces weeks after #690 merged.

Benchmark (real SQLite, 400 qnames × 3 anames on one shared IP = 1,200 rows): **~147 ms per lookup before, ~0.9 ms after (~150×)** — per connection, on the log handler thread and the packet-path upcall.

## Fix

Replace the correlated subquery with a single `MAX(time)` aggregate grouped by qname. With exactly one min/max aggregate, SQLite takes the bare columns from the row that supplied the maximum, so #690's semantics are unchanged — freshest row per qname, qnames ordered by recency — while the plan collapses to one index range scan over the IP's rows (same shape as before #690, now with recency ordering).

## Validation

- Query semantics verified against real SQLite: existing test cases (recency ordering, dedup-to-freshest-row) reproduce identical results; `EXPLAIN QUERY PLAN` confirms the correlated subquery is gone.
- New Robolectric test pins the alive-filter/dedup interplay: an expired fresher row must not shadow an older row that is still alive (rows inserted directly because `insertDns()`'s TTL clamp would keep the fresh row alive).
- No Android SDK in this container, so `:app:testGithubDebugUnitTest` runs in CI on this PR; I'll watch it.

## Review of #739 for the same symptom

"Deduplicate DNS response rewriting" (#739) was also examined for battery/heat mechanisms and none was found: the `tc-dns` parse is bounded per packet (name-compression depth 8, 255-octet cap), it only runs for port-53 traffic, the Rust library is still built `--release`, no periodic work, timers, or wakeup sources are added, and the C TCP path's new length-prefix rewrite only shortens isolated complete frames with consistent sequence accounting. Its per-response cost (heap allocation + the same one-per-response JNI upcalls) is bounded by DNS traffic and cannot produce sustained CPU.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Hp2Xpr5CSahi9Qizg9zjp

---
_Generated by [Claude Code](https://claude.ai/code/session_012Hp2Xpr5CSahi9Qizg9zjp)_