### PR TITLE
Re-apply horizontal padding on configuration change

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -615,6 +615,19 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
         if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this))
             return;
+
+        int horizontalPadding = getResources().getDimensionPixelSize(
+                R.dimen.activity_horizontal_margin);
+        updateHorizontalPadding(llAppsContent, horizontalPadding);
+        updateHorizontalPadding(findViewById(R.id.tvNotifications), horizontalPadding);
+        updateHorizontalPadding(findViewById(R.id.tvLocalNetwork), horizontalPadding);
+        updateHorizontalPadding(findViewById(R.id.tvPrivateDns), horizontalPadding);
+    }
+
+    private void updateHorizontalPadding(View view, int horizontalPadding) {
+        if (view != null)
+            view.setPaddingRelative(horizontalPadding, view.getPaddingTop(),
+                    horizontalPadding, view.getPaddingBottom());
     }
 
     @Override


### PR DESCRIPTION
Fixes #781.

## The bug

`ActivityMain` declares `android:configChanges="orientation|screenSize"` (`AndroidManifest.xml:82`), so rotation doesn't recreate it. Horizontal padding resolves `@dimen/activity_horizontal_margin` at inflation time — `64dp` under `values-w820dp/dimens.xml`, `0dp` in the base — so views inflated while the window was wide keep the 64dp inset after rotating back to portrait. `onConfigurationChanged` was a no-op for this, and nothing else re-applied it, so only an activity recreation cleared it.

## The change

`onConfigurationChanged` re-reads the dimension and re-applies it. `getResources()` already reflects the new configuration by that point, so the value read is the portrait (or wide) one, not the stale one.

**All four consumers are fixed, not just the reported one.** `main.xml` resolves that dimension in four places — `tvNotifications`, `tvLocalNetwork`, `tvPrivateDns` and `llApps` — and fixing only the apps list would have left the three notice banners inset while the list beneath them was flush, which reads worse than the original bug.

Details worth noting:

- Vertical padding is preserved via `getPaddingTop()`/`getPaddingBottom()`; `llApps` also sets `paddingTop`/`paddingBottom` and `clipToPadding="false"`, and a bare `setPadding(h, 0, h, 0)` would have silently dropped those.
- `setPaddingRelative` rather than `setPadding`, since the layout sets `paddingStart`/`paddingEnd` and RTL must keep working.
- Both directions work: wide → portrait drops to 0dp and portrait → wide gains 64dp, since the value is simply re-resolved each time.
- Placed after the existing `Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this)` guard — in those degraded paths the main layout isn't the one on screen, and the null check covers a configuration change arriving before the fields are assigned.

## Not done here

The issue notes that other activities carrying `configChanges="orientation|screenSize"` may share the latent problem. `resolving.xml`, `logging.xml` and `forwarding.xml` also reference the dimension. I left those alone — no one has reported them, and each needs its own check of which views are reachable. Happy to follow up if you'd like them swept.

The issue also raises that the Apps list is inconsistent with the Timeline tab, which has no inset on wide screens. That's a design question, not this bug: the alternative fix — deleting the padding so the list is full-bleed — would change deliberate tablet appearance, so I took the conservative option.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and `:app:lintGithubDebug` all pass.

**No visual verification** — there's no device or emulator available here, and this is a layout fix, so the thing it changes is exactly the thing I couldn't look at. Worth a rotation test on real hardware before merging. No unit test either: driving `onConfigurationChanged` meaningfully needs a real activity and a configuration change, which is instrumentation territory rather than Robolectric.

Branched from `master`, independent of #790, #791 and #792.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er2nZyUjv3AQW9PncoQR5v)_