### PR TITLE
Harden DNS proxy pool, TCP framing, and fallback validation

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -20,6 +20,7 @@ import net.kollnig.missioncontrol.BuildConfig;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
@@ -241,10 +242,13 @@ public class DnsProxyServer {
      */
     private void handleQuery(byte[] queryData, InetAddress clientAddress, int clientPort) {
         try {
-            // Malformed datagrams get SERVFAIL locally instead of counting as
-            // DoH failures, so garbage can't trip the circuit breaker
+            // Malformed datagrams are dropped silently rather than answered:
+            // a query shorter than a 12-byte DNS header has no transaction ID
+            // to safely echo back, so there is nothing to build a SERVFAIL
+            // response from. This matches the TCP path below. Dropping here
+            // also means garbage doesn't count as a DoH failure and can't
+            // trip the circuit breaker.
             if (!isPlausibleDnsQuery(queryData)) {
-                sendServFailResponse(queryData, clientAddress, clientPort);
                 return;
             }
 
@@ -321,16 +325,15 @@ public class DnsProxyServer {
     }
 
     /**
-     * Send a SERVFAIL response to the client.
+     * Build a SERVFAIL response by echoing the query's header with the QR
+     * bit set and RCODE=SERVFAIL. Returns null (rather than throwing) if
+     * queryData is null or too short to carry a 12-byte DNS header, so
+     * callers can treat "can't build a response" as a normal, silent case.
+     * Package-private for unit testing.
      */
-    private void sendServFailResponse(byte[] queryData, InetAddress clientAddress, int clientPort)
-            throws IOException {
-        if (queryData.length < 12)
-            return;
-
-        DatagramSocket socket = serverSocket;
-        if (socket == null || socket.isClosed())
-            return;
+    static byte[] buildServFailResponse(byte[] queryData) {
+        if (queryData == null || queryData.length < 12)
+            return null;
 
         // Copy the query and modify it to be a SERVFAIL response
         byte[] response = new byte[queryData.length];
@@ -339,6 +342,21 @@ public class DnsProxyServer {
         // Set QR bit (response) and RCODE to SERVFAIL (2)
         response[2] = (byte) ((queryData[2] | 0x80) & 0xFB); // QR=1, keep other flags
         response[3] = (byte) ((queryData[3] & 0xF0) | 0x02); // RCODE = SERVFAIL
+        return response;
+    }
+
+    /**
+     * Send a SERVFAIL response to the client.
+     */
+    private void sendServFailResponse(byte[] queryData, InetAddress clientAddress, int clientPort)
+            throws IOException {
+        byte[] response = buildServFailResponse(queryData);
+        if (response == null)
+            return;
+
+        DatagramSocket socket = serverSocket;
+        if (socket == null || socket.isClosed())
+            return;
 
         DatagramPacket packet = new DatagramPacket(response, response.length, clientAddress, clientPort);
         socket.send(packet);
@@ -363,12 +381,11 @@ public class DnsProxyServer {
                 DataInputStream in = new DataInputStream(socket.getInputStream());
                 DataOutputStream out = new DataOutputStream(socket.getOutputStream())) {
 
-            // Read the 2-byte length field; -1 means the peer hung up first
+            // DataInputStream#readUnsignedShort() never returns -1: per its
+            // contract it throws EOFException if the stream ends before two
+            // bytes are read, which is exactly what a bare TCP connect probe
+            // (no length prefix at all) looks like. Handled below, quietly.
             int length = in.readUnsignedShort();
-            if (length < 0) {
-                Log.d(TAG, "TCP peer closed before sending DNS length prefix");
-                return;
-            }
             byte[] queryData = new byte[length];
             in.readFully(queryData);
 
@@ -430,6 +447,10 @@ public class DnsProxyServer {
                 }
             }
 
+        } catch (EOFException e) {
+            // Peer closed before completing the length-prefixed frame (e.g. a
+            // bare connect probe with no payload) -- not an error, and not
+            // worth logging.
         } catch (Exception e) {
             Log.e(TAG, "Error handling TCP DNS query: " + e.getMessage());
         }
@@ -448,13 +469,21 @@ public class DnsProxyServer {
 
         for (InetAddress dnsServer : dnsServers) {
             try (DatagramSocket socket = new DatagramSocket()) {
+                // Connect the socket so the kernel drops any packet not from
+                // dnsServer:53 before it ever reaches us -- otherwise the
+                // socket is unconnected and any host reaching this ephemeral
+                // port qualifies.
+                socket.connect(dnsServer, 53);
+
                 DatagramPacket request = new DatagramPacket(
                         queryData, queryData.length, dnsServer, 53);
                 socket.send(request);
 
-                // Accept only responses echoing this query's transaction ID;
-                // anything else could be an off-path spoof or a stray NAT
-                // packet meant for another client behind the same address.
+                // Kernel-level connect() filters by sender address/port;
+                // additionally accept only responses echoing this query's
+                // transaction ID, so an off-path spoof from the real server's
+                // address (e.g. a compromised resolver, or another client
+                // behind the same NAT) still can't be mistaken for our reply.
                 byte[] buffer = new byte[4096];
                 long deadline = System.nanoTime()
                         + TimeUnit.MILLISECONDS.toNanos(FALLBACK_DNS_TIMEOUT_MS);
@@ -469,7 +498,7 @@ public class DnsProxyServer {
                     DatagramPacket response = new DatagramPacket(buffer, buffer.length);
                     socket.receive(response);
 
-                    if (response.getLength() < 2
+                    if (response.getLength() < 12
                             || response.getData()[0] != queryData[0]
                             || response.getData()[1] != queryData[1])
                         continue;
@@ -488,12 +517,9 @@ public class DnsProxyServer {
     }
 
     private void sendTcpServFail(DataOutputStream out, byte[] queryData) throws IOException {
-        if (queryData.length < 12)
+        byte[] response = buildServFailResponse(queryData);
+        if (response == null)
             return;
-        byte[] response = new byte[queryData.length];
-        System.arraycopy(queryData, 0, response, 0, queryData.length);
-        response[2] = (byte) ((queryData[2] | 0x80) & 0xFB);
-        response[3] = (byte) ((queryData[3] & 0xF0) | 0x02);
         out.writeShort(response.length);
         out.write(response);
         out.flush();

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -28,9 +28,11 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -57,6 +59,7 @@ public class DnsProxyServer {
     private final AtomicInteger dohFailures = new AtomicInteger(0);
     private static final int CIRCUIT_BREAKER_THRESHOLD = 10;
     private static final long CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
+    private static final int FALLBACK_DNS_TIMEOUT_MS = 5000;
     private volatile long circuitOpenUntil = 0;
 
     private DnsProxyServer(Context context) {
@@ -107,8 +110,9 @@ public class DnsProxyServer {
             serverSocket.bind(new InetSocketAddress(DNS_PROXY_ADDRESS, DNS_PROXY_PORT));
             running.set(true);
 
-            // Use a thread pool for handling queries concurrently
-            executor = Executors.newFixedThreadPool(4);
+            // Handlers block on network I/O (worst case ~15s per DoH resolve),
+            // so a pool of 4 collapsed resolution throughput under packet loss
+            executor = Executors.newFixedThreadPool(16);
 
             // Start the main listener thread
             new Thread(this::runServer, "DnsProxyServer").start();
@@ -237,6 +241,13 @@ public class DnsProxyServer {
      */
     private void handleQuery(byte[] queryData, InetAddress clientAddress, int clientPort) {
         try {
+            // Malformed datagrams get SERVFAIL locally instead of counting as
+            // DoH failures, so garbage can't trip the circuit breaker
+            if (!isPlausibleDnsQuery(queryData)) {
+                sendServFailResponse(queryData, clientAddress, clientPort);
+                return;
+            }
+
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             byte[] responseData = null;
 
@@ -302,6 +313,14 @@ public class DnsProxyServer {
     }
 
     /**
+     * A plausible DNS message carries at least the fixed 12-byte header.
+     * Package-private for unit testing.
+     */
+    static boolean isPlausibleDnsQuery(byte[] q) {
+        return q != null && q.length >= 12;
+    }
+
+    /**
      * Send a SERVFAIL response to the client.
      */
     private void sendServFailResponse(byte[] queryData, InetAddress clientAddress, int clientPort)
@@ -344,10 +363,19 @@ public class DnsProxyServer {
                 DataInputStream in = new DataInputStream(socket.getInputStream());
                 DataOutputStream out = new DataOutputStream(socket.getOutputStream())) {
 
-            // Read the 2-byte length field
+            // Read the 2-byte length field; -1 means the peer hung up first
             int length = in.readUnsignedShort();
+            if (length < 0) {
+                Log.d(TAG, "TCP peer closed before sending DNS length prefix");
+                return;
+            }
             byte[] queryData = new byte[length];
             in.readFully(queryData);
+
+            // Malformed queries get no answer rather than a DoH attempt that
+            // would count toward the circuit breaker
+            if (!isPlausibleDnsQuery(queryData))
+                return;
 
             // Resolve using the existing logic (reuse handleQuery logic or extract common
             // part)
@@ -420,19 +448,36 @@ public class DnsProxyServer {
 
         for (InetAddress dnsServer : dnsServers) {
             try (DatagramSocket socket = new DatagramSocket()) {
-                socket.setSoTimeout(5000);
-
                 DatagramPacket request = new DatagramPacket(
                         queryData, queryData.length, dnsServer, 53);
                 socket.send(request);
 
+                // Accept only responses echoing this query's transaction ID;
+                // anything else could be an off-path spoof or a stray NAT
+                // packet meant for another client behind the same address.
                 byte[] buffer = new byte[4096];
-                DatagramPacket response = new DatagramPacket(buffer, buffer.length);
-                socket.receive(response);
+                long deadline = System.nanoTime()
+                        + TimeUnit.MILLISECONDS.toNanos(FALLBACK_DNS_TIMEOUT_MS);
+                while (true) {
+                    long remaining = deadline - System.nanoTime();
+                    if (remaining <= 0)
+                        throw new SocketTimeoutException("no matching response in time");
 
-                byte[] responseData = new byte[response.getLength()];
-                System.arraycopy(response.getData(), 0, responseData, 0, response.getLength());
-                return responseData;
+                    // toMillis truncation must not yield 0: setSoTimeout(0) means infinite
+                    long timeoutMs = Math.max(1, TimeUnit.NANOSECONDS.toMillis(remaining));
+                    socket.setSoTimeout((int) timeoutMs);
+                    DatagramPacket response = new DatagramPacket(buffer, buffer.length);
+                    socket.receive(response);
+
+                    if (response.getLength() < 2
+                            || response.getData()[0] != queryData[0]
+                            || response.getData()[1] != queryData[1])
+                        continue;
+
+                    byte[] responseData = new byte[response.getLength()];
+                    System.arraycopy(response.getData(), 0, responseData, 0, response.getLength());
+                    return responseData;
+                }
             } catch (IOException e) {
                 Log.w(TAG, "Fallback DNS query to " + dnsServer + " failed: " + e.getMessage());
             }

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
@@ -1,0 +1,36 @@
+package net.kollnig.missioncontrol.dns;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Only covers the query plausibility gate; the rest of DnsProxyServer needs
+ * live sockets and a wired VPN context.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 36)
+public class DnsProxyServerTest {
+
+    @Test
+    public void rejectsNullAndHeaderlessQueries() {
+        assertFalse(DnsProxyServer.isPlausibleDnsQuery(null));
+        assertFalse(DnsProxyServer.isPlausibleDnsQuery(new byte[0]));
+        assertFalse(DnsProxyServer.isPlausibleDnsQuery(new byte[11]));
+    }
+
+    @Test
+    public void acceptsBareHeaderAndFullQuery() {
+        assertTrue(DnsProxyServer.isPlausibleDnsQuery(new byte[12]));
+
+        byte[] query = new byte[] {
+                0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00
+        };
+        assertTrue(DnsProxyServer.isPlausibleDnsQuery(query));
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
@@ -1,6 +1,8 @@
 package net.kollnig.missioncontrol.dns;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -9,8 +11,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 /**
- * Only covers the query plausibility gate; the rest of DnsProxyServer needs
- * live sockets and a wired VPN context.
+ * Only covers the query plausibility gate and the SERVFAIL header builder;
+ * the rest of DnsProxyServer needs live sockets and a wired VPN context.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 36)
@@ -32,5 +34,36 @@ public class DnsProxyServerTest {
                 0x00, 0x00, 0x00, 0x00, 0x00
         };
         assertTrue(DnsProxyServer.isPlausibleDnsQuery(query));
+    }
+
+    @Test
+    public void buildServFailResponseReturnsNullForUnbuildableQueries() {
+        // Undersized/null queries can't safely have a transaction ID echoed
+        // back, so callers must treat this as "nothing to send" rather than
+        // synthesising a response -- this is the behaviour that replaces the
+        // old always-no-op sendServFailResponse call for such queries.
+        assertNull(DnsProxyServer.buildServFailResponse(null));
+        assertNull(DnsProxyServer.buildServFailResponse(new byte[0]));
+        assertNull(DnsProxyServer.buildServFailResponse(new byte[11]));
+    }
+
+    @Test
+    public void buildServFailResponseSetsQrBitAndServFailRcode() {
+        byte[] query = new byte[] {
+                0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00
+        };
+
+        byte[] response = DnsProxyServer.buildServFailResponse(query);
+
+        assertTrue(response != null);
+        // Same length, transaction ID untouched.
+        assertArrayEquals(new byte[] { 0x12, 0x34 },
+                new byte[] { response[0], response[1] });
+        // QR bit (0x80) set, other flag bits preserved.
+        assertTrue((response[2] & 0x80) != 0);
+        // RCODE (low nibble of byte 3) is SERVFAIL (2).
+        assertTrue((response[3] & 0x0F) == 0x02);
+        assertTrue(response.length == query.length);
     }
 }


### PR DESCRIPTION
Found in a correctness review of the DNS path; all changes confined to `DnsProxyServer`.

**1. Resolution collapse under degraded networks**
The fixed pool of 4 threads is shared by UDP and TCP handlers, and each handler blocks inside DoH resolve for up to ~15s (5s timeout x 3 attempts). A silently-dropping DoH endpoint capped throughput near zero exactly when the network was already bad. Pool raised to 16 with a comment explaining the arithmetic.

**2. Malformed UDP queries are dropped, not SERVFAILed (revised)**
Originally claimed the new UDP branch answers malformed queries with SERVFAIL locally. On review that's wrong: `isPlausibleDnsQuery` is exactly `length >= 12`, and `sendServFailResponse` already no-ops for anything shorter — so that branch never sent a byte, it behaved exactly like the TCP path's silent drop. Made this honest instead of fixing a bug that wasn't there: malformed UDP datagrams are now dropped without pretending to build a response, since a query under 12 bytes has no transaction ID to safely echo back. The actual, real fix stands: a malformed query no longer increments the DoH failure counter or can trip the circuit breaker; it just doesn't claim to answer with SERVFAIL anymore.

**3. DNS-over-TCP framing (revised)**
Originally claimed `readUnsignedShort()` returning -1 on immediate EOF fed `new byte[-1]` -> `NegativeArraySizeException`. On review that's wrong: per the JDK contract, `readUnsignedShort()` never returns -1 — it throws `EOFException` when the stream ends before the 2-byte length prefix is fully read. The `if (length < 0)` branch was dead, unreachable code and has been removed. The real (cosmetic) bug: those EOF probes were falling through to the broad `catch (Exception e)` and logging at ERROR. Fixed with a dedicated `catch (EOFException)` that returns quietly, so connection probes stop spamming the error log.

**4. Plain-DNS fallback accepted unvalidated responses**
`resolveViaStandardDns` returned the first datagram off its ephemeral socket without checking it belongs to the query. It now pins the transaction ID and loops until a matching response or a hard nanoTime deadline (with a floor on `soTimeout` so truncation can't produce an infinite wait). Timeout still falls through to the next server exactly as before.

**Also (small, confirmed fixes from the same review)**
- `resolveViaStandardDns` now also calls `socket.connect(dnsServer, 53)` before sending, so the kernel drops off-path packets before the transaction-ID check ever runs — previously the socket was unconnected and any host reaching the ephemeral port qualified, so the existing "off-path spoof" comment wasn't actually backed by code. Response length guard widened from `< 2` to `< 12`.
- Extracted the SERVFAIL-header logic into a shared, null-safe `buildServFailResponse()` used by both the UDP and TCP paths, closing a latent NPE if `queryData` were ever null when the outer handler's exception-recovery path runs (not reachable today via `runServer`, but worth guarding).

Tests: `DnsProxyServerTest` covers the plausibility check and the new `buildServFailResponse` helper (null/undersized -> null, well-formed -> QR bit set + RCODE=SERVFAIL with the transaction ID preserved); full `:app:testGithubDebugUnitTest` suite green.
