### PR TITLE
Fix memory-safety and hang bugs in native packet engine

### DIFF
--- a/app/src/main/jni/netguard/dhcp.c
+++ b/app/src/main/jni/netguard/dhcp.c
@@ -81,7 +81,7 @@ int check_dhcp(const struct arguments *args, const struct udp_session *u,
         memset(&response->giaddr, 0, sizeof(response->giaddr));
 
         // https://tools.ietf.org/html/rfc2132
-        uint8_t *options = (uint8_t *) (response + sizeof(struct dhcp_packet));
+        uint8_t *options = (uint8_t *) (response + 1);
 
         int idx = 0;
         *(options + idx++) = 53; // Message type

--- a/app/src/main/jni/netguard/icmp.c
+++ b/app/src/main/jni/netguard/icmp.c
@@ -124,7 +124,7 @@ void check_icmp_socket(const struct arguments *args, const struct epoll_event *e
                     memset(&pseudo, 0, sizeof(struct ip6_hdr_pseudo));
                     memcpy(&pseudo.ip6ph_src, &s->icmp.daddr.ip6, 16);
                     memcpy(&pseudo.ip6ph_dst, &s->icmp.saddr.ip6, 16);
-                    pseudo.ip6ph_len = bytes - sizeof(struct ip6_hdr);
+                    pseudo.ip6ph_len = htonl((uint32_t) bytes);
                     pseudo.ip6ph_nxt = IPPROTO_ICMPV6;
                     csum = calc_checksum(
                             0, (uint8_t *) &pseudo, sizeof(struct ip6_hdr_pseudo));

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -338,6 +338,11 @@ void handle_ip(const struct arguments *args,
         uint8_t ipoptlen = (uint8_t) ((ip4hdr->ihl - 5) * 4);
         payload = (uint8_t *) (pkt + sizeof(struct iphdr) + ipoptlen);
 
+        if (ip4hdr->ihl < 5 || sizeof(struct iphdr) + ipoptlen > length) {
+            log_android(ANDROID_LOG_WARN, "IP4 invalid header length");
+            return;
+        }
+
         if (ntohs(ip4hdr->tot_len) != length) {
             log_android(ANDROID_LOG_ERROR, "Invalid length %u header length %u",
                         length, ntohs(ip4hdr->tot_len));
@@ -563,6 +568,11 @@ void handle_ip(const struct arguments *args,
             const struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
             const struct tcphdr *tcphdr = (struct tcphdr *) payload;
             const uint8_t tcpoptlen = (uint8_t) ((tcphdr->doff - 5) * 4);
+            if (tcphdr->doff < 5 ||
+                sizeof(struct tcphdr) + tcpoptlen > (size_t) (length - (payload - pkt))) {
+                log_android(ANDROID_LOG_WARN, "TCP invalid data offset");
+                return;
+            }
             const uint8_t *tcpoptions = payload + sizeof(struct tcphdr);
             const uint8_t *data = payload + sizeof(struct tcphdr) + tcpoptlen;
             const uint16_t datalen = (const uint16_t) (length - (data - pkt));

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -146,6 +146,8 @@ void JNI_OnUnload(JavaVM *vm, void *reserved) {
 JNIEXPORT jlong JNICALL
 Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
         JNIEnv *env, jobject instance, jint sdk) {
+    srand((unsigned int) (time(NULL) ^ getpid()));
+
     // Resolve the routing policy now: the packet path must never pay a dlopen,
     // and a failure should be logged while there is still something to read it.
     policy_ensure();
@@ -368,10 +370,15 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1socks5(JNIEnv *env, jobject insta
     ng_add_alloc(username, "username");
     ng_add_alloc(password, "password");
 
-    strcpy(socks5_addr, addr);
+    if (snprintf(socks5_addr, sizeof(socks5_addr), "%s", addr) >= (int) sizeof(socks5_addr))
+        log_android(ANDROID_LOG_WARN, "SOCKS5 address truncated");
     socks5_port = port;
-    strcpy(socks5_username, username);
-    strcpy(socks5_password, password);
+    if (snprintf(socks5_username, sizeof(socks5_username), "%s", username) >=
+        (int) sizeof(socks5_username))
+        log_android(ANDROID_LOG_WARN, "SOCKS5 username truncated");
+    if (snprintf(socks5_password, sizeof(socks5_password), "%s", password) >=
+        (int) sizeof(socks5_password))
+        log_android(ANDROID_LOG_WARN, "SOCKS5 password truncated");
 
     log_android(ANDROID_LOG_WARN, "SOCKS5 %s:%d user=%s",
                 socks5_addr, socks5_port, socks5_username);
@@ -584,7 +591,7 @@ void report_exit(const struct arguments *args, int error, const char *fmt, ...) 
         char line[1024];
         va_list argptr;
         va_start(argptr, fmt);
-        vsprintf(line, fmt, argptr);
+        vsnprintf(line, sizeof(line), fmt, argptr);
         jreason = (*args->env)->NewStringUTF(args->env, line);
         ng_add_alloc(jreason, "jreason");
         va_end(argptr);
@@ -611,7 +618,7 @@ void report_error(const struct arguments *args, jint error, const char *fmt, ...
         char line[1024];
         va_list argptr;
         va_start(argptr, fmt);
-        vsprintf(line, fmt, argptr);
+        vsnprintf(line, sizeof(line), fmt, argptr);
         jreason = (*args->env)->NewStringUTF(args->env, line);
         ng_add_alloc(jreason, "jreason");
         va_end(argptr);

--- a/app/src/main/jni/netguard/pcap.c
+++ b/app/src/main/jni/netguard/pcap.c
@@ -65,11 +65,14 @@ void write_pcap(const void *ptr, size_t len) {
 
         if (fsize > pcap_file_size) {
             log_android(ANDROID_LOG_WARN, "PCAP truncate @%ld", fsize);
-            if (ftruncate(fileno(pcap_file), sizeof(struct pcap_hdr_s)))
+            if (fflush(pcap_file))
+                log_android(ANDROID_LOG_ERROR, "PCAP fflush error %d: %s",
+                            errno, strerror(errno));
+            else if (ftruncate(fileno(pcap_file), sizeof(struct pcap_hdr_s)))
                 log_android(ANDROID_LOG_ERROR, "PCAP ftruncate error %d: %s",
                             errno, strerror(errno));
             else {
-                if (!lseek(fileno(pcap_file), sizeof(struct pcap_hdr_s), SEEK_SET))
+                if (fseek(pcap_file, sizeof(struct pcap_hdr_s), SEEK_SET))
                     log_android(ANDROID_LOG_ERROR, "PCAP ftruncate error %d: %s",
                                 errno, strerror(errno));
             }

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -649,6 +649,11 @@ jboolean handle_tcp(const struct arguments *args,
     const struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
     const struct tcphdr *tcphdr = (struct tcphdr *) payload;
     const uint8_t tcpoptlen = (uint8_t) ((tcphdr->doff - 5) * 4);
+    if (tcphdr->doff < 5 ||
+        sizeof(struct tcphdr) + tcpoptlen > (size_t) (length - (payload - pkt))) {
+        log_android(ANDROID_LOG_WARN, "TCP invalid data offset");
+        return 0;
+    }
     const uint8_t *tcpoptions = payload + sizeof(struct tcphdr);
     const uint8_t *data = payload + sizeof(struct tcphdr) + tcpoptlen;
     const uint16_t datalen = (const uint16_t) (length - (data - pkt));
@@ -718,8 +723,20 @@ jboolean handle_tcp(const struct arguments *args,
             uint8_t *options = (uint8_t *) tcpoptions;
             while (optlen > 0) {
                 uint8_t kind = *options;
-                uint8_t len = *(options + 1);
                 if (kind == 0) // End of options list
+                    break;
+
+                if (kind == 1) {
+                    optlen--;
+                    options++;
+                    continue;
+                }
+
+                if (optlen < 2)
+                    break;
+
+                uint8_t len = *(options + 1);
+                if (len < 2 || len > optlen)
                     break;
 
                 if (kind == 2 && len == 4)
@@ -728,13 +745,8 @@ jboolean handle_tcp(const struct arguments *args,
                 else if (kind == 3 && len == 3)
                     ws = *(options + 2);
 
-                if (kind == 1) {
-                    optlen--;
-                    options++;
-                } else {
-                    optlen -= len;
-                    options += len;
-                }
+                optlen -= len;
+                options += len;
             }
 
             // In tethering compatibility mode, clamp the MSS we use for

--- a/app/src/main/jni/netguard/util.c
+++ b/app/src/main/jni/netguard/util.c
@@ -65,7 +65,7 @@ void log_android(int prio, const char *fmt, ...) {
         char line[1024];
         va_list argptr;
         va_start(argptr, fmt);
-        vsprintf(line, fmt, argptr);
+        vsnprintf(line, sizeof(line), fmt, argptr);
         __android_log_print(prio, TAG, "%s", line);
         va_end(argptr);
     }


### PR DESCRIPTION
Found during a correctness audit of `app/src/main/jni/netguard/` (all inherited from the NetGuard import unless noted). 50 insertions, 18 deletions across 7 C files; no behavior change for well-formed packets.

## Memory safety

- **dhcp.c:84** — DHCP reply options were written ~57 KB past the 500-byte response allocation: `(uint8_t *)(response + sizeof(struct dhcp_packet))` advances in *struct-sized* units (~240 B each). **Reachable by any co-installed app with a single UDP datagram to port 67** (sport 68 / dport 67 → `check_dhcp`) — no special permission needed. This is the headline fix in this PR.
- **ip.c / tcp.c** — the TCP data offset (`doff`) was never validated before deriving payload pointer/length from it: doff < 5 underflows `tcpoptlen` to e.g. 236, and an oversized doff wraps the derived length. Both SNI memcpys into the reassembly buffer were already bounded (`datalen < TLS_SNI_MAX_BUFFER`, `copy = min(datalen, space)`), so this was never a 65 KB write into the 16 KB buffer. The actual defect is an out-of-bounds **read**: the bad offset lets `data`/`datalen` point past the end of the `get_mtu()`-sized tun read buffer, so `parse_tls_header` (and, in `tcp.c`, the queued bytes) can walk off the end of that buffer. Both sites now reject impossible data offsets.
- **ip.c** — added the same guard for IPv4's `ihl`: `(uint8_t)((ihl - 5) * 4)` underflows to 236 when `ihl == 0`, pushing `payload` past the packet; the downstream length checks are `size_t` so they wrap too and pass. Now rejected next to the existing `tot_len` check.

## Hangs / correctness

- **tcp.c** — SYN option parsing made no progress for an option with length 0 (kind ∉ {0,1}) → infinite loop on the VPN event thread. (`optlen` is `int`, so an over-long option already made `len > optlen` go negative and exit the loop on its own — the hang was real only for `len == 0`.) Loop always terminates now and stays inside the declared options region.
- **icmp.c** — ICMPv6 echo replies used pseudo-header length `bytes - sizeof(ip6_hdr)` (underflow, host order); now `htonl(bytes)`, matching the query path.
- **pcap.c** — rollover flushed the `FILE*` and truncated the underlying fd, then re-seeked with `lseek(fileno(pcap_file), ...)`, which never syncs the `FILE*`'s own buffered offset — `ftell()` kept reporting the pre-rollover size and the file re-truncated on every later write. Now `fseek(pcap_file, ...)` on the `FILE*` itself.

## Hardening

- `vsnprintf` instead of `vsprintf` into fixed 1024-byte stack buffers (log/exit formatting).
- SOCKS5 strings received from Java are copied with bounds checks (warn on truncation).
- Seed `rand()` once at init so TCP ISNs aren't identical across boots.

## Reachability

Other than the DHCP heap overflow above, everything in this PR is only reachable from packets the *kernel* writes into the tun device on behalf of a local app (a malformed `doff`, TCP option, or `ihl` has to come from a real socket send). That needs `CAP_NET_RAW`/root to forge directly, so these are defensive hardening against a corrupted/malicious kernel path or future refactors, not exploitable by an unprivileged co-installed app today. The DHCP overflow is the one item here that is reachable right now, by any co-installed app, with a single UDP datagram — treat it as the headline fix.

## Verification

- NDK clang `-fsyntax-only` over all engine TUs: clean (only pre-existing const-qualifier warnings).
- `./gradlew assembleGithubDebug` (native C + Rust + Kotlin): BUILD SUCCESSFUL.
- `git diff --check`: clean.

## Known follow-ups (deliberately not in this PR)

- A correct walk of IPv6 extension headers (to reach TCP/UDP inside chained-extension IPv6 packets) was dropped from this PR after review found the first attempt unsafe — wrong RFC 8200 length unit, ESP/AH have no walkable next-header field, and non-first fragments would be misparsed as L4 data. Filed separately for a correct implementation.
- Session-list mutations in `handle_events()` run outside `ctx->lock` while `jni_get_stats()` iterates under it (narrow use-after-free window) — needs a small locking design, not a drive-by fix.
- DNS-over-TCP: only isolated frames get their length prefix rewritten after blanking (coalesced/split reads keep original bytes; header counts still zeroed).
