### PR TITLE
Debounce database change notifications without sleeping the handler thread

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -99,6 +99,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private final static int MSG_LOG = 1;
     private final static int MSG_ACCESS = 2;
     private final static int MSG_FORWARD = 3;
+    private static final long NOTIFY_BATCH_MS = 1000;
 
     private SharedPreferences prefs;
     private ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
@@ -1430,32 +1431,21 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     private void notifyLogChanged() {
-        Message msg = handler.obtainMessage();
-        msg.what = MSG_LOG;
-        handler.sendMessage(msg);
+        if (!handler.hasMessages(MSG_LOG))
+            handler.sendEmptyMessageDelayed(MSG_LOG, NOTIFY_BATCH_MS);
     }
 
     private void notifyAccessChanged() {
-        Message msg = handler.obtainMessage();
-        msg.what = MSG_ACCESS;
-        handler.sendMessage(msg);
+        if (!handler.hasMessages(MSG_ACCESS))
+            handler.sendEmptyMessageDelayed(MSG_ACCESS, NOTIFY_BATCH_MS);
     }
 
     private void notifyForwardChanged() {
-        Message msg = handler.obtainMessage();
-        msg.what = MSG_FORWARD;
-        handler.sendMessage(msg);
+        if (!handler.hasMessages(MSG_FORWARD))
+            handler.sendEmptyMessageDelayed(MSG_FORWARD, NOTIFY_BATCH_MS);
     }
 
     private static void handleChangedNotification(Message msg) {
-        // Batch notifications
-        try {
-            Thread.sleep(1000);
-            if (handler.hasMessages(msg.what))
-                handler.removeMessages(msg.what);
-        } catch (InterruptedException ignored) {
-        }
-
         // Notify listeners
         if (msg.what == MSG_LOG) {
             for (LogChangedListener listener : logChangedListeners)

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperAccessBatchTest.java
@@ -4,11 +4,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import android.database.Cursor;
+import android.os.Handler;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowLooper;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Covers the access/usage batching added to collapse per-flow SQLite writes
@@ -127,6 +137,84 @@ public class DatabaseHelperAccessBatchTest {
         try (Cursor c = dh.getAccess(uid)) {
             assertEquals(2, c.getCount());
         }
+    }
+
+    @Test
+    public void repeatedAccessNotificationsCoalesceWithinWindow() throws Exception {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        Handler handler = databaseHandler();
+        waitForHandlerIdle(handler);
+        handler.removeCallbacksAndMessages(null);
+
+        AtomicInteger callbacks = new AtomicInteger();
+        CountDownLatch firstCallback = new CountDownLatch(1);
+        DatabaseHelper.AccessChangedListener listener = () -> {
+            callbacks.incrementAndGet();
+            firstCallback.countDown();
+        };
+        dh.addAccessChangedListener(listener);
+        try {
+            notifyAccessChanged(dh);
+            notifyAccessChanged(dh);
+            notifyAccessChanged(dh);
+
+            ShadowLooper shadowLooper = Shadows.shadowOf(handler.getLooper());
+            shadowLooper.idleFor(1100, TimeUnit.MILLISECONDS);
+            assertTrue("batched notification was not delivered",
+                    firstCallback.await(3, TimeUnit.SECONDS));
+            waitForHandlerIdle(handler);
+            assertEquals("notifications in one window must coalesce", 1, callbacks.get());
+        } finally {
+            dh.removeAccessChangedListener(listener);
+        }
+    }
+
+    @Test
+    public void notificationBurstDoesNotBlockDatabaseHandler() throws Exception {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        Handler handler = databaseHandler();
+        waitForHandlerIdle(handler);
+        handler.removeCallbacksAndMessages(null);
+
+        notifyAccessChanged(dh);
+        notifyAccessChanged(dh);
+        notifyAccessChanged(dh);
+
+        try {
+            CountDownLatch runnableRan = new CountDownLatch(1);
+            AtomicLong elapsedMs = new AtomicLong();
+            long startNanos = System.nanoTime();
+            handler.post(() -> {
+                elapsedMs.set(TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
+                runnableRan.countDown();
+            });
+
+            assertTrue("database handler runnable was delayed",
+                    runnableRan.await(3, TimeUnit.SECONDS));
+            assertTrue("database handler runnable took " + elapsedMs.get() + " ms",
+                    elapsedMs.get() < 500);
+        } finally {
+            handler.removeCallbacksAndMessages(null);
+        }
+    }
+
+    private static Handler databaseHandler() throws Exception {
+        Field field = DatabaseHelper.class.getDeclaredField("handler");
+        field.setAccessible(true);
+        return (Handler) field.get(null);
+    }
+
+    private static void notifyAccessChanged(DatabaseHelper dh) throws Exception {
+        Method method = DatabaseHelper.class.getDeclaredMethod("notifyAccessChanged");
+        method.setAccessible(true);
+        method.invoke(dh);
+    }
+
+    private static void waitForHandlerIdle(Handler handler) throws InterruptedException {
+        CountDownLatch idle = new CountDownLatch(1);
+        handler.post(idle::countDown);
+        assertTrue("database handler did not become idle",
+                idle.await(3, TimeUnit.SECONDS));
     }
 
     private static Packet packet(int uid, String daddr, int dport, long time, boolean allowed) {


### PR DESCRIPTION
## Confirmed defect

`DatabaseHelper.handleChangedNotification` slept 1 second inline to batch notifications:

- `app/src/main/java/eu/faircode/netguard/DatabaseHelper.java:1453` — `Thread.sleep(1000)` inside the handler callback
- the sleeping thread is the single static `HandlerThread("DatabaseHelper")` (`DatabaseHelper.java:168-177`)
- that same thread also runs `accessFlushRunnable` / `usageFlushRunnable` (`DatabaseHelper.java:124-125`, posted from the schedule/flush paths around `:670-673`), so every sleep pushed a scheduled batch flush past its intended window.

## Impact (bounded — not data loss)

The `removeMessages(msg.what)` after the sleep means at most one sleep per distinct message `what` per burst, so the delay is bounded at ~1s per `what` (≤3s worst case across `MSG_LOG` / `MSG_ACCESS` / `MSG_FORWARD`). Size-based and next-write flushes still cover sustained traffic. The cost is **tail-flush latency and stale listener/UI freshness**, not lost records. Cosmetic to minor, but it affects everyone with logging on or the UI open.

## Change

One production file, net -17/+7 lines:

- `notifyLogChanged` / `notifyAccessChanged` / `notifyForwardChanged` now schedule with `sendEmptyMessageDelayed(MSG_X, NOTIFY_BATCH_MS)` only when no message of that `what` is already pending.
- `handleChangedNotification` just fires the listeners — no sleep, no `removeMessages`.

The debounce survives, with the **same fixed-window semantics**: the first notification of a `what` delivers ~1s later, everything arriving inside that window coalesces into one callback, and delivery stays guaranteed even under continuous traffic. A resetting debounce (`removeMessages` + `postDelayed` on *every* notification) was deliberately rejected — it would restart the timer on each event and starve listeners entirely while traffic keeps flowing.

No new preferences, no polling, no extra wakeups: the number of scheduled messages is unchanged (one delayed message per window instead of one immediate message per notification, coalesced either way).

## Test evidence

Two Robolectric tests added to `DatabaseHelperAccessBatchTest`:

- `repeatedAccessNotificationsCoalesceWithinWindow` — three notifications inside one window produce exactly one listener callback. Passes on both the old and new implementation, i.e. it pins the semantics that must not change.
- `notificationBurstDoesNotBlockDatabaseHandler` — a runnable posted to the DB handler right after a notification burst must run in <500 ms. Verified to **fail against the pre-fix code** (`java.lang.AssertionError: database handler runnable took 1001 ms`) and pass after.

```
$ ./gradlew :app:compileGithubDebugJavaWithJavac -q
COMPILE_EXIT=0

$ ./gradlew :app:testGithubDebugUnitTest --rerun-tasks
TEST_EXIT=0
```

Fixes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)