### PR TITLE
Fix offline release build failing on desugar_jdk_libs (CI failure blocking #718)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,8 @@ tasks.register('prefetchOfflineBuildClasspaths') {
     doLast {
         ['fdroidDebugUnitTestRuntimeClasspath',
          'fdroidReleaseCompileClasspath',
-         'fdroidReleaseRuntimeClasspath'].each { name ->
+         'fdroidReleaseRuntimeClasspath',
+         'coreLibraryDesugaring'].each { name ->
             configurations.named(name).get().resolve()
         }
     }


### PR DESCRIPTION
## Summary

The `test` job's `./gradlew :app:assembleFdroidRelease --offline` step fails on CI (currently blocking #718 and any other PR, unrelated to their own diffs):

```
Could not resolve all files for configuration ':app:coreLibraryDesugaring'.
> Failed to transform desugar_jdk_libs-2.1.5.jar (com.android.tools:desugar_jdk_libs:2.1.5) ...
  > Could not download desugar_jdk_libs-2.1.5.jar (com.android.tools:desugar_jdk_libs:2.1.5): No cached version available for offline mode
```

`prefetchOfflineBuildClasspaths` (`app/build.gradle`) resolves the runtime/compile classpaths needed for the later `--offline` steps, but never resolved the `coreLibraryDesugaring` configuration, so `desugar_jdk_libs` was never downloaded while networking was available.

- Add `coreLibraryDesugaring` to the list of configurations `prefetchOfflineBuildClasspaths` resolves.

## Test plan

- [x] `app/build.gradle` parses (Gradle configuration phase reaches the SDK-location check, i.e. no Groovy/DSL errors) — could not run further, since this sandbox has no Android SDK installed.
- [ ] CI green on this PR (`test` job's offline `assembleFdroidRelease` step)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KeT37qcx2rPabwxU848bpi)_