### PR TITLE
Warn when tunnelled traffic to the LAN is being dropped

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1767,15 +1767,15 @@ public class ServiceSinkhole extends VpnService {
                     Log.e(TAG, "addRoute DNS " + dns + ": " + ex);
                 }
 
-        // Android 17 refuses local network traffic without ACCESS_LOCAL_NETWORK:
-        // TCP times out, UDP fails with EPERM. A LAN resolver routed into the tun
-        // above is re-sent from our own socket, so it goes silent (#701).
-        // The symptom is "nothing resolves", which no one attributes to a
-        // permission — and the banner only reaches someone who opens the app.
+        // Android 17 applies local network protection to non-DNS traffic that
+        // enters the tun: TCP times out and UDP fails with EPERM for every app.
+        // DNS queries to port 53 survive the exemption, so a LAN resolver can
+        // keep resolving while other traffic silently fails (#701).
         // Notify, so the reason meets the user where the failure appears.
         if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(ServiceSinkhole.this)) {
-            Log.w(TAG, "Local network access not granted: configured LAN destinations" +
-                    " (custom DNS, Secure DNS resolver, WireGuard peer, proxy) are unreachable");
+            Log.w(TAG, "Local network access not granted: LAN destinations are" +
+                    " unreachable, whether configured (custom DNS, Secure DNS resolver," +
+                    " WireGuard peer, proxy) or reached through the tun by another app");
             showLocalNetworkNotification();
         } else
             clearLocalNetworkNotification();
@@ -2591,6 +2591,12 @@ public class ServiceSinkhole extends VpnService {
             Log.i(TAG, "Blocking DoT " + packet);
             packet.allowed = false;
         }
