### PR TITLE
Gate DoH retries and keep-alives on screen state

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2819,11 +2819,13 @@ public class ServiceSinkhole extends VpnService {
                                     }
                                 });
 
-                        // On screen-off, drop idle DoH keep-alive sockets so a
-                        // server-side reset during doze can't wake the radio.
-                        if (!last_interactive)
-                            net.kollnig.missioncontrol.dns.DnsProxyServer
-                                    .getInstance(ServiceSinkhole.this).onScreenOff();
+                        // Screen state gates the DoH battery policy: while the
+                        // screen is off the proxy drops retries and idle
+                        // keep-alive sockets so a server-side reset during doze
+                        // can't wake the radio.
+                        net.kollnig.missioncontrol.dns.DnsProxyServer
+                                .getInstance(ServiceSinkhole.this)
+                                .onScreenStateChanged(last_interactive);
                     } catch (Throwable ex) {
                         Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
 

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -70,6 +70,9 @@ public class DnsOverHttpsClient {
     });
     private static DnsOverHttpsClient instance;
     private static Cache responseCache;
+    // Screen-off DoH battery policy: while the device is dozing we skip retries
+    // and evict keep-alive sockets so a server-side reset can't wake the radio.
+    private static volatile boolean screenOff = false;
     private final OkHttpClient client;
     private final String endpoint;
 
@@ -134,13 +137,14 @@ public class DnsOverHttpsClient {
     }
 
     /**
-     * Evict idle keep-alive connections from the current client, if any. Called on
-     * screen-off so an idle pooled TLS socket cannot be reset by the server during
-     * doze and wake the radio. In-flight requests are unaffected. No-op if no
-     * client has been created yet.
+     * Apply the screen-state DoH battery policy. While the screen is off the
+     * client drops retries and evicts keep-alive connections so an idle pooled
+     * TLS socket cannot be reset by the server during doze and wake the radio.
+     * In-flight requests are unaffected. No-op if no client has been created yet.
      */
-    public static synchronized void evictIdleConnections() {
-        if (instance != null) {
+    public static synchronized void setScreenOff(boolean off) {
+        screenOff = off;
+        if (off && instance != null) {
             instance.evictIdle();
         }
     }
@@ -191,7 +195,11 @@ public class DnsOverHttpsClient {
 
         Request request = buildRequest(endpoint, dnsQuery);
 
-        for (int attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        // Screen off: do not retry. A second round trip would double the radio
+        // wakeups during doze for a query that is already failing.
+        int maxRetries = screenOff ? 0 : MAX_RETRIES;
+
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
             if (attempt > 0) {
                 try {
                     Thread.sleep(RETRY_DELAY_MS);
@@ -228,6 +236,13 @@ public class DnsOverHttpsClient {
                 }
             } catch (IOException e) {
                 Log.e(TAG, "DoH request failed: " + e.getMessage());
+            } finally {
+                // Screen off: never leave an idle keep-alive socket behind — a
+                // server-side reset during doze would wake the radio. Cache
+                // hits are unaffected (no connection is created for them).
+                if (screenOff) {
+                    evictIdle();
+                }
             }
         }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -113,6 +113,10 @@ public class DnsProxyServer {
             // Start the main listener thread
             new Thread(this::runServer, "DnsProxyServer").start();
 
+            // Sync the screen-state policy so a start mid-doze (e.g. a network
+            // reload at night) doesn't inherit the screen-on behaviour.
+            DnsOverHttpsClient.setScreenOff(!eu.faircode.netguard.Util.isInteractive(context));
+
             Log.i(TAG, "DNS proxy server started on " + DNS_PROXY_ADDRESS + ":" + DNS_PROXY_PORT);
 
             // Start TCP server only if enabled (still in testing)
@@ -166,16 +170,17 @@ public class DnsProxyServer {
     }
 
     /**
-     * Called when the screen turns off. Evicts idle keep-alive HTTPS connections
-     * so an idle pooled TLS socket can't be reset by the server mid-doze and wake
-     * the radio. In-flight requests keep their connections. The response cache is
-     * intentionally preserved — it is most valuable precisely while the screen is
-     * off. No-op when the proxy is not running.
+     * Apply the screen-state DoH battery policy. While the screen is off the
+     * DoH client drops retries and evicts idle keep-alive HTTPS connections so
+     * a server-side reset mid-doze can't wake the radio. In-flight requests
+     * keep their connections; the response cache is intentionally preserved —
+     * it is most valuable precisely while the screen is off. No-op when the
+     * proxy is not running.
      */
-    public void onScreenOff() {
+    public void onScreenStateChanged(boolean interactive) {
         if (!running.get())
             return;
-        DnsOverHttpsClient.evictIdleConnections();
+        DnsOverHttpsClient.setScreenOff(!interactive);
     }
 
     /**

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -46,6 +46,7 @@ public class DnsOverHttpsClientTest {
 
     @Before
     public void setUp() throws IOException {
+        DnsOverHttpsClient.setScreenOff(false);
         DnsOverHttpsClient.resetInstance();
         server = new MockWebServer();
         server.start();
@@ -53,6 +54,7 @@ public class DnsOverHttpsClientTest {
 
     @After
     public void tearDown() throws IOException {
+        DnsOverHttpsClient.setScreenOff(false);
         DnsOverHttpsClient.resetInstance();
         server.close();
     }
@@ -100,6 +102,22 @@ public class DnsOverHttpsClientTest {
         assertNull(client().resolve(QUERY));
 
         assertEquals(3, server.getRequestCount());
+    }
+
+    @Test
+    public void resolveDoesNotRetryWhenScreenOff() {
+        DnsOverHttpsClient.setScreenOff(true);
+        try {
+            server.enqueue(dnsResponse(503, new byte[0]));
+
+            assertNull(client().resolve(QUERY));
+
+            // A retry would be a second radio wakeup during doze; screen-off
+            // resolution must give up after the first failed round trip.
+            assertEquals(1, server.getRequestCount());
+        } finally {
+            DnsOverHttpsClient.setScreenOff(false);
+        }
     }
 
     @Test


### PR DESCRIPTION
Screen-off DoH queries used to run the full retry loop and leave an idle TLS keep-alive socket behind after every lookup. During doze a retry is a second radio wakeup for a query that is already failing, and an idle pooled socket can be reset by the server mid-doze, waking the radio (the known screen-off DoH battery issue from AGENTS.md).

**What changes**
- `DnsOverHttpsClient`: new `setScreenOff()` policy. While the screen is off, `resolve()` skips retries (`MAX_RETRIES -> 0`) and evicts the connection pool after each query so nothing idle survives. Screen-on restores retries and normal pooling.
- `DnsProxyServer`: `onScreenOff()` replaced with `onScreenStateChanged(interactive)`; `start()` syncs the policy so a reload mid-doze doesn't inherit screen-on behaviour.
- `ServiceSinkhole`: the interactive-state receiver now pushes both screen transitions to the proxy.
- The response cache is intentionally preserved - it is most valuable at night, when queries repeat against a dozing device.

**Tests**
- `DnsOverHttpsClientTest`: `resolveDoesNotRetryWhenScreenOff` asserts a 503 gives up after one request (vs three with the screen on). All 16 tests pass.