### PR TITLE
Document the fragmented-traffic drop on the direct path (#779)

### DIFF
--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -69,3 +69,15 @@ which drives future block decisions recorded in `DatabaseHelper`.
 onboarding); *Standard* loads Disconnect + X-Ray + DDG and **allows** ambiguous
 shared-IP hosts; *Strict* **blocks** those ambiguous shared-IP hosts. Shared-IP
 ambiguity + UID-global DNS evidence is the root of a whole cluster of reports.
+
+## Known limitations (deliberate)
+
+* **Fragmented traffic is dropped on the direct path.** IPv4 packets with
+  `IP_MF` set (first fragments included) drop up front; IPv6 packets whose
+  extension-header chain stops at a Fragment (44) or ESP (50) header never
+  reach an L4 dispatch branch, so they drop too -- even when the destination
+  would be allowed. No reassembly engine, on purpose: memory/battery cost
+  outweighs traffic PMTUD keeps rare. IPv4 fragments drop before the
+  WireGuard hijack as well, while IPv6 fragmented flows pass through when
+  WireGuard-routed (raw forward). ESP stays a permanent limitation.
+  See issue #779.

--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -73,7 +73,8 @@ ambiguity + UID-global DNS evidence is the root of a whole cluster of reports.
 ## Known limitations (deliberate)
 
 * **Fragmented traffic is dropped on the direct path.** IPv4 packets with
-  `IP_MF` set (first fragments included) drop up front; IPv6 packets whose
+  `IP_MF` set or a non-zero fragment offset (first, middle and last
+  fragments alike) drop up front; IPv6 packets whose
   extension-header chain stops at a Fragment (44) or ESP (50) header never
   reach an L4 dispatch branch, so they drop too -- even when the destination
   would be allowed. No reassembly engine, on purpose: memory/battery cost

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -29,6 +29,8 @@ extern _Atomic int wg_required;
 
 static atomic_long wg_drop_count = 0;
 static atomic_long wg_gap_drop_count = 0;
+static atomic_long undispatchable_drop_count = 0;
+static atomic_long undispatchable_log_count = 0;
 
 // Skip tunneling for addresses WireGuard cannot meaningfully forward
 // (multicast, link-local, loopback). Apps targeting these wouldn't gain
