### PR TITLE
Fix misc correctness bugs: channel bypass-DND, atomic hosts rename, locale, fresh-install version

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
@@ -261,7 +261,7 @@ public class ApplicationEx extends Application {
         NotificationChannel access = new NotificationChannel("access", getString(R.string.channel_access),
                 NotificationManager.IMPORTANCE_DEFAULT);
         access.setSound(null, Notification.AUDIO_ATTRIBUTES_DEFAULT);
-        notify.setBypassDnd(true);
+        access.setBypassDnd(true);
         nm.createNotificationChannel(access);
     }
 }

--- a/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
@@ -139,6 +139,9 @@ public class ReceiverAutostart extends BroadcastReceiver {
                         editor.putBoolean("show_user", true);
                 }
 
+                // Persist version only once initialized: a fresh install must not
+                // look like an existing install to blocking-mode migration
+                editor.putInt("version", newVersion);
             } else {
                 Log.i(TAG, "Initializing sdk=" + Build.VERSION.SDK_INT);
             }
@@ -164,7 +167,6 @@ public class ReceiverAutostart extends BroadcastReceiver {
             if (!Util.isDebuggable(context))
                 editor.remove("loglevel");
 
-            editor.putInt("version", newVersion);
             editor.apply();
         }
     }

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -83,6 +83,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.GZIPInputStream;
@@ -258,7 +259,7 @@ public class Util {
     }
 
     public static boolean isEU(String country) {
-        return (country != null && listEU.contains(country.toUpperCase()));
+        return (country != null && listEU.contains(country.toUpperCase(Locale.ROOT)));
     }
 
     public static String getNetworkGeneration(int networkType) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlocklistManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlocklistManager.java
@@ -219,9 +219,6 @@ public class BlocklistManager {
             return false;
         }
 
-        if (hostsFile.exists()) {
-            hostsFile.delete();
-        }
         return hostsTmp.renameTo(hostsFile);
     }
 }


### PR DESCRIPTION
Four small independent fixes from a correctness review:

- **Notification channel copy-paste**: the third channel configures `access` but called `notify.setBypassDnd(true)` — access notifications could be silenced by DND contrary to intent (channel properties are fixed at creation, so existing installs keep the wrong behavior until this lands).
- **Delete-before-rename in `BlocklistManager.mergeBlocklists`**: `hostsFile.delete()` ran before `hostsTmp.renameTo(hostsFile)`, so a failed rename left *no* hosts file and hosts-based blocking silently went empty. POSIX rename replaces atomically on Linux/Android; pre-delete removed.
- **Turkish-locale breakage in `Util.isEU`**: `country.toUpperCase()` uses the default locale — on tr-TR `"it"` becomes `"İT"` and never matches. Now `toUpperCase(Locale.ROOT)`.
- **Fresh installs migrated out of Minimal mode**: `ReceiverAutostart.upgrade()` persisted `version` even for never-initialized installs, so a reboot/update before first launch made `migratePreferences` treat the brand-new install as existing and pick STANDARD instead of the minimal default. `version` is now persisted only once initialized (verified both call sites: `ActivityMain` passes live state, settings-import passes `true` deliberately; uninitialized invocations stay idempotent).

Tests: full `:app:testGithubDebugUnitTest` (35 suites / 248 tests) — green.
