### PR TITLE
Let a user-initiated start clear the background-user flag

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -236,7 +236,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
         if (!getIntent().hasExtra(EXTRA_APPROVE)) {
             if (enabled)
-                ServiceSinkhole.start("UI", this);
+                ServiceSinkhole.start("UI", this, true);
             else
                 ServiceSinkhole.stop("UI", this, false);
         }
@@ -692,7 +692,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 PendingIntent pi = PendingIntentCompat.getBroadcast(this, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
                 am.cancel(pi);
 
-                ServiceSinkhole.start("prepared", this);
+                ServiceSinkhole.start("prepared", this, true);
             } else if (resultCode == RESULT_CANCELED)
                 Toast.makeText(this, R.string.msg_vpn_cancelled, Toast.LENGTH_LONG).show();
 

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -273,6 +273,7 @@ public class ServiceSinkhole extends VpnService {
     public static final String EXTRA_BLOCKED = "Blocked";
     public static final String EXTRA_INTERACTIVE = "Interactive";
     public static final String EXTRA_TEMPORARY = "Temporary";
+    private static final String EXTRA_USER_INITIATED = "UserInitiated";
 
     private static final int MSG_STATS_START = 1;
     private static final int MSG_STATS_STOP = 2;
@@ -469,8 +470,15 @@ public class ServiceSinkhole extends VpnService {
             // Check if foreground
             if (cmd != Command.stop)
                 if (!user_foreground) {
-                    Log.i(TAG, "Command " + cmd + " ignored for background user");
-                    return;
+                    if (cmd == Command.start && intent.getBooleanExtra(EXTRA_USER_INITIATED, false)) {
+                        // The user reached our UI in this profile, so it is in the foreground
+                        // regardless of whether a matching ACTION_USER_FOREGROUND ever arrived.
+                        user_foreground = true;
+                        Log.i(TAG, "User-initiated start, clearing background user state");
+                    } else {
+                        Log.i(TAG, "Command " + cmd + " ignored for background user");
+                        return;
+                    }
                 }
 
             // Handle temporary stop
@@ -4374,9 +4382,15 @@ public class ServiceSinkhole extends VpnService {
     }
 
     public static void start(String reason, Context context) {
+        start(reason, context, false);
+    }
+
+    public static void start(String reason, Context context, boolean userInitiated) {
         Intent intent = new Intent(context, ServiceSinkhole.class);
         intent.putExtra(EXTRA_COMMAND, Command.start);
         intent.putExtra(EXTRA_REASON, reason);
+        if (userInitiated)
+            intent.putExtra(EXTRA_USER_INITIATED, true);
         try {
             ContextCompat.startForegroundService(context, intent);
         } catch (Throwable ex) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
@@ -85,7 +85,7 @@ public class ServiceTileMain extends TileService implements SharedPreferences.On
         boolean enabled = !prefs.getBoolean("enabled", false);
         prefs.edit().putBoolean("enabled", enabled).apply();
         if (enabled)
-            ServiceSinkhole.start("tile", this);
+            ServiceSinkhole.start("tile", this, true);
         else
             ServiceSinkhole.stop("tile", this, false);
     }

--- a/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
+++ b/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
@@ -75,7 +75,7 @@ public class WidgetAdmin extends ReceiverAutostart {
                 boolean enabled = INTENT_ON.equals(intent.getAction());
                 prefs.edit().putBoolean("enabled", enabled).apply();
                 if (enabled)
-                    ServiceSinkhole.start("widget", context);
+                    ServiceSinkhole.start("widget", context, true);
                 else
                     ServiceSinkhole.stop("widget", context, false);
 

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
@@ -495,7 +495,7 @@ public class ActivityOnboarding extends AppCompatActivity {
                 .apply();
 
         if (vpnPrepared)
-            ServiceSinkhole.start("onboarding", this);
+            ServiceSinkhole.start("onboarding", this, true);
 
         startActivity(new Intent(this, ActivityMain.class));
         finish();


### PR DESCRIPTION
## The problem

`ServiceSinkhole`'s command loop drops **every** command except `stop` while `user_foreground` is false:

```java
if (cmd != Command.stop)
    if (!user_foreground) {
        Log.i(TAG, "Command " + cmd + " ignored for background user");
        return;
    }
```

The flag is inherited from NetGuard's secondary-user handling: `ACTION_USER_BACKGROUND` sets it false, `ACTION_USER_FOREGROUND` sets it true again. That pairing holds for a switched-to secondary user, which genuinely stops being foreground. It is a much weaker assumption for a **managed profile** (Shelter and similar), which runs *alongside* its parent rather than instead of it.

If the flag is ever set without the matching foreground broadcast arriving, the profile's VPN cannot be started again from the UI at all — the main switch, the tile and the widget each queue a `start` that is silently discarded. There is no error, no notification, and nothing in the UI to distinguish it from a start that worked. This matches a report of the VPN flip-flopping in a Shelter work profile on GrapheneOS/A17 and needing a **reboot** to come back, a reboot being exactly what clears a stale in-memory flag.

## The change

A `start` command that originated from a user gesture clears the flag and proceeds, rather than being dropped. Reaching our UI inside a profile is itself evidence that the profile is usable, which is the thing `user_foreground` is trying to approximate.

The marker is set only at genuine user entry points — the main switch, the post-consent start, onboarding, the quick-settings tile, the widget. **Boot, package-replacement and call-state starts deliberately stay subject to the guard**, so the multi-user handoff itself is unchanged; marking `ReceiverAutostart` would have defeated it entirely.

A sticky restart cannot re-clear the flag by accident: `onStartCommand` builds a fresh intent when Android redelivers a null one, so the marker is never carried across a restart.

## Scope — please read before merging

**This deliberately fixes only the unrecoverable half.** The underlying hypothesis — that `ACTION_USER_BACKGROUND` fires for a managed profile without a matching `ACTION_USER_FOREGROUND` — is **not device-validated**. I have no evidence about what those broadcasts actually do for a Shelter profile, only that the code has no recovery if they misbehave.

So this PR does *not* touch the background self-stop, the 3-second handoff sleep, or the broadcast handling. Changing per-user VPN handoff semantics on an untested hypothesis seemed like the wrong trade; making a stuck state recoverable from the UI is defensible on its own, and is a strict improvement even if the multi-user diagnosis turns out to be wrong.

What would settle it: `logcat` from a Shelter profile across a parent-user switch, checking whether `Command start ignored for background user` appears and whether a foreground broadcast follows.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and `:app:lintGithubDebug` all pass.

No new JVM test: the guard sits inside the private command handler with no existing seam to drive it from Robolectric, and adding one would have meant restructuring service lifecycle code well beyond this fix. No device testing.

Branched from `master`, independent of #790 and #791.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er2nZyUjv3AQW9PncoQR5v)_