### PR TITLE
Port ProtectedUdpFactory to the gotatun 0.9 UDP API

### DIFF
--- a/wgbridge-rs/src/transport/udp.rs
+++ b/wgbridge-rs/src/transport/udp.rs
@@ -26,9 +26,9 @@ impl ProtectedUdpFactory {
     }
 
     fn protect(&self, socket: &UdpSocket) -> io::Result<()> {
-        // gotatun 0.8.x hides the inner socket behind an enum; socket() exposes
-        // the underlying tokio UdpSocket (0.8.1+) so we can protect its fd.
-        let fd = socket.socket()?.as_raw_fd();
+        // gotatun hides the inner socket behind a struct; socket() exposes the
+        // underlying tokio UdpSocket so we can protect its fd.
+        let fd = socket.socket().as_raw_fd();
         if !self.protector.protect(fd) {
             // Fail closed: an unprotected socket would loop through the TUN.
             return Err(io::Error::other(format!(
@@ -40,20 +40,18 @@ impl ProtectedUdpFactory {
 }
 
 impl UdpTransportFactory for ProtectedUdpFactory {
-    type SendV4 = UdpSocket;
-    type SendV6 = UdpSocket;
-    type RecvV4 = UdpSocket;
-    type RecvV6 = UdpSocket;
+    type Send = UdpSocket;
+    type Recv = UdpSocket;
 
     async fn bind(
         &mut self,
         params: &UdpTransportFactoryParams,
-    ) -> io::Result<((Self::SendV4, Self::RecvV4), (Self::SendV6, Self::RecvV6))> {
-        let ((send_v4, recv_v4), (send_v6, recv_v6)) = self.inner.bind(params).await?;
-        // send/recv halves are clones of the same socket; protect each family once.
-        self.protect(&send_v4)?;
-        self.protect(&send_v6)?;
-        log::info!("bound and protected WG UDP sockets");
-        Ok(((send_v4, recv_v4), (send_v6, recv_v6)))
+    ) -> io::Result<(Self::Send, Self::Recv)> {
+        // gotatun 0.9 binds a single dual-stack socket; send/recv are clones of
+        // it, so protecting one half protects both.
+        let (send, recv) = self.inner.bind(params).await?;
+        self.protect(&send)?;
+        log::info!("bound and protected WG UDP socket");
+        Ok((send, recv))
     }
 }


### PR DESCRIPTION
Stacked on top of [#782](https://github.com/TrackerControl/tracker-control-android/pull/782) (`deps(rust): bump gotatun from 0.8.1 to 0.9.0`), which currently fails CI because 0.9.0 is a breaking API change.

## Why #782 is red

Both the `test` and `instrumentation` jobs fail in `:app:wgbridgeBuild` with 12 errors in `wgbridge-rs/src/transport/udp.rs`:

- `E0437` / `E0046` — `UdpTransportFactory` merged `SendV4`+`SendV6` into `Send` and `RecvV4`+`RecvV6` into `Recv`.
- `E0308: expected UdpSocket, found (_, _)` — `UdpSocketFactory::bind` now binds a single dual-stack socket and returns `(Send, Recv)` rather than `((send_v4, recv_v4), (send_v6, recv_v6))`.
- `E0277` on `?` — `UdpSocket::socket()` returns `&tokio::net::UdpSocket` directly instead of `io::Result<_>`.

## What this changes

`ProtectedUdpFactory` is ported to the new shape: one `Send`/`Recv` pair, one `bind` returning a single socket, and `protect()` without the `?`. The send and recv halves are clones of the same fd, so protecting one covers both address families — where 0.8 needed a `protect()` per family, the dual-stack socket needs one.

No `Cargo.toml` change is needed: 0.9.0's new `socket` feature (which gates the native UDP socket impls) is implied by the `device` feature already enabled.

## Testing

- `cargo build` and `cargo test` in `wgbridge-rs` — 43 tests pass.
- Not exercised on a device; the change is confined to socket binding, which the JVM tests don't cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo5YQGCw3D6fAZzEB74j5E)_