@@ -309,16 +311,20 @@ void handle_ip(const struct arguments *args,
         saddr = &ip4hdr->saddr;
         daddr = &ip4hdr->daddr;
 
-        // Deliberate: every IPv4 fragment (IP_MF set, first fragments
-        // included) is dropped on the direct path -- the L4 state machines
-        // have no reassembly, and a non-first fragment has no header they
-        // could parse. This return also fires before the WireGuard hijack
+        uint16_t frag_off = ntohs(ip4hdr->frag_off);
+
+        // Deliberate: every IPv4 fragment -- MF set or a non-zero offset,
+        // so first, middle and last alike -- is dropped on the direct path.
+        // The L4 state machines have no reassembly, and a non-first
+        // fragment has no header they could parse. This return also fires before the WireGuard hijack
         // below, so unlike IPv6 fragments, IPv4 ones die even when
         // WireGuard-routed. Same standing limitation as the IPv6
-        // Fragment/ESP stop further down; see issue #779.
-        if (ip4hdr->frag_off & IP_MF) {
-            log_android(ANDROID_LOG_ERROR, "IP fragment offset %u",
-                        (ip4hdr->frag_off & IP_OFFMASK) * 8);
+        // Fragment/ESP stop further down; see issue #779. The ntohs above
+        // is load-bearing: frag_off is network byte order but IP_MF and
+        // IP_OFFMASK are host-order constants; don't simplify it away.
+        if ((frag_off & IP_MF) || (frag_off & IP_OFFMASK)) {
+            log_android(ANDROID_LOG_ERROR, "IP fragment MF %d offset %u",
+                        (frag_off & IP_MF) != 0, (frag_off & IP_OFFMASK) * 8);
             return;
         }
 
@@ -741,10 +747,26 @@ void handle_ip(const struct arguments *args,
         else {
             // Allowed but undispatchable: no L4 handler for this protocol
             // (in practice a Fragment/ESP-stopped ext-header walk, see
-            // above). Drop visibly rather than vanish silently.
-            log_android(ANDROID_LOG_WARN,
-                        "Protocol %d allowed but not forwardable, dropping",
-                        protocol);
+            // above). Drop visibly rather than vanish silently, but
+            // rate-limit: a single ESP/IPsec flow can hit this every
+            // packet and would otherwise spam logcat.
+            long drops = atomic_fetch_add_explicit(
+                    &undispatchable_drop_count, 1, memory_order_relaxed) + 1;
+            // HOPOPTS/IGMP/ESP are exempted from the log here too, mirroring
+            // the "Unknown protocol" exemption above -- still counted so the
+            // running total stays honest, just never logged. The throttle
+            // runs off its own counter: sharing one with the exempt
+            // protocols would let a steady ESP flow eat every slot and
+            // silence the protocols worth seeing.
+            if (protocol != IPPROTO_HOPOPTS && protocol != IPPROTO_IGMP &&
+                protocol != IPPROTO_ESP) {
+                long logged = atomic_fetch_add_explicit(
+                        &undispatchable_log_count, 1, memory_order_relaxed) + 1;
+                if ((logged & 1023L) == 1)
+                    log_android(ANDROID_LOG_WARN,
+                                "Protocol %d allowed but not forwardable, dropped %ld packets (%ld total)",
+                                protocol, logged, drops);
+            }
         }
     } else {
         if (protocol == IPPROTO_UDP)

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -309,6 +309,13 @@ void handle_ip(const struct arguments *args,
         saddr = &ip4hdr->saddr;
         daddr = &ip4hdr->daddr;
 
+        // Deliberate: every IPv4 fragment (IP_MF set, first fragments
+        // included) is dropped on the direct path -- the L4 state machines
+        // have no reassembly, and a non-first fragment has no header they
+        // could parse. This return also fires before the WireGuard hijack
+        // below, so unlike IPv6 fragments, IPv4 ones die even when
+        // WireGuard-routed. Same standing limitation as the IPv6
+        // Fragment/ESP stop further down; see issue #779.
         if (ip4hdr->frag_off & IP_MF) {
             log_android(ANDROID_LOG_ERROR, "IP fragment offset %u",
                         (ip4hdr->frag_off & IP_OFFMASK) * 8);
@@ -350,6 +357,17 @@ void handle_ip(const struct arguments *args,
         size_t payload_off;
         if (!ip6_skip_ext_headers(pkt, length, &protocol, &payload_off))
             log_android(ANDROID_LOG_WARN, "IP6 extension %d not walkable", protocol);
+
+        // A stopped walk leaves protocol at the stopping header type --
+        // Fragment (44) or ESP (50) in practice -- which matches none of
+        // the dispatch branches below. On the direct path such a packet is
+        // therefore dropped even when the destination passes the allow
+        // check: there is no L4 header to parse, no session to attach to,
+        // and no raw-forward path in this userspace stack. WireGuard-routed
+        // flows are unaffected: the WG hijack below forwards them raw
+        // before dispatch. Fragment reassembly was considered and rejected
+        // (memory and battery cost against traffic PMTUD keeps rare); ESP
+        // stays a documented limitation permanently. See issue #779.
 
         saddr = &ip6hdr->ip6_src;
         daddr = &ip6hdr->ip6_dst;
@@ -720,6 +738,14 @@ void handle_ip(const struct arguments *args,
             handle_udp(args, pkt, length, payload, uid, redirect, epoll_fd);
         else if (protocol == IPPROTO_TCP)
             handle_tcp(args, pkt, length, payload, uid, allowed, redirect, epoll_fd);
+        else {
+            // Allowed but undispatchable: no L4 handler for this protocol
+            // (in practice a Fragment/ESP-stopped ext-header walk, see
+            // above). Drop visibly rather than vanish silently.
+            log_android(ANDROID_LOG_WARN,
+                        "Protocol %d allowed but not forwardable, dropping",
+                        protocol);
+        }
     } else {
         if (protocol == IPPROTO_UDP)
             block_udp(args, pkt, length, payload, uid);

--- a/app/src/main/jni/netguard/ip6_ext.h
+++ b/app/src/main/jni/netguard/ip6_ext.h
@@ -74,7 +74,8 @@ extern "C" {
  *       - Fragment (44): ip6e_len is a reserved field for this header,
  *         not a length, so it cannot be walked; the packet may also not
  *         be first-fragment, so there may be no upper-layer header here
- *         at all.
+ *         at all. The resulting direct-path drop of fragmented flows is
+ *         a documented limitation (issue #779).
  *       - ESP (50): the payload is encrypted; nothing after it is
  *         parseable in plaintext.
  *       - An unrecognised/non-walkable next-header value.


### PR DESCRIPTION
Closes #779.

Implements the issue's **option B**: fragmented traffic keeps being dropped on the direct path, and the limitation becomes stated, deliberate, and observable rather than silent.

## Decision rationale

- **Option A (reassembly)** rejected: per-packet fragment buffers are a memory + battery cost for state that legitimate traffic rarely produces — PMTUD keeps most flows unfragmented. This is exactly the trade the standing constraints rule out.
- **Option C (dispatch first fragments only)** rejected as in the issue: continuations carry no L4 header, so sessions strand half-open.
- **ESP** stays a documented limitation permanently (stated in code comment and docs).

## What changed

- `ip.c`:
  - Comment at the IPv4 `IP_MF` guard documenting that first fragments are dropped deliberately, that this fires *before* the WireGuard hijack (unlike IPv6 fragments), and why reassembly was rejected.
  - Comment at the ext-header walk call site explaining what a Fragment(44)/ESP(50)-stopped walk means downstream: no L4 dispatch branch matches, so an allowed packet is dropped on the direct path; WG-routed flows pass through raw before dispatch.
  - New trailing `else` on the L4 dispatch chain: a previously silent blackhole now logs `Protocol %d allowed but not forwardable, dropping` at WARN — one logcat line per affected packet, no DB writes.
- `ip6_ext.h`: the Fragment bullet of the walk's contract now cross-references #779.
- `agents/docs/codebase-map.md`: new "Known limitations (deliberate)" section covering both families' behavior, the IPv4-before-WG-hijack asymmetry, and the ESP decision.

## Verification

- NDK clang (`ndk;27.2.12479018`, aarch64-linux-android24) `-fsyntax-only -Wall -Wextra` over `ip.c`: clean; all warnings pre-existing, none in changed regions.
- Host tests with `-Wall -Wextra -Werror`: `ip6_ext_test` and `dns_frame_test` both pass.
- No Java/Kotlin touched; behavior change limited to the one new WARN log line on the previously silent drop path.