### PR TITLE
Fix blocklist load integrity: short reads and premature hosts mtime stamp

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/HostsBlocklistLogic.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsBlocklistLogic.java
@@ -1,0 +1,78 @@
+package eu.faircode.netguard;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Locale;
+import java.util.Map;
+
+final class HostsBlocklistLogic {
+    interface Logger {
+        void log(String message);
+    }
+
+    private static final Logger NOOP_LOGGER = message -> {
+    };
+
+    static final class State {
+        private final Map<String, Boolean> mapHostsBlocked;
+        private final Logger logger;
+        private long lastModified;
+
+        State(Map<String, Boolean> mapHostsBlocked, long lastModified) {
+            this(mapHostsBlocked, lastModified, NOOP_LOGGER);
+        }
+
+        State(Map<String, Boolean> mapHostsBlocked, long lastModified, Logger logger) {
+            this.mapHostsBlocked = mapHostsBlocked;
+            this.lastModified = lastModified;
+            this.logger = logger;
+        }
+
+        boolean shouldReload(long modified) {
+            return modified != lastModified || mapHostsBlocked.size() == 0;
+        }
+
+        boolean load(Reader reader, long modified) throws IOException {
+            if (!shouldReload(modified))
+                return false;
+
+            parse(reader);
+            lastModified = modified;
+            return true;
+        }
+
+        void parse(Reader reader) throws IOException {
+            mapHostsBlocked.clear();
+            BufferedReader br = reader instanceof BufferedReader
+                    ? (BufferedReader) reader : new BufferedReader(reader);
+            int count = 0;
+            String line;
+            while ((line = br.readLine()) != null) {
+                int hash = line.indexOf('#');
+                if (hash >= 0)
+                    line = line.substring(0, hash);
+                line = line.trim();
+                if (line.length() > 0) {
+                    String[] words = line.split("\\s+");
+                    if (words.length == 2) {
+                        count++;
+                        // Keyed lowercase to match TrackerList.findTracker(),
+                        // which normalises qnames before the hosts lookup.
+                        mapHostsBlocked.put(words[1].toLowerCase(Locale.ROOT), true);
+                    } else
+                        logger.log("Invalid hosts file line: " + line);
+                }
+            }
+            mapHostsBlocked.put("test.netguard.me", true);
+            logger.log(count + " hosts read");
+        }
+
+        long getLastModified() {
+            return lastModified;
+        }
+    }
+
+    private HostsBlocklistLogic() {
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -114,7 +114,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -2134,49 +2133,37 @@ public class ServiceSinkhole extends VpnService {
         InputStreamReader is = null;
         boolean locked = false;
         File hosts = new File(c.getFilesDir(), "hosts.txt");
+        boolean hostsFile = false;
+        long hostsModified = 0;
+        HostsBlocklistLogic.State hostsState = new HostsBlocklistLogic.State(
+                mapHostsBlocked, last_hosts_modified, message -> Log.i(TAG, message));
 
         try {
-            if (!hosts.exists() || !hosts.canRead()) {
+            hostsFile = hosts.exists() && hosts.canRead();
+            if (!hostsFile) {
                 if (mapHostsBlocked.size() > 0) {
                     Log.i(TAG, "Hosts file unchanged");
                     return;
                 }
                 is = new InputStreamReader(c.getAssets().open("hosts.txt"));
             } else {
-                boolean changed = (hosts.lastModified() != last_hosts_modified);
-                if (!changed && mapHostsBlocked.size() > 0) {
+                hostsModified = hosts.lastModified();
+                if (!hostsState.shouldReload(hostsModified)) {
                     Log.i(TAG, "Hosts file unchanged");
                     return;
                 }
-                last_hosts_modified = hosts.lastModified();
                 is = new FileReader(hosts);
             }
 
             lock.writeLock().lock();
             locked = true;
-            mapHostsBlocked.clear();
 
-            int count = 0;
             br = new BufferedReader(is);
-            String line;
-            while ((line = br.readLine()) != null) {
-                int hash = line.indexOf('#');
-                if (hash >= 0)
-                    line = line.substring(0, hash);
-                line = line.trim();
-                if (line.length() > 0) {
-                    String[] words = line.split("\\s+");
-                    if (words.length == 2) {
-                        count++;
-                        // Keyed lowercase to match TrackerList.findTracker(),
-                        // which normalises qnames before the hosts lookup.
-                        mapHostsBlocked.put(words[1].toLowerCase(Locale.ROOT), true);
-                    } else
-                        Log.i(TAG, "Invalid hosts file line: " + line);
-                }
-            }
-            mapHostsBlocked.put("test.netguard.me", true);
-            Log.i(TAG, count + " hosts read");
+            if (hostsFile) {
+                hostsState.load(br, hostsModified);
+                last_hosts_modified = hostsState.getLastModified();
+            } else
+                hostsState.parse(br);
         } catch (IOException ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
         } finally {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
@@ -23,8 +23,8 @@ import android.util.Log;
 
 import androidx.preference.PreferenceManager;
 
+import java.io.DataInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Collections;
@@ -166,11 +166,13 @@ public class BlockingMode {
 
     private static Set<String> loadExcludedApps(Context c) {
         Set<String> apps = new HashSet<>();
-        try (InputStream is = c.getAssets().open("ddg-excluded-apps.json")) {
+        try (DataInputStream is = new DataInputStream(
+                c.getAssets().open("ddg-excluded-apps.json"))) {
             int size = is.available();
             byte[] buffer = new byte[size];
-            if (is.read(buffer) <= 0)
+            if (size <= 0)
                 throw new IOException("No bytes read.");
+            is.readFully(buffer);
 
             String json = new String(buffer, StandardCharsets.UTF_8);
             apps.addAll(BlockingModeLogic.parseExcludedAppsJson(json));
@@ -184,11 +186,13 @@ public class BlockingMode {
 
     private static Set<String> loadBrowserApps(Context c) {
         Set<String> apps = new HashSet<>();
-        try (InputStream is = c.getAssets().open("ddg-excluded-apps.json")) {
+        try (DataInputStream is = new DataInputStream(
+                c.getAssets().open("ddg-excluded-apps.json"))) {
             int size = is.available();
             byte[] buffer = new byte[size];
-            if (is.read(buffer) <= 0)
+            if (size <= 0)
                 throw new IOException("No bytes read.");
+            is.readFully(buffer);
 
             String json = new String(buffer, StandardCharsets.UTF_8);
             apps.addAll(BlockingModeLogic.parseBrowserAppsJson(json));

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -32,6 +32,7 @@ import androidx.preference.PreferenceManager;
 
 import eu.faircode.netguard.DatabaseHelper;
 
+import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -582,11 +583,13 @@ public class TrackerList {
          * More here:
          * https://github.com/TrackerControl/tracker-control-android/issues/30
          */
-        try (InputStream is = c.getAssets().open("disconnect-blacklist.reversed.json")) {
+        try (DataInputStream is = new DataInputStream(
+                c.getAssets().open("disconnect-blacklist.reversed.json"))) {
             int size = is.available();
             byte[] buffer = new byte[size];
-            if (is.read(buffer) <= 0)
+            if (size <= 0)
                 throw new IOException("No bytes read.");
+            is.readFully(buffer);
 
             String reversedJson = new String(buffer, StandardCharsets.UTF_8);
             String json = new StringBuilder(reversedJson).reverse().toString();

--- a/app/src/test/java/eu/faircode/netguard/HostsBlocklistLogicTest.java
+++ b/app/src/test/java/eu/faircode/netguard/HostsBlocklistLogicTest.java
@@ -1,0 +1,70 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HostsBlocklistLogicTest {
+    @Test
+    public void failedParseDoesNotPinPartialMapAtNewMtime() throws Exception {
+        Map<String, Boolean> hosts = new HashMap<>();
+        HostsBlocklistLogic.State state = new HostsBlocklistLogic.State(hosts, 10L);
+
+        try {
+            state.load(new FailingReader(), 20L);
+            fail("Expected the parse to fail");
+        } catch (IOException expected) {
+            // The partial entry remains, matching the service's failure behavior.
+        }
+
+        assertEquals(10L, state.getLastModified());
+        assertTrue(state.shouldReload(20L));
+        assertTrue(hosts.containsKey("first.example"));
+
+        assertTrue(state.load(new StringReader(
+                "1.1.1.1 first.example\n2.2.2.2 second.example\n"), 20L));
+        assertEquals(20L, state.getLastModified());
+        assertEquals(3, hosts.size());
+        assertTrue(hosts.containsKey("first.example"));
+        assertTrue(hosts.containsKey("second.example"));
+        assertTrue(hosts.containsKey("test.netguard.me"));
+
+        assertFalse(state.load(new FailingReader(), 20L));
+        assertEquals(20L, state.getLastModified());
+        assertEquals(3, hosts.size());
+    }
+
+    private static final class FailingReader extends Reader {
+        private final String firstLine = "1.1.1.1 first.example\n";
+        private int position;
+        private boolean failed;
+
+        @Override
+        public int read(char[] cbuf, int off, int len) throws IOException {
+            if (failed)
+                throw new IOException("mid-parse");
+            if (position == firstLine.length()) {
+                failed = true;
+                throw new IOException("mid-parse");
+            }
+
+            int count = Math.min(len, firstLine.length() - position);
+            firstLine.getChars(position, position + count, cbuf, off);
+            position += count;
+            return count;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
Two confirmed silent-degradation defects in the Java-side blocklist loading path.

## Defect 1 — asset loads assume a single `read(byte[])` fills the buffer

- `app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java:585-588` (`loadDisconnectTrackers`)
- `app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java:168-172` (`loadExcludedApps`)
- `app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java:187-191` (`loadBrowserApps`)

Each sizes a buffer from `is.available()` and then calls `is.read(buffer)` once, treating any positive return as a full read. `InputStream.read(byte[])` may legally return fewer bytes. These assets are deflate-compressed — there is no `noCompress` entry for them in `app/build.gradle` — so the contract violation is real; it does not bite today only because Android's `StreamingZipInflater` happens to loop internally. A short read would feed truncated bytes straight into JSON parsing: a partial Disconnect list (detection quietly degrades) or empty minimal-mode exclusions / browser classification, with only a log line.

Fixed by wrapping the asset stream in `DataInputStream` and using `readFully()`. `EOFException` is an `IOException`, so the existing catch/log behaviour is unchanged.

## Defect 2 — hosts-file mtime stamped before the parse succeeds

`app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java:2151` (`prepareHostsBlocked`) set `last_hosts_modified = hosts.lastModified()` **before** the parse loop, and an `IOException` mid-parse is swallowed by the `catch` at `:2179`. The early return at `:2146-2149` (`!changed && mapHostsBlocked.size() > 0`) then short-circuits every later call.

**Accurate impact** — narrower than issue #762 states: the other early return at `:2140` is guarded by `mapHostsBlocked.size() > 0`, so a *total* failure (map ends up empty) does still retry. Only a **partial** parse gets pinned: the map keeps whatever prefix was read until the file's mtime changes again.

Fixed by reading the mtime once before opening the reader and committing it to `last_hosts_modified` only after the parse loop completes without throwing. On failure the field keeps its previous value, so the next call re-reads.

The parse loop and the reload/commit state machine move into a small pure helper, `eu.faircode.netguard.HostsBlocklistLogic`, following the existing `NetworkReloadPolicy` / `VpnRevokePolicy` / `BlockingModeLogic` pattern in this repo, so the retry behaviour is unit-testable. Parsing behaviour is byte-for-byte identical: `#` comment stripping, 2-word line validation, `Locale.ROOT` lowercase keying, the `test.netguard.me` entry, and the same log lines.

## Deliberately excluded

Issue #762 parts **(b)** (a deleted `hosts.txt` keeps stale entries) and **(c)** (a missing file silently restores the bundled ~90k-domain StevenBlack asset) are **not** addressed here. Both change fresh-install and post-deletion defaults, which is a product decision that has not been made — whether a missing file should be treated as authoritative-empty, and whether the bundled fallback should be surfaced to the user. They need their own PR once that call is made.

## Test evidence

New `app/src/test/java/eu/faircode/netguard/HostsBlocklistLogicTest.java` drives a `Reader` that throws `IOException` after the first line and asserts:

1. after the mid-parse failure the recorded mtime is **unchanged**, and `shouldReload(sameMtime)` is still true — the partial map is not pinned;
2. a following successful parse at the *same* mtime repopulates the map fully and *then* commits the mtime;
3. a successful parse followed by an unchanged mtime still short-circuits — no regression of the existing skip.

Assertion (1) fails against the pre-fix ordering.

```
$ ./gradlew :app:compileGithubDebugJavaWithJavac -q
Note: [1] Wrote GeneratedAppGlideModule with: []
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
# exit 0

$ ./gradlew :app:testGithubDebugUnitTest
BUILD SUCCESSFUL in 36s
# exit 0
```

`TEST-eu.faircode.netguard.HostsBlocklistLogicTest.xml`: `tests="1" skipped="0" failures="0" errors="0"`.

No short-read regression test: the three call sites read directly from `AssetManager` with no injectable seam, and adding one purely for this would mean widening the API surface for a test.

## Merge notes

`ServiceSinkhole.java` is also touched by open PRs #752 and #768, in `getBuilder` (~:1762), `LogHandler` (~:945) and `onCreate`/`onDestroy` (~:3209/:3691). This change stays inside `prepareHostsBlocked` (~:2132-2170), plus dropping the now-unused `java.util.Locale` import.

Fixes #758
Partially addresses #762 (part (a) only).
