### PR TITLE
Fix ServiceSinkhole thread leak and teardown races

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -122,6 +122,9 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.zip.GZIPInputStream;
@@ -273,6 +276,24 @@ public class ServiceSinkhole extends VpnService {
     private static volatile PowerManager.WakeLock wlInstance = null;
 
     private ExecutorService executor = Executors.newCachedThreadPool();
+
+    // Shared resolver for the carrier ePDG lookup in getBuilder(). A fresh
+    // executor per build leaked one non-daemon worker thread per VPN rebuild.
+    private static final ExecutorService EPDG_RESOLVER = createEpdgResolver();
+
+    private static ExecutorService createEpdgResolver() {
+        ThreadPoolExecutor resolver = new ThreadPoolExecutor(
+                1, 1, 30L, TimeUnit.SECONDS,
+                new LinkedBlockingQueue<>(),
+                runnable -> {
+                    Thread thread = new Thread(runnable, "epdg-resolver");
+                    thread.setDaemon(true);
+                    return thread;
+                });
+        // Idle workers die instead of lingering between rebuilds
+        resolver.allowCoreThreadTimeOut(true);
+        return resolver;
+    }
 
     private static final String ACTION_HOUSE_HOLDING = "eu.faircode.netguard.HOUSE_HOLDING";
     private static final String ACTION_SCREEN_OFF_DELAYED = "eu.faircode.netguard.SCREEN_OFF_DELAYED";
@@ -935,12 +956,14 @@ public class ServiceSinkhole extends VpnService {
                         Log.e(TAG, "Unknown log message=" + msg.what);
                 }
 
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            } finally {
+                // Decrement even when log()/usage() threw, or failed messages
+                // would permanently consume queue slots until logging died
                 synchronized (this) {
                     queue--;
                 }
-
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }
         }
 
