### PR TITLE
Cap the DoH response read at 65535 bytes (#761)

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -63,6 +63,7 @@ public class DnsOverHttpsClient {
     private static final int WRITE_TIMEOUT_MS = 5000;
     private static final long HTTP_CACHE_MAX_BYTES = 2L * 1024L * 1024L;
     private static final int MAX_GET_URL_LENGTH = 2048;
+    private static final int MAX_DOH_RESPONSE_BYTES = 65535;
     private static final ExecutorService SHUTDOWN_EXECUTOR = Executors.newSingleThreadExecutor(r -> {
         Thread thread = new Thread(r, "DoH-shutdown");
         thread.setDaemon(true);
@@ -224,7 +225,17 @@ public class DnsOverHttpsClient {
                         continue;
                     }
 
-                    byte[] dnsResponse = responseBody.bytes();
+                    long contentLength = responseBody.contentLength();
+                    if (contentLength > MAX_DOH_RESPONSE_BYTES) {
+                        Log.w(TAG, "DoH response too large: " + contentLength + " bytes");
+                        continue;
+                    }
+
+                    byte[] dnsResponse = response.peekBody(MAX_DOH_RESPONSE_BYTES + 1L).bytes();
+                    if (dnsResponse.length > MAX_DOH_RESPONSE_BYTES) {
+                        Log.w(TAG, "DoH response too large: " + dnsResponse.length + " bytes");
+                        continue;
+                    }
                     if (dnsResponse.length < 12) {
                         Log.w(TAG, "DoH response too short: " + dnsResponse.length + " bytes");
                         continue;

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -131,6 +131,34 @@ public class DnsOverHttpsClientTest {
     }
 
     @Test
+    public void resolveRejectsOversizedDnsResponse() {
+        DnsOverHttpsClient.setScreenOff(true);
+        try {
+            server.enqueue(dnsResponse(200, responseOfLength(65536)));
+
+            assertNull(client().resolve(QUERY));
+
+            assertEquals(1, server.getRequestCount());
+        } finally {
+            DnsOverHttpsClient.setScreenOff(false);
+        }
+    }
+
+    @Test
+    public void resolveRejectsOversizedChunkedDnsResponse() {
+        DnsOverHttpsClient.setScreenOff(true);
+        try {
+            server.enqueue(chunkedDnsResponse(200, responseOfLength(65536)));
+
+            assertNull(client().resolve(QUERY));
+
+            assertEquals(1, server.getRequestCount());
+        } finally {
+            DnsOverHttpsClient.setScreenOff(false);
+        }
+    }
+
+    @Test
     public void normalizeTransactionIdUsesZeroWithoutMutatingQuery() {
         byte[] query = new byte[]{0x12, 0x34, 0x01, 0x00};
 
@@ -254,5 +282,17 @@ public class DnsOverHttpsClientTest {
                 .addHeader("Content-Type", "application/dns-message")
                 .body(new Buffer().write(body))
                 .build();
+    }
+
+    private static MockResponse chunkedDnsResponse(int status, byte[] body) {
+        return new MockResponse.Builder()
+                .code(status)
+                .addHeader("Content-Type", "application/dns-message")
+                .chunkedBody(new Buffer().write(body), 1024)
+                .build();
+    }
+
+    private static byte[] responseOfLength(int length) {
+        return Arrays.copyOf(RESPONSE, length);
     }
 }


### PR DESCRIPTION
## The defect

`DnsOverHttpsClient.java:218` (master, `197d4047`) reads the DoH response with:

```java
byte[] dnsResponse = responseBody.bytes();
```

No `contentLength()` check, no cap. OkHttp imposes no practical limit on
`ResponseBody.bytes()`, so a hostile or broken DoH endpoint can drive an
unbounded heap allocation inside the always-on VPN process.

## Honest scoping

This is **edge-configuration hardening, not a default-user bug**:

- DoH is opt-in and defaults to off (`preferences.xml:64-67`).
- It additionally requires a hostile or broken endpoint; the default endpoint
  is Quad9.

It is worth doing anyway because the fix is ~13 lines, adds no user-facing
surface, and carries near-zero risk.

## The change

At the body-read site only:

1. `MAX_DOH_RESPONSE_BYTES = 65535` — the DNS-over-TCP framing limit, which a
   legitimate DoH response can never exceed.
2. Reject on the advertised length first: if `responseBody.contentLength()`
   exceeds the cap, log and take the failure path **without reading the body**.
3. Make the actual read bounded: `response.peekBody(MAX + 1)` never allocates
   more than 64 KiB + 1, so a chunked body with no advertised length cannot
   allocate without limit either. If the peeked array still exceeds the cap,
   reject.
4. Oversized bodies take the **existing** failure path (`continue`), exactly
   like the existing `length < 12` too-short check — so the retry loop still
   applies and `resolve()` ultimately returns `null`. Never truncate-and-parse
   into a malformed DNS message.

For a normal-sized body the peek reads the source to EOF, so the exchange
still completes and connection reuse is unaffected.

## Overlap with #768

PR #768 also edits `resolve()` — it adds an `onFailedAttempt` callback in the
retry loop around this very call — and is pending a rebase. This change is
deliberately confined to the body-read site: no loop refactor, no renames, no
reordering, so the two should merge cleanly. Whichever lands second just needs
the new guard block and the callback to sit side by side.

## Test evidence

Two new tests in `DnsOverHttpsClientTest`, both with `setScreenOff(true)` to
disable retries:

- `resolveRejectsOversizedDnsResponse` — 65536-byte fixed-length body, exercises
  the `contentLength()` guard; asserts `resolve()` returns `null` and exactly one
  request was made.
- `resolveRejectsOversizedChunkedDnsResponse` — 65536-byte chunked body (no
  `Content-Length`), exercises the bounded `peekBody` path; same assertions.

Normal-sized success is already covered by the existing
`resolveSendsCacheFriendlyGetAndReturnsResponse` and the caching/TTL tests,
which all still pass.

Verified both new tests fail on master without the fix (`18 tests completed,
2 failed`) and pass with it.

```
./gradlew :app:compileGithubDebugJavaWithJavac -q                              # exit 0
./gradlew :app:testGithubDebugUnitTest --tests 'net.kollnig.missioncontrol.dns.*'  # exit 0
./gradlew :app:testGithubDebugUnitTest                                          # exit 0
```

Fixes #761
