### PR TITLE
Gate TCP DNS answer recording on known framing

### DIFF
--- a/wgbridge-rs/README.md
+++ b/wgbridge-rs/README.md
@@ -183,8 +183,9 @@ hostnames, and re-resolves them on network changes via `updateEndpoint`).
 
 ## Potential improvements
 
-- **Split DNS-over-TCP rewriting**: inbound TCP DNS is recorded with bounded
-  reassembly, but response rewriting is limited to complete frames that begin
+- **Split DNS-over-TCP rewriting**: inbound TCP DNS is recorded only when the
+  inspector saw the connection's SYN (bounded reassembly), but response
+  rewriting is limited to complete frames that begin
   and end in one sequence-aligned segment. Rewriting a frame split across
   packets needs buffering plus TCP sequence translation; continuation segments
   are deliberately forwarded unchanged until that exists.

--- a/wgbridge-rs/src/dns.rs
+++ b/wgbridge-rs/src/dns.rs
@@ -182,18 +182,20 @@ impl DnsInspector {
             flow.buffer.extend_from_slice(payload);
             flow.next_seq = flow.next_seq.wrapping_add(payload.len() as u32);
 
-            while flow.buffer.len() >= 2 {
-                let msg_len = u16::from_be_bytes([flow.buffer[0], flow.buffer[1]]) as usize;
-                if msg_len == 0 {
-                    flow.buffer.drain(..2);
-                    continue;
+            if flow.framing_known {
+                while flow.buffer.len() >= 2 {
+                    let msg_len = u16::from_be_bytes([flow.buffer[0], flow.buffer[1]]) as usize;
+                    if msg_len == 0 {
+                        flow.buffer.drain(..2);
+                        continue;
+                    }
+                    if flow.buffer.len() < msg_len + 2 {
+                        break;
+                    }
+                    let msg = flow.buffer[2..2 + msg_len].to_vec();
+                    flow.buffer.drain(..2 + msg_len);
+                    record_dns_answers(&msg, &SinkPolicy(recorder));
                 }
-                if flow.buffer.len() < msg_len + 2 {
-                    break;
-                }
-                let msg = flow.buffer[2..2 + msg_len].to_vec();
-                flow.buffer.drain(..2 + msg_len);
-                record_dns_answers(&msg, &SinkPolicy(recorder));
             }
         }
 
@@ -904,7 +906,10 @@ mod tests {
         assert_eq!(payload, msg.as_slice());
 
         let sink = CollectingSink(Mutex::new(Vec::new()));
-        inspect_dns_response(&packet, &sink);
+        let mut inspector = DnsInspector::default();
+        let syn = ipv4_tcp_segment(&[], 999, 0x12);
+        inspector.inspect(&syn, &sink);
+        inspector.inspect(&packet, &sink);
         let answers = sink.0.lock().unwrap();
         assert_eq!(answers.len(), 1);
         assert_eq!(answers[0].0, "tracker.example");
@@ -923,7 +928,9 @@ mod tests {
         let second = ipv4_tcp_segment(&framed[split..], 1000 + split as u32, 0x18);
         let sink = CollectingSink(Mutex::new(Vec::new()));
         let mut inspector = DnsInspector::default();
+        let syn = ipv4_tcp_segment(&[], 999, 0x12);
 
+        inspector.inspect(&syn, &sink);
         inspector.inspect(&first, &sink);
         assert!(sink.0.lock().unwrap().is_empty());
         inspector.inspect(&second, &sink);
@@ -944,7 +951,9 @@ mod tests {
         let packet = ipv4_tcp_segment(&framed, 1000, 0x18);
         let sink = CollectingSink(Mutex::new(Vec::new()));
         let mut inspector = DnsInspector::default();
+        let syn = ipv4_tcp_segment(&[], 999, 0x12);
 
+        inspector.inspect(&syn, &sink);
         inspector.inspect(&packet, &sink);
         inspector.inspect(&packet, &sink);
 
@@ -966,7 +975,9 @@ mod tests {
         let second = ipv4_tcp_segment(&framed[split..], 1000 + split as u32, 0x18);
         let sink = CollectingSink(Mutex::new(Vec::new()));
         let mut inspector = DnsInspector::default();
+        let syn = ipv4_tcp_segment(&[], 999, 0x12);
 
+        inspector.inspect(&syn, &sink);
         inspector.inspect(&first, &sink);
         assert!(sink.0.lock().unwrap().is_empty());
         inspector.inspect(&old_retransmit, &sink);
@@ -977,6 +988,21 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].0, "tracker.example");
         assert_eq!(records[0].2, "203.0.113.7");
+    }
+
+    #[test]
+    fn stateful_inspector_does_not_record_without_known_tcp_framing() {
+        let msg = dns_message(&[
+            dns_question("tracker.example", DNS_TYPE_A),
+            dns_answer_bytes("tracker.example", DNS_TYPE_A, 300, &[203, 0, 113, 7]),
+        ]);
+        let packet = ipv4_tcp_segment(&tcp_dns_framed(&msg), 1000, 0x18);
+        let sink = CollectingSink(Mutex::new(Vec::new()));
+        let mut inspector = DnsInspector::default();
+
+        inspector.inspect(&packet, &sink);
+
+        assert!(sink.0.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/wgbridge-rs/tc-dns/src/message.rs
+++ b/wgbridge-rs/tc-dns/src/message.rs
@@ -204,7 +204,8 @@ pub(crate) fn read_dns_name(msg: &[u8], start: usize, depth: u32) -> Option<(Str
         labels: 0,
         encoded_octets: 0,
     };
-    read_dns_name_inner(msg, start, depth, &mut state)
+    let (labels, next) = read_dns_name_inner(msg, start, depth, &mut state)?;
+    Some((labels.join("."), next))
 }
 
 struct NameState {
@@ -217,7 +218,7 @@ fn read_dns_name_inner(
     start: usize,
     depth: u32,
     state: &mut NameState,
-) -> Option<(String, usize)> {
+) -> Option<(Vec<String>, usize)> {
     if depth > MAX_NAME_DEPTH || start >= msg.len() {
         return None;
     }
@@ -238,11 +239,9 @@ fn read_dns_name_inner(
                 // `MAX_NAME_OCTETS`. Pointer-chasing is bounded separately
                 // by `MAX_NAME_DEPTH` and the bounds check above.
                 let ptr = ((length & 0x3f) << 8) | usize::from(*msg.get(offset + 1)?);
-                let (name, _) = read_dns_name_inner(msg, ptr, depth + 1, state)?;
-                if !name.is_empty() {
-                    labels.extend(name.split('.').map(str::to_owned));
-                }
-                return Some((labels.join("."), pointer_end));
+                let (pointer_labels, _) = read_dns_name_inner(msg, ptr, depth + 1, state)?;
+                labels.extend(pointer_labels);
+                return Some((labels, pointer_end));
             }
             0x00 => {
                 state.encoded_octets = state.encoded_octets.checked_add(1)?;
@@ -250,7 +249,7 @@ fn read_dns_name_inner(
                     return None;
                 }
                 if length == 0 {
-                    return Some((labels.join("."), offset.checked_add(1)?));
+                    return Some((labels, offset.checked_add(1)?));
                 }
                 if length > 63 {
                     return None;

--- a/wgbridge-rs/tc-dns/tests/message.rs
+++ b/wgbridge-rs/tc-dns/tests/message.rs
@@ -149,6 +149,19 @@ fn labels_then_pointer_resumes_after_pointer_and_records_answer() {
 }
 
 #[test]
+fn pointer_preserves_literal_dot_inside_wire_label() {
+    let qname = [3, b'a', b'.', b'b', 0];
+    let answer_name = [1, b'x', 0xc0, 12];
+    let message = response(&[question(&qname, TYPE_A)], &[a_answer(&answer_name)]);
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    let records = policy.records.borrow();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].1, "x.a.b");
+}
+
+#[test]
 fn reserved_name_length_bits_are_rejected() {
     for reserved in [0x40u8, 0x80] {
         let message = response(&[question(&[reserved, 0], TYPE_A)], &[a_answer(&[0])]);


### PR DESCRIPTION
## Summary

Two correctness fixes for the WireGuard DNS inspector, from a review of `wgbridge-rs`:

1. **Gate TCP answer recording on known framing** (`src/dns.rs`). A TCP flow bootstrapped mid-stream (SYN never observed) had `framing_known = false`, yet every buffered byte still went through the DNS-over-TCP drain loop — arbitrary payload offsets were parsed as length prefixes, and anything that happened to validate was recorded as a qname→IP attribution. Recording now requires known framing, exactly like response *rewriting* already did. Unframed flows remain bounded by the existing 64 KiB buffer cap (flow dropped on overflow).
   - Tests that relied on mid-stream bootstrap recording now establish framing via a SYN first, preserving their original assertions.
   - New regression test: valid framed response without any observed SYN records nothing.
   - README "Potential improvements" clause updated to match.

2. **Thread DNS name labels as vectors through compression pointers** (`tc-dns/src/message.rs`). `read_dns_name_inner` round-tripped pointed-to names through `split('.')`/`join(".")` — lossless today, but it makes an embedded dot byte inside a wire label indistinguishable from a label separator for any future list-aware change (escaping, validation, counting). Labels now accumulate as `Vec<String>` end to end. Visible output is unchanged and pinned by a new test that follows a compression pointer into a label containing a literal `.`.

## Verification

- `cargo test --workspace` → 68 passed (66 before + 2 new; no tests lost)
- `cargo test -p tc-dns --features capi` → 22 passed
- Diff is 61 lines across 4 files; no behaviour change beyond the intended gate

Note: `cargo clippy -p wgbridge` fails on master already (`clippy::not_unsafe_ptr_arg_deref`, `src/policy.rs:134`) — pre-existing and untouched here.