### PR TITLE
Align the UI's shared-IP view with the runtime blocking decision (#759)

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -1189,7 +1189,18 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
     }
 
-    public Cursor getQAName(int uid, String ip, boolean alive) {
+    /**
+     * DNS evidence for an IP, freshest qname first, one row per qname.
+     *
+     * <p>Expired rows are always excluded. Both callers — the runtime
+     * blocking decision in {@code blockKnownTracker()} and the UI
+     * classification in {@code ServiceSinkhole.log()} — must answer "is this
+     * IP shared, and whose is it?" from the same row set. When the UI alone
+     * saw the full history (see issue #759), it drew the shared-IP marker and
+     * the ALLOWED/BLOCKED text from evidence the blocker had already
+     * discarded, so the log contradicted what actually happened.
+     */
+    public Cursor getQAName(int uid, String ip) {
         long now = new Date().getTime();
         lock.readLock().lock();
         try {
@@ -1197,9 +1208,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 readableDb = this.getReadableDatabase();
             SQLiteDatabase db = readableDb;
             String escapedIp = ip.replace("'", "''");
-            String aliveFilter = alive
-                    ? " AND (d.time IS NULL OR d.time + d.ttl >= " + now + ")"
-                    : "";
+            String aliveFilter = " AND (d.time IS NULL OR d.time + d.ttl >= " + now + ")";
             // There is a segmented index on resource. A shared IP can carry
             // DNS evidence for several qnames; keep only the most recently
             // observed row per qname (dedup) and order qnames by recency, so

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -999,7 +999,7 @@ public class ServiceSinkhole extends VpnService {
 
             int uncertain = DatabaseHelper.ACCESS_UNCERTAIN_NONE;
             boolean isTracker = false;
-            try (Cursor lookup = dh.getQAName(packet.uid, packet.daddr, false)) {
+            try (Cursor lookup = dh.getQAName(packet.uid, packet.daddr)) {
                 uncertain = (lookup != null
                         && lookup.getCount() > 1) ? DatabaseHelper.ACCESS_UNCERTAIN_SHARED_IP
                                 : DatabaseHelper.ACCESS_UNCERTAIN_NONE;
@@ -2697,7 +2697,7 @@ public class ServiceSinkhole extends VpnService {
                 boolean sawFirstRow = false;
                 boolean sawTrackerEvidence = false;
                 boolean sawNonTrackerEvidence = false;
-                try (Cursor lookup = dh.getQAName(uid, daddr, true)) {
+                try (Cursor lookup = dh.getQAName(uid, daddr)) {
                     // Loop through all fresh DNS candidates for this IP and only fail closed
                     // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
                     if (lookup != null) {

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
@@ -20,6 +20,8 @@ import org.robolectric.RuntimeEnvironment;
 @RunWith(RobolectricTestRunner.class)
 public class DatabaseHelperDnsAttributionTest {
 
+    private static final long NOW = System.currentTimeMillis();
+
     @Test
     public void mostRecentlyObservedQnameIsReturnedFirst() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
@@ -27,10 +29,10 @@ public class DatabaseHelperDnsAttributionTest {
 
         String ip = "203.0.113.10";
         // Alphabetically "aaa..." would sort first, but "zzz..." was resolved later.
-        dh.insertDns(rr(1_000L, "aaa-old.example.com", "aaa-old.example.com", ip, 3600));
-        dh.insertDns(rr(2_000L, "zzz-new.example.com", "zzz-new.example.com", ip, 3600));
+        dh.insertDns(rr(NOW - 2_000L, "aaa-old.example.com", "aaa-old.example.com", ip, 3600));
+        dh.insertDns(rr(NOW - 1_000L, "zzz-new.example.com", "zzz-new.example.com", ip, 3600));
 
-        try (Cursor c = dh.getQAName(-1, ip, false)) {
+        try (Cursor c = dh.getQAName(-1, ip)) {
             assertEquals(2, c.getCount());
             assertTrue(c.moveToFirst());
             assertEquals("zzz-new.example.com", c.getString(c.getColumnIndexOrThrow("qname")));
@@ -46,16 +48,16 @@ public class DatabaseHelperDnsAttributionTest {
 
         String ip = "203.0.113.20";
         // Same qname, two distinct CNAME targets observed at different times.
-        dh.insertDns(rr(1_000L, "tracker.example.com", "old-cname.example.com", ip, 3600));
-        dh.insertDns(rr(5_000L, "tracker.example.com", "new-cname.example.com", ip, 3600));
+        dh.insertDns(rr(NOW - 5_000L, "tracker.example.com", "old-cname.example.com", ip, 3600));
+        dh.insertDns(rr(NOW - 1_000L, "tracker.example.com", "new-cname.example.com", ip, 3600));
 
-        try (Cursor c = dh.getQAName(-1, ip, false)) {
+        try (Cursor c = dh.getQAName(-1, ip)) {
             assertEquals("duplicate rows for the same qname must collapse to one", 1, c.getCount());
             assertTrue(c.moveToFirst());
             assertEquals("tracker.example.com", c.getString(c.getColumnIndexOrThrow("qname")));
             assertEquals("the freshest row's aname should win",
                     "new-cname.example.com", c.getString(c.getColumnIndexOrThrow("aname")));
-            assertEquals(5_000L, c.getLong(c.getColumnIndexOrThrow("time")));
+            assertEquals(NOW - 1_000L, c.getLong(c.getColumnIndexOrThrow("time")));
         }
     }
 
@@ -65,15 +67,15 @@ public class DatabaseHelperDnsAttributionTest {
         dh.clearDns();
 
         String ip = "203.0.113.25";
-        dh.insertDns(rr(1_000L, "Graph.Facebook.Com", "Alias.Example.Com", ip, 3600));
-        dh.insertDns(rr(5_000L, "graph.facebook.com", "alias.example.com", ip, 3600));
+        dh.insertDns(rr(NOW - 5_000L, "Graph.Facebook.Com", "Alias.Example.Com", ip, 3600));
+        dh.insertDns(rr(NOW - 1_000L, "graph.facebook.com", "alias.example.com", ip, 3600));
 
-        try (Cursor c = dh.getQAName(-1, ip, false)) {
+        try (Cursor c = dh.getQAName(-1, ip)) {
             assertEquals("case variants must share one stored qname", 1, c.getCount());
             assertTrue(c.moveToFirst());
             assertEquals("graph.facebook.com", c.getString(c.getColumnIndexOrThrow("qname")));
             assertEquals("alias.example.com", c.getString(c.getColumnIndexOrThrow("aname")));
-            assertEquals(5_000L, c.getLong(c.getColumnIndexOrThrow("time")));
+            assertEquals(NOW - 1_000L, c.getLong(c.getColumnIndexOrThrow("time")));
         }
     }
 
@@ -84,7 +86,7 @@ public class DatabaseHelperDnsAttributionTest {
 
         String ip = "203.0.113.30";
         // The freshest observation has already expired; an older one is still
-        // alive. With alive=true the expired row must not shadow the alive one.
+        // alive. The expired row must not shadow the alive one.
         // Rows are inserted directly because insertDns() clamps the TTL to the
         // "ttl" preference floor, which would keep the fresh row alive.
         long now = System.currentTimeMillis();
@@ -97,10 +99,42 @@ public class DatabaseHelperDnsAttributionTest {
                         + (now - 5_000) + ", 't2.example.com', 'expired-cname.example.com', '"
                         + ip + "', 1000)");
 
-        try (Cursor c = dh.getQAName(-1, ip, true)) {
+        try (Cursor c = dh.getQAName(-1, ip)) {
             assertEquals(1, c.getCount());
             assertTrue(c.moveToFirst());
             assertEquals("alive-cname.example.com", c.getString(c.getColumnIndexOrThrow("aname")));
+        }
+    }
+
+    /**
+     * Issue #759: an expired qname must not make an IP look shared. The UI
+     * derived its shared-IP marker from a row set that still contained
+     * expired evidence while the blocker had already dropped it, so the log
+     * flagged an ambiguity the blocking decision never saw.
+     */
+    @Test
+    public void expiredQnameDoesNotMakeIpLookShared() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        String ip = "203.0.113.40";
+        // Two different qnames on one IP, but only one is still alive. Rows are
+        // inserted directly because insertDns() clamps the TTL to the "ttl"
+        // preference floor, which would keep the expired one alive.
+        long now = System.currentTimeMillis();
+        dh.getWritableDatabase().execSQL(
+                "INSERT INTO dns (time, qname, aname, resource, ttl) VALUES ("
+                        + (now - 10_000) + ", 'alive.example.com', 'alive.example.com', '"
+                        + ip + "', 3600000)");
+        dh.getWritableDatabase().execSQL(
+                "INSERT INTO dns (time, qname, aname, resource, ttl) VALUES ("
+                        + (now - 5_000) + ", 'expired.example.com', 'expired.example.com', '"
+                        + ip + "', 1000)");
+
+        try (Cursor c = dh.getQAName(-1, ip)) {
+            assertEquals("an expired qname must not count towards shared-IP", 1, c.getCount());
+            assertTrue(c.moveToFirst());
+            assertEquals("alive.example.com", c.getString(c.getColumnIndexOrThrow("qname")));
         }
     }
 


### PR DESCRIPTION
Closes #759. Implements **option 1** from the triage: the runtime stays alive-only and the UI aligns to it.

`ServiceSinkhole.log()` called `getQAName(uid, daddr, false)` — full DNS history — while `blockKnownTracker()` called it with `true`, which applies the alive-row filter. Both are asking the same question ("is this IP shared, and whose is it?") and were answering it from different row sets, so the `*` shared-IP marker and the ALLOWED/BLOCKED text could disagree with what the blocker actually did.

### Why this direction

Aligning the UI to the runtime keeps the log truthful about the decision that was actually taken, and leaves blocking strength untouched. The alternative — widening the runtime to full history — would treat more IPs as shared and therefore let *more* tracker traffic through to avoid collateral breakage. That is the wrong direction for a tracker blocker, and it would have been a silent weakening rather than a fix.

It also removes an inconsistency inside the UI itself: `getAccessDns()`, which backs the access list, is already unconditionally alive-filtered. `log()` was the outlier.

### The parameter is gone

With both call sites passing the same value, `boolean alive` is dead configurability of exactly the kind that produced this bug, so it is dropped and the filter is unconditional. That makes the divergence impossible to reintroduce.

### Behaviour change worth naming

When *every* DNS row for an IP has expired, `log()` now records no dname instead of a stale one, so that entry shows the raw IP. This is the intended consequence — the blocker saw nothing either — and the window is narrow: `insertDns` floors TTLs at the `ttl` preference (3 days) and `cleanupDns()` deletes expired rows every 12h, so "expired but not yet cleaned" is at most a 12h tail on a ≥3-day record, and any IP still being contacted has been re-resolved.

### Deliberately out of scope

Two nearby lookups still read full history. Both are per-qname questions rather than shared-IP judgements, so they are left alone rather than folded in silently:

- `getDecloakedTracker(qname, dh)` → `getAName(qname, false)`, reached only from the opt-in SNI research branch.
- `usage()` → `getQName(uid, daddr)`, reached only when the non-default `track_usage` is on.

### Verification

- Full JVM suite: **280 tests, 0 failures** across 40 suites.
- New regression test `expiredQnameDoesNotMakeIpLookShared`: an IP with one alive and one expired qname must yield one row, so it cannot be marked shared.
- Negative control — with the alive filter forced back to `""` and the tests unchanged, exactly two fail: the new test with `expected:<1> but was:<2>` (the spurious shared-IP marker itself) and `aliveFilterAppliesBeforeDedup`. The three pure dedup/ordering tests pass either way, as they should.

The three pre-existing dedup tests moved from 1970-epoch timestamps to now-relative ones, since the filter is no longer optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
