### PR TITLE
Align lockdown troubleshooting text with actual behaviour (#743)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -292,7 +292,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
                 if (isChecked) {
                     // Check always-on VPN settings only on Android < S (API 31)
-                    // From Android S+, these settings keys are restricted to system apps
+                    // From Android S+, these settings keys are restricted to system apps,
+                    // so lockdown cannot be detected there; coverage on S+ is limited to
+                    // the onboarding slide and the troubleshooting page (deliberate, see #743)
                     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S)
                         try {
                             String alwaysOn = Settings.Secure.getString(getContentResolver(), "always_on_vpn_app");

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,7 +79,7 @@
     <string name="troubleshooting_categories_desc">You can fine-tune blocking for each app by tapping it and toggling individual tracker categories (e.g. Analytics, Ads) on or off in the Trackers tab.</string>
 
     <string name="troubleshooting_alwayson_title">Always-on VPN</string>
-    <string name="troubleshooting_alwayson_desc">If \"Block connections without VPN\" (lockdown) is enabled in Android VPN settings, TrackerControl cannot work correctly. Disable this option. A notification will appear if this is detected.</string>
+    <string name="troubleshooting_alwayson_desc">If \"Block connections without VPN\" (lockdown) is enabled in Android VPN settings, TrackerControl cannot work correctly. Disable this option.</string>
     <string name="troubleshooting_alwayson_action">Open VPN settings</string>
     <string name="menu_apps">Other apps</string>
 
@@ -388,7 +388,6 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="title_ruid">Destination app</string>
     <string name="title_external">For an external server select \'nobody\'</string>
 
-    <string name="title_lockdown_enabled">Traffic is locked down</string>
     <string name="title_unmetered_allowed">Unmetered traffic is allowed</string>
     <string name="title_unmetered_blocked">Unmetered traffic is blocked</string>
     <string name="title_unmetered_disabled">Unmetered rules are not applied</string>


### PR DESCRIPTION
Fixes the actionable half of #743 (part 2), and documents the decision on part 1.

- `troubleshooting_alwayson_desc` no longer claims "A notification will appear if this is detected" — no such notification is posted anywhere, and on Android S+ the lockdown condition cannot be detected by non-system apps at all.
- Removed the dead `title_lockdown_enabled` string (defined, never referenced). Only the source `values/strings.xml` is touched; Crowdin sync will drop the stale translations.
- Extended the comment on the `SDK_INT < S` guard in `ActivityMain` to record that the missing S+ enable-time check is deliberate, with onboarding and the troubleshooting page as the remaining coverage — so part 1 of #743 can be closed as a decision rather than rediscovered.

Validation: XML well-formedness checked and no remaining `title_lockdown_enabled` references in `app/src`. No Android SDK is available in this environment, so `compileGithubDebugJavaWithJavac` could not be run — the Java change is a comment only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GTx9x5FNwfkVpNfJmWiqWT

---
_Generated by [Claude Code](https://claude.ai/code/session_01GTx9x5FNwfkVpNfJmWiqWT)_