### PR TITLE
Trip the DoH circuit breaker per attempt and drop the dead delayed-screen-off alarm

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -316,7 +316,6 @@ public class ServiceSinkhole extends VpnService {
     }
 
     private static final String ACTION_HOUSE_HOLDING = "eu.faircode.netguard.HOUSE_HOLDING";
-    private static final String ACTION_SCREEN_OFF_DELAYED = "eu.faircode.netguard.SCREEN_OFF_DELAYED";
     private static final String ACTION_WATCHDOG = "eu.faircode.netguard.WATCHDOG";
 
     private native long jni_init(int sdk);
@@ -493,7 +492,6 @@ public class ServiceSinkhole extends VpnService {
                     IntentFilter ifInteractive = new IntentFilter();
                     ifInteractive.addAction(Intent.ACTION_SCREEN_ON);
                     ifInteractive.addAction(Intent.ACTION_SCREEN_OFF);
-                    ifInteractive.addAction(ACTION_SCREEN_OFF_DELAYED);
                     ContextCompat.registerReceiver(ServiceSinkhole.this, interactiveStateReceiver, ifInteractive,
                             ContextCompat.RECEIVER_NOT_EXPORTED);
                     registeredInteractiveState = true;
@@ -2854,13 +2852,6 @@ public class ServiceSinkhole extends VpnService {
             executor.submit(new Runnable() {
                 @Override
                 public void run() {
-                    AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-                    Intent i = new Intent(ACTION_SCREEN_OFF_DELAYED);
-                    i.setPackage(context.getPackageName());
-                    PendingIntent pi = PendingIntentCompat.getBroadcast(context, 0, i,
-                            PendingIntent.FLAG_UPDATE_CURRENT);
-                    am.cancel(pi);
-
                     try {
                         last_interactive = Intent.ACTION_SCREEN_ON.equals(intent.getAction());
                         InteractiveStatePolicy.onScreenStateChanged(
@@ -2887,11 +2878,6 @@ public class ServiceSinkhole extends VpnService {
                                 .onScreenStateChanged(last_interactive);
                     } catch (Throwable ex) {
                         Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-
-                        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
-                            am.set(AlarmManager.RTC_WAKEUP, new Date().getTime() + 15 * 1000L, pi);
-                        else
-                            am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, new Date().getTime() + 15 * 1000L, pi);
                     }
                 }
             });

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import okhttp3.Cache;
+import okhttp3.Call;
 import okhttp3.ConnectionPool;
 import okhttp3.Dns;
 import okhttp3.HttpUrl;
@@ -200,6 +201,9 @@ public class DnsOverHttpsClient {
      *                         every attempt that costs its full timeout budget.
      *                         Not invoked for non-retryable client errors — the
      *                         caller's own null handling still counts those once.
+     *                         Also not invoked when the request was canceled by
+     *                         our own {@link #getInstance} endpoint swap — that
+     *                         is not evidence the endpoint is unhealthy.
      * @return DNS wire format response bytes, or null on failure
      */
     @Nullable
@@ -226,8 +230,9 @@ public class DnsOverHttpsClient {
                 Log.d(TAG, "DoH retry attempt " + attempt);
             }
 
+            Call call = client.newCall(request);
             try {
-                try (Response response = client.newCall(request).execute()) {
+                try (Response response = call.execute()) {
                     if (!response.isSuccessful()) {
                         Log.w(TAG, "DoH request failed with code: " + response.code());
                         if (response.code() < 500) return null; // Don't retry client errors
@@ -254,6 +259,14 @@ public class DnsOverHttpsClient {
                     return dnsResponse;
                 }
             } catch (IOException e) {
+                if (call.isCanceled()) {
+                    // Canceled by our own getInstance()/shutdown() swap (a DoH
+                    // endpoint change), not a real network failure. Counting
+                    // this would let an endpoint switch alone trip the circuit
+                    // breaker against a perfectly healthy new endpoint.
+                    Log.d(TAG, "DoH request canceled (client shutdown), not counted as a failure");
+                    return null;
+                }
                 Log.e(TAG, "DoH request failed: " + e.getMessage());
                 reportFailedAttempt(onFailedAttempt);
             } finally {

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -188,6 +188,22 @@ public class DnsOverHttpsClient {
 
     @Nullable
     public byte[] resolve(@NonNull byte[] dnsQuery) {
+        return resolve(dnsQuery, null);
+    }
+
+    /**
+     * Resolve a DNS query using DoH, reporting each wasted network attempt.
+     *
+     * @param dnsQuery         Raw DNS wire format query bytes
+     * @param onFailedAttempt  Invoked once per retryable failure (network error,
+     *                         server 5xx, or unusable response body), i.e. for
+     *                         every attempt that costs its full timeout budget.
+     *                         Not invoked for non-retryable client errors — the
+     *                         caller's own null handling still counts those once.
+     * @return DNS wire format response bytes, or null on failure
+     */
+    @Nullable
+    public byte[] resolve(@NonNull byte[] dnsQuery, @Nullable Runnable onFailedAttempt) {
         if (dnsQuery.length < 12) {
             Log.w(TAG, "DNS query too short: " + dnsQuery.length + " bytes");
             return null;
@@ -215,18 +231,21 @@ public class DnsOverHttpsClient {
                     if (!response.isSuccessful()) {
                         Log.w(TAG, "DoH request failed with code: " + response.code());
                         if (response.code() < 500) return null; // Don't retry client errors
+                        reportFailedAttempt(onFailedAttempt);
                         continue;
                     }
 
                     ResponseBody responseBody = response.body();
                     if (responseBody == null) {
                         Log.w(TAG, "DoH response body is null");
+                        reportFailedAttempt(onFailedAttempt);
                         continue;
                     }
 
                     byte[] dnsResponse = responseBody.bytes();
                     if (dnsResponse.length < 12) {
                         Log.w(TAG, "DoH response too short: " + dnsResponse.length + " bytes");
+                        reportFailedAttempt(onFailedAttempt);
                         continue;
                     }
                     dnsResponse = finalizeResponse(dnsResponse, response, dnsQuery);
@@ -236,6 +255,7 @@ public class DnsOverHttpsClient {
                 }
             } catch (IOException e) {
                 Log.e(TAG, "DoH request failed: " + e.getMessage());
+                reportFailedAttempt(onFailedAttempt);
             } finally {
                 // Screen off: never leave an idle keep-alive socket behind — a
                 // server-side reset during doze would wake the radio. Cache
@@ -247,6 +267,14 @@ public class DnsOverHttpsClient {
         }
 
         return null;
+    }
+
+    private static void reportFailedAttempt(@Nullable Runnable onFailedAttempt) {
+        if (onFailedAttempt != null)
+            try {
+                onFailedAttempt.run();
+            } catch (Throwable ignored) {
+            }
     }
 
     static byte[] normalizeTransactionId(byte[] dnsQuery) {

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -58,6 +58,9 @@ public class DnsProxyServer {
     private ServerSocket tcpServerSocket;
     private ExecutorService executor;
     private final AtomicInteger dohFailures = new AtomicInteger(0);
+    // Trips after this many consecutive failed network attempts (not queries):
+    // a single failing resolve burns up to three full timeout budgets, so a
+    // broken endpoint must stop being hammered within a few bad queries.
     private static final int CIRCUIT_BREAKER_THRESHOLD = 10;
     private static final long CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
     private static final int FALLBACK_DNS_TIMEOUT_MS = 5000;
@@ -262,10 +265,11 @@ public class DnsProxyServer {
 
             // Circuit breaker: skip DoH if we recently had too many failures
             boolean circuitOpen = System.currentTimeMillis() < circuitOpenUntil;
+            AtomicInteger queryFailedAttempts = new AtomicInteger(0);
             if (!circuitOpen) {
                 String endpoint = prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT);
                 DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, endpoint);
-                responseData = dohClient.resolve(queryData);
+                responseData = dohClient.resolve(queryData, queryFailedAttempts::incrementAndGet);
             }
 
             if (responseData != null) {
@@ -279,8 +283,13 @@ public class DnsProxyServer {
                 Log.d(TAG, "DoH query successful, response sent to " + clientAddress + ":" + clientPort);
             } else {
                 if (!circuitOpen) {
-                    int failures = dohFailures.incrementAndGet();
-                    Log.w(TAG, "DoH query returned null response, failures=" + failures);
+                    // Each wasted attempt counts: one broken query can burn
+                    // three full timeout budgets, and waiting for ten whole
+                    // queries before tripping kept ~30s of hung work alive
+                    // per query on a dead network.
+                    int failures = dohFailures.addAndGet(Math.max(1, queryFailedAttempts.get()));
+                    Log.w(TAG, "DoH query returned null response after "
+                            + queryFailedAttempts.get() + " attempt(s), failures=" + failures);
 
                     if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
                         circuitOpenUntil = System.currentTimeMillis() + CIRCUIT_BREAKER_COOLDOWN_MS;
@@ -410,10 +419,11 @@ public class DnsProxyServer {
             byte[] responseData = null;
 
             boolean circuitOpen = System.currentTimeMillis() < circuitOpenUntil;
+            AtomicInteger queryFailedAttempts = new AtomicInteger(0);
             if (!circuitOpen) {
                 String endpoint = prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT);
                 DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, endpoint);
-                responseData = dohClient.resolve(queryData);
+                responseData = dohClient.resolve(queryData, queryFailedAttempts::incrementAndGet);
             }
 
             if (responseData != null) {
@@ -425,7 +435,8 @@ public class DnsProxyServer {
                 Log.d(TAG, "DoH TCP query successful");
             } else {
                 if (!circuitOpen) {
-                    int failures = dohFailures.incrementAndGet();
+                    // Same attempt-based accounting as the UDP path above.
+                    int failures = dohFailures.addAndGet(Math.max(1, queryFailedAttempts.get()));
                     if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
                         circuitOpenUntil = System.currentTimeMillis() + CIRCUIT_BREAKER_COOLDOWN_MS;
                         dohFailures.set(0);

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import mockwebserver3.MockResponse;
 import mockwebserver3.MockWebServer;
@@ -127,6 +128,51 @@ public class DnsOverHttpsClientTest {
 
         assertArrayEquals(RESPONSE, client().resolve(QUERY));
 
+        assertEquals(2, server.getRequestCount());
+    }
+
+    // --- failed-attempt reporting (drives the DoH circuit breaker) --------
+
+    /**
+     * Every retryable failure — here three consecutive 5xx responses — must be
+     * reported individually: DnsProxyServer's circuit breaker counts wasted
+     * network attempts (each burns a full timeout budget), not queries.
+     */
+    @Test
+    public void resolveReportsEachRetryableServerError() {
+        server.enqueue(dnsResponse(503, new byte[0]));
+        server.enqueue(dnsResponse(503, new byte[0]));
+        server.enqueue(dnsResponse(503, new byte[0]));
+
+        AtomicInteger failures = new AtomicInteger(0);
+        assertNull(client().resolve(QUERY, failures::incrementAndGet));
+
+        assertEquals(3, failures.get());
+        assertEquals(3, server.getRequestCount());
+    }
+
+    /** A non-retryable client error is not reported as a wasted attempt. */
+    @Test
+    public void resolveDoesNotReportClientErrorsAsAttempts() {
+        server.enqueue(dnsResponse(400, new byte[0]));
+
+        AtomicInteger failures = new AtomicInteger(0);
+        assertNull(client().resolve(QUERY, failures::incrementAndGet));
+
+        assertEquals(0, failures.get());
+        assertEquals(1, server.getRequestCount());
+    }
+
+    /** An unusable 200 body is a wasted attempt and still retries to success. */
+    @Test
+    public void resolveReportsUnusableBodyThenRecovers() {
+        server.enqueue(dnsResponse(200, new byte[] { 1, 2, 3 }));
+        server.enqueue(dnsResponse(200, RESPONSE));
+
+        AtomicInteger failures = new AtomicInteger(0);
+        assertArrayEquals(RESPONSE, client().resolve(QUERY, failures::incrementAndGet));
+
+        assertEquals(1, failures.get());
         assertEquals(2, server.getRequestCount());
     }
 

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -176,6 +176,34 @@ public class DnsOverHttpsClientTest {
         assertEquals(2, server.getRequestCount());
     }
 
+    /**
+     * A request canceled by our own client shutdown (e.g. a DoH endpoint
+     * switch via {@link DnsOverHttpsClient#getInstance}) must not be reported
+     * as a failed attempt — see issue #760: counting it would let switching
+     * endpoints alone trip the circuit breaker against the new, healthy one.
+     */
+    @Test
+    public void resolveDoesNotReportCanceledCallAsFailedAttempt() throws Exception {
+        server.enqueue(new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/dns-message")
+                .body(new Buffer().write(RESPONSE))
+                .headersDelay(2, TimeUnit.SECONDS)
+                .build());
+
+        DnsOverHttpsClient client = client();
+        AtomicInteger failures = new AtomicInteger(0);
+        Thread resolver = new Thread(() -> client.resolve(QUERY, failures::incrementAndGet));
+        resolver.start();
+
+        // Give the request time to actually be dispatched before shutting down.
+        server.takeRequest(1, TimeUnit.SECONDS);
+        client.shutdown();
+        resolver.join(5000);
+
+        assertEquals(0, failures.get());
+    }
+
     @Test
     public void normalizeTransactionIdUsesZeroWithoutMutatingQuery() {
         byte[] query = new byte[]{0x12, 0x34, 0x01, 0x00};


### PR DESCRIPTION
Two battery follow-ups from the battery audit (companions to #747/#748/#749). Rebased onto current master (f520ebab), which already contains #747 (DoH retries/keep-alives gated on screen state), #752 (ServiceSinkhole teardown) and #753 (DNS proxy hardening).

## 1. DoH circuit breaker counts attempts, not queries

**Updated rationale post-#747:** #747 already sets `maxRetries = 0` while the screen is off, so a failing query in doze now costs one ~5s attempt, not three — this PR's per-attempt counting degenerates to the old per-query behaviour there, and #747 has already captured that battery win. The remaining value of this PR is **screen-on**: a dead endpoint hit by #753's larger DoH thread pool now trips the breaker in ~3–4 bad queries (3 wasted attempts each) instead of needing 10 full queries, so screen-on doesn't keep hammering (and logging around) a known-dead endpoint as long.

- `DnsOverHttpsClient.resolve(query)` gains an optional `onFailedAttempt` callback fired once per retryable failure (network error, server 5xx, unusable body) — exactly the attempts that waste their full budget. Non-retryable client errors are *not* reported there; the caller still counts those once via its null handling.
- Both proxy paths (UDP and TCP) now aggregate per-query attempts into `dohFailures` with `addAndGet(max(1, attempts))`, so the breaker trips after ~3–4 bad queries instead of ten, on screen-on.
- Threshold value unchanged; semantics documented at the constant.
- Verified against #753: its new `isPlausibleDnsQuery` gate returns before DoH is ever called, so garbage/malformed queries still never reach the counter.

**#760 (per-attempt counting worsens the endpoint-switch false-trip) — assessed and fixed.** #760 already flags that `DnsOverHttpsClient.getInstance(context, endpoint)` cancels in-flight calls on the outgoing client via `shutdown()`'s `dispatcher().cancelAll()`, and `DnsProxyServer` counts every null `resolve()` as a failure. With straight per-attempt counting that's worse than before: a query whose in-flight call gets canceled and then keeps retrying against the same doomed client can rack up all `MAX_RETRIES+1` attempts as "failures," so as few as ~4 in-flight queries at switch time (4×3=12) could trip the threshold-of-10 breaker against the *new*, healthy endpoint, versus 10 queries needed pre-#768. Fixed in this rebase: `resolve()` now checks `Call#isCanceled()` in the `IOException` handler and returns without calling `onFailedAttempt` when the failure was our own cancellation rather than a real network error. This directly implements the "don't count cancellations caused by our own shutdown()" direction from #760's own suggested fix (the other two #760 issues — reset-on-any-success, and the shared UDP/TCP counter — are pre-existing and out of scope here).

## 2. Remove the half-dead `ACTION_SCREEN_OFF_DELAYED` machinery

The action had a receiver registration and a cancel, but nothing ever scheduled it — except an error fallback in the screen-state receiver that armed a `setAndAllowWhileIdle` RTC_WAKEUP every **15 seconds** if handling a screen event threw, looping indefinitely in doze while the underlying failure persisted. Removed: the action constant, its registration line, and the fallback loop (the catch now just logs). Unaffected by #752's ServiceSinkhole teardown changes (different code path).

## Testing

- New tests in `DnsOverHttpsClientTest`: three 5xx → 3 reports; a 400 → 0 reports (still counted once by the caller); short-body retry → 1 report then success; a canceled in-flight call → 0 reports (the #760 fix).
- Full `net.kollnig.missioncontrol.dns.*` suite and the full unit test suite pass.