+
+        // Report only traffic that will be forwarded, and never TC's own
+        // sockets. The helper's cheap gates run before it parses packet.daddr.
+        if (packet.allowed && packet.uid != Process.myUid()
+                && net.kollnig.missioncontrol.LocalNetworkAccess.shouldReportForwardedDestination())
+            net.kollnig.missioncontrol.LocalNetworkAccess.reportForwardedDestination(packet.daddr);
 
         if (packet.allowed)
             if (mapForward.containsKey(packet.dport)) {

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -42,16 +42,19 @@ import java.net.URI;
  * permission for apps targeting API 37 or higher. Without it, TCP connections
  * time out and UDP fails with {@code EPERM}.
  *
- * <p>Traffic other apps send to the LAN is unaffected by TrackerControl's
- * permission state: those are their own sockets, and TrackerControl keeps RFC
- * 1918 ranges out of its routes (see {@link eu.faircode.netguard.VpnRoutes}),
- * so that traffic never enters the tun. What does depend on this permission is
- * traffic TrackerControl itself sends to the local network:
+ * <p>Traffic other apps send to the LAN normally remains unaffected by
+ * TrackerControl's permission state because TrackerControl keeps RFC 1918
+ * ranges out of its routes (see {@link eu.faircode.netguard.VpnRoutes}). The
+ * exception is traffic to a LAN host that another route pulls into the tun:
+ * DNS queries survive Android's port-53 exemption, but non-DNS traffic can
+ * fail for every app without this permission. What also depends on this
+ * permission is traffic TrackerControl itself sends to the local network:
  *
  * <ul>
  *   <li>a custom VPN DNS server on the LAN (Pi-hole, AdGuard Home, the router).
- *       Such resolvers get a host route into the tun, so the queries are
- *       re-sent from TrackerControl's own socket (#701);</li>
+ *       Such resolvers get a host route into the tun; DNS queries survive the
+ *       port-53 exemption, but non-DNS traffic to a LAN host pulled into the
+ *       tun can fail for every app (#701);</li>
  *   <li>Secure DNS (DoH) pointed at a local resolver — an ordinary HTTPS
  *       connection, with no DNS exemption to fall back on;</li>
  *   <li>tethering compatibility mode, which installs a full-tunnel default
@@ -113,15 +116,38 @@ public class LocalNetworkAccess {
                 == PackageManager.PERMISSION_GRANTED;
     }
 
+    /** Cached missing-permission state used by the per-flow forwarded-destination gate. */
+    private static volatile boolean missingPermission;
+
+    /**
+     * Refresh the permission cache. Called by {@link #isMissing(Context)} on
+     * tunnel rebuilds and from UI warning checks, never once per packet.
+     */
+    public static void refreshPermission(Context context) {
+        refreshPermission(isEnforced() && !isGranted(context));
+    }
+
+    /**
+     * The same refresh, given the answer rather than computing it. Robolectric
+     * caps at API 36, below enforcement, so this is the only way a test can
+     * reach the state the gate exists for.
+     */
+    static void refreshPermission(boolean missing) {
+        missingPermission = missing;
+    }
+
     /**
      * Whether local network access is both needed by the current configuration
      * and not granted — i.e. whether something the user configured is about to
      * break, or has already broken.
      */
     public static boolean isMissing(Context context) {
+        // Refresh outside the packet path: the tunnel builder and UI warning
+        // checks call here, while forwarded packets only read the cache below.
+        refreshPermission(context);
         // Cheapest checks first: nothing to do below Android 17, and parsing the
         // WireGuard config is pointless once the permission is granted.
-        return isEnforced() && !isGranted(context)
+        return missingPermission
                 && (observedLocalDestination || isConfigured(context));
     }
 
@@ -157,6 +183,20 @@ public class LocalNetworkAccess {
             Log.i(TAG, "Local network destination observed at runtime");
             observedLocalDestination = true;
         }
+    }
+
+    /**
+     * Report a destination from a flow another app sent through the tun.
+     * {@link eu.faircode.netguard.ServiceSinkhole} performs the cheap platform,
+     * permission, latch, and UID gates before calling this entry point.
+     */
+    public static void reportForwardedDestination(String address) {
+        reportDestination(address);
+    }
+
+    /** Whether a forwarded destination needs the one-time local-address check. */
+    public static boolean shouldReportForwardedDestination() {
+        return !observedLocalDestination && missingPermission;
     }
 
     /** Whether a local destination has been seen since the last reset. */
@@ -205,7 +245,8 @@ public class LocalNetworkAccess {
      * 1918 range, the RFC 6598 range some routers use on their LAN side, a
      * link-local address, or an IPv6 unique local address. Only literals are
      * considered — resolving a hostname here would mean a network lookup on the
-     * caller's (often main) thread.
+     * caller's (often main) thread. LAN hosts reached over a global IPv6 address
+     * are not recognised; that is a known gap.
      */
     static boolean isLocalAddress(String address) {
         if (TextUtils.isEmpty(address))

--- a/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
@@ -33,8 +33,8 @@ import org.robolectric.RuntimeEnvironment;
 /**
  * Which configurations make TrackerControl talk to the local network, and thus
  * need the Android 17 {@code ACCESS_LOCAL_NETWORK} permission (#701). The SDK
- * gating itself is not covered: Robolectric runs on API 36, below the level
- * where local network protections are enforced.
+ * is pinned to API 36, below the enforcement level, so forwarded-destination
+ * tests assert the observation latch directly and keep {@code isMissing()} false.
  */
 @RunWith(RobolectricTestRunner.class)
 public class LocalNetworkAccessTest {
@@ -56,6 +56,7 @@ public class LocalNetworkAccessTest {
         prefs = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.getApplication());
         prefs.edit().clear().commit();
         LocalNetworkAccess.forgetObservations();
+        LocalNetworkAccess.refreshPermission(false);
     }
 
     @Test
@@ -87,6 +88,51 @@ public class LocalNetworkAccessTest {
 
         LocalNetworkAccess.forgetObservations();
         assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+    }
+
+    @Test
+    public void localForwardedDestinationIsRememberedBelowEnforcement() {
+        LocalNetworkAccess.reportForwardedDestination("192.168.1.10");
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+        assertFalse(LocalNetworkAccess.isMissing(RuntimeEnvironment.getApplication()));
+    }
+
+    @Test
+    public void publicForwardedDestinationDoesNotLatchObservation() {
+        LocalNetworkAccess.reportForwardedDestination("9.9.9.9");
+        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+        assertFalse(LocalNetworkAccess.isMissing(RuntimeEnvironment.getApplication()));
+    }
+
+    @Test
+    public void forwardedDestinationObservationIsClearedOnReset() {
+        LocalNetworkAccess.reportForwardedDestination("192.168.1.10");
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+
+        LocalNetworkAccess.forgetObservations();
+        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+        assertFalse(LocalNetworkAccess.isMissing(RuntimeEnvironment.getApplication()));
+    }
+
+    @Test
+    public void forwardedGateIsOpenWhileThePermissionIsMissing() {
+        // The gate the packet path consults: it must actually be satisfiable
+        // for a plain install, with nothing configured and nothing observed.
+        LocalNetworkAccess.refreshPermission(true);
+        assertTrue(LocalNetworkAccess.shouldReportForwardedDestination());
+
+        LocalNetworkAccess.reportForwardedDestination("192.168.1.10");
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+
+        // Once latched there is nothing left to learn, so the per-flow check
+        // stops parsing addresses.
+        assertFalse(LocalNetworkAccess.shouldReportForwardedDestination());
+    }
+
+    @Test
+    public void forwardedGateStaysClosedWhileThePermissionIsHeld() {
+        LocalNetworkAccess.refreshPermission(false);
+        assertFalse(LocalNetworkAccess.shouldReportForwardedDestination());
     }
 
     @Test


### PR DESCRIPTION
Closes #785.

On Android 17 the local-network failure that actually reaches users is invisible
to us. Measured on a Pixel (Android 17, GrapheneOS) with `ACCESS_LOCAL_NETWORK`
**not** granted, probing the LAN router at 192.168.178.1 from `adb shell` — an
ordinary uid inside the tun, not TrackerControl's own:

| probe | permission denied | permission granted |
|---|---|---|
| DNS resolution (port 53) | works | works |
| TCP 80 / 443 / 8080 | timeout | connects |
| ICMP | 100% loss | 0% loss |

Two things follow, and both contradict comments we had in the tree:

1. Packets that enter the tun are re-sent from **TrackerControl's** socket, so
   **our** permission decides LAN reachability for every app behind the tunnel.
2. This is not confined to configured LAN destinations. `vpnStart()` adds a host
   route for each DNS server, so with the router as DNS — the common home setup
   — the router's whole address is pulled into the tun. DNS keeps working
   (Android exempts port 53 to the network's own resolvers), while the router
   UI, the NAS and the printer go dark for every app.

`isMissing()` could never see that: `isConfigured()` deliberately ignores the
network's own resolvers, and `observedLocalDestination` was only ever set from
our *own* outbound paths (`DnsOverHttpsClient`, `WgEgress`). So the user got no
banner and no notification — a silent, total loss of LAN access.

**Change:** report the destination of forwarded flows from `isAddressAllowed()`,
the per-flow native callback, so the existing banner and notification fire for
this case too.

The per-flow cost is a volatile read of a cached "permission is missing" flag
plus the existing latch check; the address is only parsed while both are true,
which is at most once. The permission itself is sampled in `isMissing()` — on
tunnel rebuilds and UI checks — never per packet.

Also corrects the two comments stating the refuted premise (the class javadoc of
`LocalNetworkAccess` and the #701 block in `vpnStart()`), and notes the known
gap that a LAN host reached over a *global* IPv6 address is not recognised as
local.

Tests: `LocalNetworkAccessTest` covers the latch, the non-local case, the reset,
and — via a value-taking `refreshPermission` seam, since Robolectric caps at API
36, below enforcement — that the per-flow gate is actually satisfiable for a
plain install with nothing configured.
