### PR TITLE
Compare metered flag, search domains and excluded routes in Builder.equals

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -4256,10 +4256,13 @@ public class ServiceSinkhole extends VpnService {
         private Network activeNetwork;
         private NetworkInfo networkInfo;
         private int mtu;
+        private boolean metered;
         private List<String> listAddress = new ArrayList<>();
         private List<String> listRoute = new ArrayList<>();
         private List<InetAddress> listDns = new ArrayList<>();
         private List<String> listDisallowed = new ArrayList<>();
+        private List<String> listSearchDomain = new ArrayList<>();
+        private List<IpPrefix> listExcludedRoute = new ArrayList<>();
 
         private Builder() {
             super();
@@ -4272,6 +4275,14 @@ public class ServiceSinkhole extends VpnService {
         public VpnService.Builder setMtu(int mtu) {
             this.mtu = mtu;
             super.setMtu(mtu);
+            return this;
+        }
+
+        @Override
+        @TargetApi(Build.VERSION_CODES.Q)
+        public Builder setMetered(boolean metered) {
+            this.metered = metered;
+            super.setMetered(metered);
             return this;
         }
 
@@ -4303,6 +4314,21 @@ public class ServiceSinkhole extends VpnService {
             return this;
         }
 
+        @Override
+        public Builder addSearchDomain(String domain) {
+            listSearchDomain.add(domain);
+            super.addSearchDomain(domain);
+            return this;
+        }
+
+        @Override
+        @TargetApi(Build.VERSION_CODES.TIRAMISU)
+        public Builder excludeRoute(IpPrefix prefix) {
+            listExcludedRoute.add(prefix);
+            super.excludeRoute(prefix);
+            return this;
+        }
+
         /**
          * Excludes apps, such as system apps if disabled, as well as deactivated apps
          * by user
@@ -4328,11 +4354,17 @@ public class ServiceSinkhole extends VpnService {
             if (!Objects.equals(this.activeNetwork, other.activeNetwork))
                 return false;
 
-            if (this.networkInfo == null || other.networkInfo == null ||
+            if ((this.networkInfo == null) != (other.networkInfo == null))
+                return false;
+
+            if (this.networkInfo != null &&
                     this.networkInfo.getType() != other.networkInfo.getType())
                 return false;
 
             if (this.mtu != other.mtu)
+                return false;
+
+            if (this.metered != other.metered)
                 return false;
 
             if (this.listAddress.size() != other.listAddress.size())
@@ -4345,6 +4377,12 @@ public class ServiceSinkhole extends VpnService {
                 return false;
 
             if (this.listDisallowed.size() != other.listDisallowed.size())
+                return false;
+
+            if (this.listSearchDomain.size() != other.listSearchDomain.size())
+                return false;
+
+            if (this.listExcludedRoute.size() != other.listExcludedRoute.size())
                 return false;
 
             for (String address : this.listAddress)
@@ -4361,6 +4399,14 @@ public class ServiceSinkhole extends VpnService {
 
             for (String pkg : this.listDisallowed)
                 if (!other.listDisallowed.contains(pkg))
+                    return false;
+
+            for (String domain : this.listSearchDomain)
+                if (!other.listSearchDomain.contains(domain))
+                    return false;
+
+            for (IpPrefix prefix : this.listExcludedRoute)
+                if (!other.listExcludedRoute.contains(prefix))
                     return false;
 
             return true;


### PR DESCRIPTION
Fixes #763.

> **Stacked on #791** — this targets `claude/vpn-replacement-retry`, not `master`, per the sequencing your comment on the issue called for. Review #791 first; this diff is the 47 lines on top. Retarget to `master` if #791 is dropped.

## The bug

`Builder` captures what it is given by overriding `setMtu`, `addAddress`, `addRoute`, `addDnsServer` and `addDisallowedApplication` into fields, then compares those fields in `equals` to decide whether the tun must be re-established.

It never overrode `setMetered`, `addSearchDomain` or `excludeRoute`. Those calls passed straight to `super` and were never captured — so `equals` *structurally could not see them*, regardless of how it was written. When only an uncaptured value changed, the builders compared equal, re-establishment was skipped, and the new value never reached the live interface.

Two consequences:

- **Metered flag.** `NetworkReloadPolicy` triggers a reload precisely on a meteredness flip, but with the same `Network` and identical address/route/DNS/disallowed lists the builders compare equal, so only the native restart branch runs and `setMetered` never takes effect. Apps keep seeing the VPN as unmetered over a now-metered network.
- **ePDG exclusions.** These are re-resolved on every rebuild behind a 1.5s timeout. If the first establish timed out and a later rebuild resolves them, `equals` suppressed the re-establish and VoWiFi stayed broken until something unrelated forced a real replacement. This is the more user-visible of the two.

## The change

Capture the three values in the existing style — a field plus an override that records and delegates to `super` — and compare them the same order-insensitive way (`size` then `contains`) the existing lists use.

Also: two null `networkInfo` values now compare **equal**. The old condition returned false whenever either was null, forcing needless replacements while offline. Null vs. non-null still compares unequal.

Not changed, both considered and deliberately rejected: the `(Builder) obj` cast (casting null is legal, and only `Builder` instances are ever compared) and adding a `hashCode` (`Builder` is never used in a hash-based container).

## API safety

`minSdk` is 23, `setMetered` is API 29+ and `excludeRoute` is API 33+. Both call sites are *already* SDK-guarded — `Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q` at the two `setMetered` calls, `>= 33` at the ePDG block — so neither new override is reachable below its API level. `@TargetApi` annotations match the file's existing convention.

## The risk this introduces — worth weighing before merge

**This deliberately makes `equals` stricter, so it produces more interface replacements than before.** That's the correction, but it is the whole risk.

Concretely: ePDG resolution is nondeterministic by construction — it's a DNS lookup behind a 1.5s timeout. Under the old comparison that nondeterminism was invisible. Under the new one, a lookup that succeeds on one rebuild and times out on the next flips the comparison and forces a tun replacement each time. On a flaky network that's replacement churn where there was none.

That is exactly the load #791 exists to survive, and it's the reason this is stacked rather than standing alone. If #791 doesn't merge, I'd weigh this against simply leaving the metered flag stale.

A cheaper alternative if the churn proves real: compare only whether the exclusion *set* is non-empty, or cache the resolved ePDG addresses across rebuilds so the input stops flapping. Both are follow-ups rather than part of this fix.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and `:app:lintGithubDebug` all pass. Lint matters here for the API-level annotations.

**No device testing, and CI does not substitute for it** — the `instrumentation` job runs a single JNI test class and touches no VPN code. The behaviour this changes (a metered flip on a live network, an ePDG lookup resolving on a later rebuild) needs real network transitions on hardware. No unit test either: `Builder` is a private inner class of the service, and I did not widen its visibility purely to test it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Er2nZyUjv3AQW9PncoQR5v)_