### PR TITLE
Count an oversized DoH body as a failed attempt (#760)

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -251,12 +251,19 @@ public class DnsOverHttpsClient {
                     long contentLength = responseBody.contentLength();
                     if (contentLength > MAX_DOH_RESPONSE_BYTES) {
                         Log.w(TAG, "DoH response too large: " + contentLength + " bytes");
+                        // An oversized body is a wasted attempt like any other unusable
+                        // response. Leaving it uncounted made the query worth a single
+                        // failure however many attempts it burned, so an endpoint
+                        // spraying junk took ten whole queries to trip the breaker
+                        // while every other failure mode took three.
+                        reportFailedAttempt(onFailedAttempt);
                         continue;
                     }
 
                     byte[] dnsResponse = response.peekBody(MAX_DOH_RESPONSE_BYTES + 1L).bytes();
                     if (dnsResponse.length > MAX_DOH_RESPONSE_BYTES) {
                         Log.w(TAG, "DoH response too large: " + dnsResponse.length + " bytes");
+                        reportFailedAttempt(onFailedAttempt);
                         continue;
                     }
                     if (dnsResponse.length < 12) {

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -204,6 +204,37 @@ public class DnsOverHttpsClientTest {
         assertEquals(0, failures.get());
     }
 
+    /**
+     * An oversized body is a wasted attempt and must be reported, so that an
+     * endpoint spraying junk trips the circuit breaker at the same rate as any
+     * other failing one — see issue #760.
+     */
+    @Test
+    public void resolveReportsOversizedDnsResponseAsFailedAttempt() {
+        server.enqueue(dnsResponse(200, responseOfLength(65536)));
+        server.enqueue(dnsResponse(200, responseOfLength(65536)));
+        server.enqueue(dnsResponse(200, responseOfLength(65536)));
+
+        AtomicInteger failures = new AtomicInteger(0);
+        assertNull(client().resolve(QUERY, failures::incrementAndGet));
+
+        assertEquals(3, failures.get());
+        assertEquals(3, server.getRequestCount());
+    }
+
+    /** The chunked path (no declared Content-Length) reports the same way. */
+    @Test
+    public void resolveReportsOversizedChunkedResponseThenRecovers() {
+        server.enqueue(chunkedDnsResponse(200, responseOfLength(65536)));
+        server.enqueue(dnsResponse(200, RESPONSE));
+
+        AtomicInteger failures = new AtomicInteger(0);
+        assertArrayEquals(RESPONSE, client().resolve(QUERY, failures::incrementAndGet));
+
+        assertEquals(1, failures.get());
+        assertEquals(2, server.getRequestCount());
+    }
+
     @Test
     public void resolveRejectsOversizedDnsResponse() {
         DnsOverHttpsClient.setScreenOff(true);


### PR DESCRIPTION
Closes #760.

`DnsOverHttpsClient.resolve()` reports every unusable response through
`reportFailedAttempt()` before retrying — a 5xx, a null body, a sub-12-byte
answer, a non-cancelled `IOException`. The two oversized-body branches added by
#771 were the exception: they `continue` without reporting.

`DnsProxyServer` charges a failed query `Math.max(1, queryFailedAttempts.get())`,
so this was not "never trips the breaker" — the floor of 1 still applies. But it
did mean an endpoint returning nothing but oversized bodies cost **one** failure
per query however many attempts it burned, so it took ten whole queries to reach
`CIRCUIT_BREAKER_THRESHOLD` where every other failure mode takes three. That is
exactly the per-attempt accounting #768 introduced, applied to the one path that
missed it.

Two lines, plus regression coverage for both the declared-`Content-Length` and
the chunked path (the latter is only caught after `peekBody`, so it needs its own
test).

### What is *not* changed

The other half of #760 — `dohFailures.set(0)` on any success — is left alone
deliberately. #768 made each wasted attempt count, so a flapping endpoint now
trips after ~3–4 bad queries rather than needing ten consecutive clean failures,
which defuses the original report. Resetting on success is the fail-open
behaviour we want for a DNS path that must not stay broken.

### Verification

- `./gradlew :app:testGithubDebugUnitTest --tests '…DnsOverHttpsClientTest'` — 24 tests, 0 failures.
- Negative control: with the source change reverted and the tests kept, exactly
  the two new tests fail (`expected:<3> but was:<0>` and `expected:<1> but was:<0>`)
  and no others — so they test the fix rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
