### PR TITLE
Say what clearing an app's activity does, and confirm it first

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -69,6 +69,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import eu.faircode.netguard.DatabaseHelper;
+import eu.faircode.netguard.Util;
 
 public class DetailsActivity extends AppCompatActivity {
     public static final String INTENT_EXTRA_APP_PACKAGENAME = "INTENT_APP_PACKAGENAME";
@@ -198,9 +199,16 @@ public class DetailsActivity extends AppCompatActivity {
             startActivityForResult(getIntentCreateExport(), REQUEST_EXPORT);
             return true;
         } else if (itemId == R.id.action_clear) {
-            DatabaseHelper dh = DatabaseHelper.getInstance(this);
-            dh.clearAccess(appUid, false);
-            detailsStateAdapter.updateTrackerLists();
+            Util.areYouSure(this, R.string.msg_clear_activity, new Util.DoubtListener() {
+                @Override
+                public void onSure() {
+                    if (running) {
+                        DatabaseHelper dh = DatabaseHelper.getInstance(DetailsActivity.this);
+                        dh.clearAccess(appUid, false);
+                        detailsStateAdapter.updateTrackerLists();
+                    }
+                }
+            });
             return true;
         } else if (itemId == R.id.action_launch) {
             Intent launch = Common.getLaunchIntent(this, appPackageName);

--- a/app/src/main/res/menu/menu_details.xml
+++ b/app/src/main/res/menu/menu_details.xml
@@ -14,6 +14,6 @@
         app:showAsAction="never" />
     <item
         android:id="@+id/action_clear"
-        android:title="@string/menu_clear"
+        android:title="@string/menu_clear_activity"
         app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="menu_pcap_enabled">PCAP enabled</string>
     <string name="menu_pcap_export">PCAP export</string>
     <string name="menu_clear">Clear</string>
+    <string name="menu_clear_activity">Clear recorded activity</string>
     <string name="menu_export">Export</string>
     <string name="menu_reset">Reset</string>
 
@@ -341,6 +342,7 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="msg_filter4">Android 4 requires filtering to be enabled</string>
     <string name="msg_log_disabled">Traffic logging is disabled, use the switch above to enable logging. Traffic logging might result in extra battery usage.</string>
     <string name="msg_clear_rules">This will reset the rules and conditions to their default values</string>
+    <string name="msg_clear_activity">This removes the recorded activity for this app. Per-tracker block/allow settings for this app are kept.</string>
     <string name="msg_reset_access">This will delete access attempt log lines without allow/block rules</string>
     <string name="msg_import_last">Last import: %s</string>
     <string name="msg_downloading">Downloading…</string>


### PR DESCRIPTION
Fixes #787.

## The problem

The details screen's overflow menu offered a bare **"Clear"** with no confirmation and no explanation. It deletes only the app's recorded activity — `clearAccess(appUid, false)` removes rows from the `access` table, while per-tracker block/allow state lives in a separate SharedPreferences file owned by `TrackerBlocklist` and is never touched by that path.

Nothing in the UI said so. The user in the Telegram group who prompted this asked directly — *"But if I clear it will stay the same what I've allowed and blocked?"* — and couldn't tell. So the one action that fixes an unmanageably long tracker list is the action people avoid, because it looks like it might cost them their configuration.

## The change

- The menu item now reads **"Clear recorded activity"**.
- It goes through `Util.areYouSure`, the same pattern `ActivityDns` already uses for its own clear action (`ActivityDns.java:97`), with the explanation: *"This removes the recorded activity for this app. Per-tracker block/allow settings for this app are kept."*

`clearAccess` and the adapter refresh both moved inside the confirmed branch, so cancelling or dismissing leaves everything untouched. `onOptionsItemSelected` still returns `true` immediately — `areYouSure` is asynchronous and the return value must not wait on it. The callback is guarded by the existing `running` field (onCreate→onDestroy), matching how the export task at `DetailsActivity.java:339` already guards its own late callback.

New strings rather than a reworded `menu_clear`: that string is still used by `dns.xml`, `logging.xml` and `ActivityDns`, and changing it in place would have changed those screens too. Only `values/strings.xml` is touched — translations are handled separately.

## A related thing I did not change

`ActivityDns` passes `R.string.menu_clear` — the word "Clear" — as the *explanation* argument to `areYouSure`, so its confirmation dialog says nothing more than its menu item does. Same weakness this PR fixes, one screen over. Left alone as out of scope; say the word if you want it swept in.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and `:app:lintGithubDebug` all pass.

**No device or emulator here**, so the dialog has not been seen on screen — the wording and layout deserve a look on real hardware. The behavioural claim in the dialog text was verified from the code path rather than by clearing an app and inspecting the preferences file; that's the check worth repeating on a device before this ships, since the text makes a promise to users.

Branched from `master`, independent of #790, #791, #792 and #793.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er2nZyUjv3AQW9PncoQR5v)_