### PR TITLE
Normalise DNS qnames to lowercase on the database write path

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -42,6 +42,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -84,7 +85,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final String TAG = "TrackerControl.Database";
 
     private static final String DB_NAME = "Netguard";
-    private static final int DB_VERSION = 22;
+    private static final int DB_VERSION = 23;
 
     private static boolean once = true;
     private static List<LogChangedListener> logChangedListeners = new ArrayList<>();
@@ -446,6 +447,23 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             if (oldVersion < 22) {
                 db.execSQL("ALTER TABLE access ADD COLUMN uncertain INTEGER");
                 oldVersion = 22;
+            }
+            if (oldVersion < 23) {
+                // Remove case-variant duplicates before lowercasing because idx_dns is UNIQUE.
+                // Keep the freshest row for each DNS identity, breaking time ties by ID.
+                db.execSQL("DELETE FROM dns WHERE ID NOT IN (" +
+                        "SELECT MAX(d.ID) FROM dns d" +
+                        " JOIN (" +
+                        "SELECT lower(qname) AS qname, lower(aname) AS aname, resource, MAX(time) AS time" +
+                        " FROM dns" +
+                        " GROUP BY lower(qname), lower(aname), resource" +
+                        ") latest ON lower(d.qname) = latest.qname" +
+                        " AND lower(d.aname) = latest.aname" +
+                        " AND d.resource = latest.resource" +
+                        " AND d.time = latest.time" +
+                        " GROUP BY latest.qname, latest.aname, latest.resource)");
+                db.execSQL("UPDATE dns SET qname = lower(qname), aname = lower(aname)");
+                oldVersion = 23;
             }
 
             if (oldVersion == DB_VERSION) {
@@ -935,7 +953,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             // There is a segmented index on uid
             // There is no index on time for write performance
             String query = "SELECT a.ID AS _id, a.*";
-            query += ", (SELECT COUNT(DISTINCT d.qname) FROM dns d WHERE d.resource IN (SELECT d1.resource FROM dns d1 WHERE d1.qname = a.daddr)) count";
+            query += ", (SELECT COUNT(DISTINCT d.qname) FROM dns d WHERE d.resource IN (SELECT d1.resource FROM dns d1 WHERE d1.qname = lower(a.daddr))) count";
             query += " FROM access a";
             query += " WHERE a.uid = ?";
             query += " ORDER BY a.time DESC";
@@ -1053,6 +1071,10 @@ public class DatabaseHelper extends SQLiteOpenHelper {
 
     // DNS
 
+    private static String lower(String name) {
+        return (name == null ? null : name.toLowerCase(Locale.ROOT));
+    }
+
     public boolean insertDns(ResourceRecord rr) {
         lock.writeLock().lock();
         try {
@@ -1069,12 +1091,21 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 cv.put("time", rr.Time);
                 cv.put("ttl", ttl * 1000L);
 
+                // DNS names are case-insensitive, but the tracker and hosts lookups
+                // are keyed in lowercase (see TrackerList.findTracker). Storing the
+                // wire case verbatim made a server-chosen CNAME case — or a resolver
+                // using 0x20 randomisation — a distinct row under the BINARY-collated
+                // idx_dns, splitting one domain across several rows and making
+                // getQAName report it as several qnames sharing an IP.
+                String qname = lower(rr.QName);
+                String aname = lower(rr.AName);
+
                 int rows = db.update("dns", cv, "qname = ? AND aname = ? AND resource = ?",
-                        new String[] { rr.QName, rr.AName, rr.Resource });
+                        new String[] { qname, aname, rr.Resource });
 
                 if (rows == 0) {
-                    cv.put("qname", rr.QName);
-                    cv.put("aname", rr.AName);
+                    cv.put("qname", qname);
+                    cv.put("aname", aname);
                     cv.put("resource", rr.Resource);
 
                     if (db.insert("dns", null, cv) == -1)
@@ -1199,6 +1230,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
+            qname = lower(qname);
             String query = "SELECT DISTINCT d2.qname";
             query += " FROM dns d1";
             query += " JOIN dns d2";
@@ -1216,6 +1248,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
+            qname = lower(qname);
             String query = "SELECT d.qname, d.aname, d.time, d.ttl";
             query += " FROM dns d";
             query += " WHERE d.qname = ?";
@@ -1248,13 +1281,16 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         lock.readLock().lock();
         try {
             SQLiteDatabase db = this.getReadableDatabase();
+            // dns.qname is stored lowercase; access.daddr is written from it, so
+            // the parameter is matched against the indexed column as-is.
+            dname = lower(dname);
 
             // There is a segmented index on dns.qname
             // There is an index on access.daddr and access.block
             String query = "SELECT a.uid, a.version, a.protocol, a.daddr, d.resource, a.dport, a.block, d.time, d.ttl";
             query += " FROM access AS a";
             query += " LEFT JOIN dns AS d";
-            query += "   ON d.qname = a.daddr";
+            query += "   ON d.qname = lower(a.daddr)";
             query += " WHERE a.block >= 0";
             query += " AND (d.time IS NULL OR d.time + d.ttl >= " + now + ")";
             if (dname != null)

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
@@ -60,6 +60,24 @@ public class DatabaseHelperDnsAttributionTest {
     }
 
     @Test
+    public void caseVariantQnamesShareOneRowAndDoNotLookUncertain() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        String ip = "203.0.113.25";
+        dh.insertDns(rr(1_000L, "Graph.Facebook.Com", "Alias.Example.Com", ip, 3600));
+        dh.insertDns(rr(5_000L, "graph.facebook.com", "alias.example.com", ip, 3600));
+
+        try (Cursor c = dh.getQAName(-1, ip, false)) {
+            assertEquals("case variants must share one stored qname", 1, c.getCount());
+            assertTrue(c.moveToFirst());
+            assertEquals("graph.facebook.com", c.getString(c.getColumnIndexOrThrow("qname")));
+            assertEquals("alias.example.com", c.getString(c.getColumnIndexOrThrow("aname")));
+            assertEquals(5_000L, c.getLong(c.getColumnIndexOrThrow("time")));
+        }
+    }
+
+    @Test
     public void aliveFilterAppliesBeforeDedup() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
         dh.clearDns();

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
@@ -35,14 +35,18 @@ public class DatabaseHelperMigrationTest {
         database.execSQL("ALTER TABLE access ADD COLUMN sent INTEGER");
         database.execSQL("ALTER TABLE access ADD COLUMN received INTEGER");
         database.execSQL("ALTER TABLE access ADD COLUMN connections INTEGER");
+        database.execSQL("CREATE TABLE dns ("
+                + "ID INTEGER PRIMARY KEY AUTOINCREMENT, time INTEGER NOT NULL, "
+                + "qname TEXT NOT NULL, aname TEXT NOT NULL, resource TEXT NOT NULL, ttl INTEGER)");
+        database.execSQL("CREATE UNIQUE INDEX idx_dns ON dns(qname, aname, resource)");
         database.execSQL("INSERT INTO access "
                 + "(uid, version, protocol, daddr, dport, time, allowed, block, sent, received, connections) "
                 + "VALUES (1001, 4, 6, 'tracker.example', 443, 123456, 0, 1, 10, 20, 3)");
         database.setVersion(21);
 
-        helper.onUpgrade(database, 21, 22);
+        helper.onUpgrade(database, 21, 23);
 
-        assertEquals(22, database.getVersion());
+        assertEquals(23, database.getVersion());
         assertTrue(columnExists("access", "uncertain"));
         try (Cursor cursor = database.rawQuery("SELECT * FROM access WHERE uid = 1001", null)) {
             assertTrue(cursor.moveToFirst());
@@ -70,9 +74,9 @@ public class DatabaseHelperMigrationTest {
                 + "VALUES (654321, 'example.org', 'alias.example.org', '1.2.3.4', 60)");
         database.setVersion(16);
 
-        helper.onUpgrade(database, 16, 22);
+        helper.onUpgrade(database, 16, 23);
 
-        assertEquals(22, database.getVersion());
+        assertEquals(23, database.getVersion());
         assertTrue(columnExists("access", "sent"));
         assertTrue(columnExists("access", "received"));
         assertTrue(columnExists("access", "connections"));
@@ -93,6 +97,31 @@ public class DatabaseHelperMigrationTest {
             assertEquals("example.org", cursor.getString(0));
             assertEquals("alias.example.org", cursor.getString(1));
             assertEquals("1.2.3.4", cursor.getString(2));
+        }
+    }
+
+    @Test
+    public void upgradeFrom22NormalizesAndDeduplicatesDns() {
+        database.execSQL("CREATE TABLE dns ("
+                + "ID INTEGER PRIMARY KEY AUTOINCREMENT, time INTEGER NOT NULL, "
+                + "qname TEXT NOT NULL, aname TEXT NOT NULL, resource TEXT NOT NULL, ttl INTEGER)");
+        database.execSQL("CREATE UNIQUE INDEX idx_dns ON dns(qname, aname, resource)");
+        database.execSQL("INSERT INTO dns (time, qname, aname, resource, ttl) "
+                + "VALUES (1000, 'Graph.Facebook.Com', 'Alias.Example.Com', '203.0.113.25', 60)");
+        database.execSQL("INSERT INTO dns (time, qname, aname, resource, ttl) "
+                + "VALUES (5000, 'graph.facebook.com', 'alias.example.com', '203.0.113.25', 60)");
+        database.setVersion(22);
+
+        helper.onUpgrade(database, 22, 23);
+
+        assertEquals(23, database.getVersion());
+        try (Cursor cursor = database.rawQuery("SELECT qname, aname, resource, time FROM dns", null)) {
+            assertEquals(1, cursor.getCount());
+            assertTrue(cursor.moveToFirst());
+            assertEquals("graph.facebook.com", cursor.getString(0));
+            assertEquals("alias.example.com", cursor.getString(1));
+            assertEquals("203.0.113.25", cursor.getString(2));
+            assertEquals(5000L, cursor.getLong(3));
         }
     }
 


### PR DESCRIPTION
## The defect

DNS names are case-insensitive, but the two halves of the DNS store disagreed about it.

- **Write side did not normalise.** `DatabaseHelper.insertDns()` (`app/src/main/java/eu/faircode/netguard/DatabaseHelper.java:1072-1078` on master) UPDATEd on the exact `(qname, aname, resource)` string triple and INSERTed `rr.QName`/`rr.AName` verbatim. The schema's `CREATE UNIQUE INDEX idx_dns ON dns(qname, aname, resource)` (`DatabaseHelper.java:294`, recreated in the v18 migration at `:429`) is BINARY-collated, so case variants of one domain became distinct rows.
- **Read side already did.** `TrackerList.findTracker` lowercases (`app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java:121`) and `ServiceSinkhole.prepareHostsBlocked` lowercases hosts.txt keys (`ServiceSinkhole.java:2167`).
- `getQAName` does `GROUP BY d.qname` (`DatabaseHelper.java:1185-1189`), so those variants counted as several distinct qnames for one IP.

## User-visible symptom (default configuration)

`ServiceSinkhole.log()` computes `uncertain = getQAName(...).getCount() > 1 ? ACCESS_UNCERTAIN_SHARED_IP : NONE` (`ServiceSinkhole.java:960-968`), and `log_app` defaults to `true`, so `dh.updateAccess(packet, dname, -1, uncertain)` runs (`:1035`). A perfectly unambiguous domain therefore picked up the spurious "shared IP / uncertain" marker in the UI, and fed the mixed-evidence classification that decides whether an IP counts as an ambiguous shared host in Standard mode. The realistic trigger is **server-chosen CNAME case in `aname`**, rather than DNS 0x20 query-case randomisation.

The issue text points at `get_qname` in `app/src/main/jni/netguard/dns.c`; that reference is stale — DNS parsing now lives in Rust (`wgbridge-rs/tc-dns/src/message.rs`). **Preserving wire case in the parser is correct and is unchanged here.** The fix is purely on the Java write path.

## What changed

`app/src/main/java/eu/faircode/netguard/DatabaseHelper.java`:

- `insertDns()` lowercases `qname`/`aname` with `Locale.ROOT` before both the UPDATE match and the INSERT, via a null-safe `lower()` helper (the columns are `NOT NULL`, so a null still fails as a caught SQLite error rather than an NPE thrown out of the native `dnsResolved` callback). `resource` is an IP literal and is left alone.
- The qname parameters of `getAName()`, `getAlternateQNames()` and `getAccessDns()` are lowercased to match the now-lowercase column — `dnsResolved()` calls `prepareUidIPFilters(rr.QName)` with the wire-case name.
- The two joins that match `dns.qname` against `access.daddr` (`getAccess`'s shared-IP count subquery and `getAccessDns`'s LEFT JOIN) compare against `lower(a.daddr)`, so access rows written before this change still resolve. The `WHERE` clause deliberately keeps the plain `a.daddr = ?` comparison so `idx_access_daddr` is still usable — `prepareUidIPFilters` runs on **every** new DNS record, and `lower()` there would have turned that into a full scan of a table that is never pruned. Battery is a first-class constraint in this repo.

**Migration: yes, `DB_VERSION` 22 -> 23.** The `dns` table is TTL-expiring, so duplicates would eventually age out on their own — but `ttl` defaults to a 259200 s (3 day) floor and users refresh the same domains constantly, so "eventually" can mean the false uncertainty marker sticks around for days on exactly the domains a user looks at most. The migration deletes case-variant duplicates first (keeping the freshest row per `(lower(qname), lower(aname), resource)`, ties broken by `MAX(ID)`) and only then runs `UPDATE dns SET qname = lower(qname), aname = lower(aname)`; the dedup must precede the update because `idx_dns` is UNIQUE and a naive lowercase would hit a constraint violation where a lowercase twin already exists. SQLite's `lower()` is ASCII-only, which is exactly right for DNS names. It is a one-off, two-statement pass over a small table.

## Test evidence

- `DatabaseHelperDnsAttributionTest.caseVariantQnamesShareOneRowAndDoNotLookUncertain` — inserts `Graph.Facebook.Com`/`Alias.Example.Com` and `graph.facebook.com`/`alias.example.com` for the same IP, then asserts `getQAName` returns **one** row (not two, which is what drove the false `ACCESS_UNCERTAIN_SHARED_IP`), with the lowercase names and the freshest timestamp.
- `DatabaseHelperMigrationTest.upgradeFrom22NormalizesAndDeduplicatesDns` — seeds a v22 `dns` table with the same two case variants, runs `onUpgrade(22, 23)`, asserts a single lowercase row survives carrying the newer `time`. The two existing migration tests were extended to target 23.

Reverting only `DatabaseHelper.java` and re-running these tests fails with `case variants must share one stored qname expected:<1> but was:<2>`, confirming the test reproduces the reported defect.

```
$ ./gradlew :app:compileGithubDebugJavaWithJavac -q
Note: [1] Wrote GeneratedAppGlideModule with: []
Note: Some input files use or override a deprecated API.
Note: Some input files use unchecked or unsafe operations.
(exit 0)

$ ./gradlew :app:testGithubDebugUnitTest
(exit 0) — 258 tests, 0 skipped, 0 failures, 0 errors
```

## Deliberately out of scope

- No change to the Rust/C DNS parsers: keeping wire case there is correct.
- `access.daddr` is not normalised or deduplicated. A domain observed in mixed case before this change can leave a stale access row alongside the new lowercase one; the joins above still resolve it, and normalising `access` means a second dedup against `UNIQUE INDEX idx_access(uid, version, protocol, daddr, dport)` for a cosmetic legacy artefact.
- Per-app DNS attribution remains global; unrelated to this fix.

Fixes #756