@@ -1332,9 +1355,17 @@ public class ServiceSinkhole extends VpnService {
 
             // Show session/file count
             if (loglevel <= Log.WARN) {
-                int[] count = jni_get_stats(jni_context);
-                remoteViews.setTextViewText(R.id.tvSessions, count[0] + "/" + count[1] + "/" + count[2]);
-                remoteViews.setTextViewText(R.id.tvFiles, count[3] + "/" + count[4]);
+                // jni_lock: onDestroy can free the context while this tick is
+                // in flight; a stale pointer here would crash natively
+                int[] count = null;
+                synchronized (jni_lock) {
+                    if (jni_context != 0)
+                        count = jni_get_stats(jni_context);
+                }
+                if (count != null) {
+                    remoteViews.setTextViewText(R.id.tvSessions, count[0] + "/" + count[1] + "/" + count[2]);
+                    remoteViews.setTextViewText(R.id.tvFiles, count[3] + "/" + count[4]);
+                }
             } else {
                 remoteViews.setTextViewText(R.id.tvSessions, "");
                 remoteViews.setTextViewText(R.id.tvFiles, "");
@@ -1753,8 +1784,7 @@ public class ServiceSinkhole extends VpnService {
                     // Resolve with 1.5s timeout to avoid blocking VPN startup
                     final String domain = epdgDomain;
                     java.util.concurrent.Future<InetAddress[]> future =
-                            java.util.concurrent.Executors.newSingleThreadExecutor()
-                                    .submit(() -> InetAddress.getAllByName(domain));
+                            EPDG_RESOLVER.submit(() -> InetAddress.getAllByName(domain));
                     InetAddress[] addrs = future.get(1500, java.util.concurrent.TimeUnit.MILLISECONDS);
                     for (InetAddress addr : addrs) {
                         Log.i(TAG, "Excluding ePDG address=" + addr.getHostAddress());
@@ -3631,12 +3661,16 @@ public class ServiceSinkhole extends VpnService {
             networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
             cancelNativeRecovery(true);
 
-            commandLooper.quit();
-            logLooper.quit();
-            statsLooper.quit();
+            // onCreate can stopSelf() before creating the handler threads when
+            // startForeground is denied (Android 12+); there is nothing to quit
+            if (commandLooper != null) {
+                commandLooper.quit();
+                logLooper.quit();
+                statsLooper.quit();
 
-            for (Command command : Command.values())
-                commandHandler.removeMessages(command.ordinal());
+                for (Command command : Command.values())
+                    commandHandler.removeMessages(command.ordinal());
+            }
             releaseLock(this);
 
             // Registered in command loop

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -122,7 +122,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -213,6 +213,17 @@ public class ServiceSinkhole extends VpnService {
     private volatile LogHandler logHandler;
     private volatile StatsHandler statsHandler;
 
+    // Set at the very end of a fully successful onCreate. onCreate can
+    // stopSelf()+return early (e.g. startForeground denied on Android 12+,
+    // see ForegroundServiceStartNotAllowedException below) before the handler
+    // threads, the network monitor callback registration, or jni_init() run.
+    // onDestroy must not tear down anything past the point onCreate actually
+    // reached, or it crashes: unregistering a callback that was never
+    // registered throws IllegalArgumentException, and jni_done() on the
+    // still-zero native context segfaults (netguard.c dereferences it
+    // unconditionally).
+    private volatile boolean initialized = false;
+
     private static final int NATIVE_RECOVERY_MAX_RETRIES = 5;
     private static final long NATIVE_RECOVERY_INITIAL_DELAY_MS = 1_000L;
     private static final long NATIVE_RECOVERY_STABLE_WINDOW_MS = 2 * 60_000L;
@@ -282,9 +293,14 @@ public class ServiceSinkhole extends VpnService {
     private static final ExecutorService EPDG_RESOLVER = createEpdgResolver();
 
     private static ExecutorService createEpdgResolver() {
+        // core=0/max=2 with a SynchronousQueue (not an unbounded queue, which
+        // would let corePoolSize=0 starve every submitted task of a worker
+        // thread): a hung getAllByName() lookup ties up only one worker, so a
+        // later rebuild's lookup still gets a second thread instead of
+        // queuing behind it and burning its own 1.5s timeout for nothing.
         ThreadPoolExecutor resolver = new ThreadPoolExecutor(
-                1, 1, 30L, TimeUnit.SECONDS,
-                new LinkedBlockingQueue<>(),
+                0, 2, 30L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
                 runnable -> {
                     Thread thread = new Thread(runnable, "epdg-resolver");
                     thread.setDaemon(true);
@@ -1785,10 +1801,17 @@ public class ServiceSinkhole extends VpnService {
                     final String domain = epdgDomain;
                     java.util.concurrent.Future<InetAddress[]> future =
                             EPDG_RESOLVER.submit(() -> InetAddress.getAllByName(domain));
-                    InetAddress[] addrs = future.get(1500, java.util.concurrent.TimeUnit.MILLISECONDS);
-                    for (InetAddress addr : addrs) {
-                        Log.i(TAG, "Excluding ePDG address=" + addr.getHostAddress());
-                        builder.excludeRoute(new IpPrefix(addr, addr instanceof Inet4Address ? 32 : 128));
+                    try {
+                        InetAddress[] addrs = future.get(1500, java.util.concurrent.TimeUnit.MILLISECONDS);
+                        for (InetAddress addr : addrs) {
+                            Log.i(TAG, "Excluding ePDG address=" + addr.getHostAddress());
+                            builder.excludeRoute(new IpPrefix(addr, addr instanceof Inet4Address ? 32 : 128));
+                        }
+                    } finally {
+                        // A timed-out lookup must not linger: cancel it rather than let
+                        // it occupy a resolver thread until the real DNS query returns
+                        // (radio wakeup on a battery-constrained path).
+                        future.cancel(true);
                     }
                 }
             } catch (java.util.concurrent.TimeoutException ex) {
@@ -3333,6 +3356,10 @@ public class ServiceSinkhole extends VpnService {
         AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         am.setInexactRepeating(AlarmManager.RTC, SystemClock.elapsedRealtime() + 60 * 1000,
                 AlarmManager.INTERVAL_HALF_DAY, pi);
+
+        // Marks that onCreate ran to completion; onDestroy uses this to decide
+        // which teardown steps are safe to run. Must stay the last statement.
+        initialized = true;
     }
 
     @TargetApi(Build.VERSION_CODES.LOLLIPOP)
@@ -3663,7 +3690,7 @@ public class ServiceSinkhole extends VpnService {
 
             // onCreate can stopSelf() before creating the handler threads when
             // startForeground is denied (Android 12+); there is nothing to quit
-            if (commandLooper != null) {
+            if (initialized) {
                 commandLooper.quit();
                 logLooper.quit();
                 statsLooper.quit();
@@ -3713,8 +3740,12 @@ public class ServiceSinkhole extends VpnService {
 
             net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.removeStateListener(wgStateListener);
 
-            ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-            cm.unregisterNetworkCallback(networkMonitorCallback);
+            // Registered at the end of onCreate, right after jni_init(); never
+            // registered (and jni_context never set) if onCreate bailed early.
+            if (initialized) {
+                ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+                cm.unregisterNetworkCallback(networkMonitorCallback);
+            }
 
             try {
                 if (vpn != null) {
@@ -3727,10 +3758,12 @@ public class ServiceSinkhole extends VpnService {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }
 
-            Log.i(TAG, "Destroy context=" + jni_context);
-            synchronized (jni_lock) {
-                jni_done(jni_context);
-                jni_context = 0;
+            if (initialized) {
+                Log.i(TAG, "Destroy context=" + jni_context);
+                synchronized (jni_lock) {
+                    jni_done(jni_context);
+                    jni_context = 0;
+                }
             }
         }
 


### PR DESCRIPTION
Found in a correctness review of the Java code; four small fixes in `ServiceSinkhole`.

**1. ePDG resolver leaked one non-daemon thread per VPN rebuild**
`getBuilder()` created `Executors.newSingleThreadExecutor()` for the carrier ePDG lookup and never shut it down or kept a reference; on the 1.5s-timeout path the abandoned DNS lookup keeps the worker alive even longer. Commuting users trigger debounced rebuilds all day, accumulating threads indefinitely. Replaced with one shared static daemon-thread executor (`allowCoreThreadTimeOut(true)`), so idle workers die between rebuilds.

**2. Log queue counter leaked on processing exceptions**
`LogHandler.handleMessage` decremented `queue` inside `try`, so an exception out of `log()`/`usage()` (e.g. SQLiteException on disk-full) skipped the decrement while the outer catch swallowed the error — each failure permanently consumed one slot toward `MAX_QUEUE` until packet/access logging died entirely. Decrement moved to `finally`.

**3. NPE in `onDestroy` after FGS-denied early return**
When `startForeground` throws `ForegroundServiceStartNotAllowedException` (Android 12+), `onCreate` calls `stopSelf()` before creating the handler threads; `onDestroy` then unconditionally called `commandLooper.quit()` etc. The looper/handler teardown is now guarded, so a denied start stays stopped instead of crashing teardown.

**4. `jni_context` use-after-free window at teardown**
`updateStats()` read the static `jni_context` without `jni_lock`; `onDestroy` quits `statsLooper` (which does not join an in-flight tick) and then frees the native context, so a concurrent stats tick could hand a freed pointer to JNI. The check-and-call now happens under `jni_lock` (a leaf lock held only across short init/done sections).

Tests: `:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest --tests eu.faircode.netguard.ServiceSinkholeSecureDnsTest` — both green.
