### PR TITLE
Warn when a routed LAN resolver loses non-DNS traffic

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1832,19 +1832,26 @@ public class ServiceSinkhole extends VpnService {
                 try {
                     Log.i(TAG, "Adding DNS host route=" + dns.getHostAddress());
                     builder.addRoute(dns, dns instanceof Inet4Address ? 32 : 128);
+                    // The route covers the whole address, not just port 53, and
+                    // everything on it is now re-sent from our socket — so our
+                    // permission decides its reachability for every app (#785).
+                    net.kollnig.missioncontrol.LocalNetworkAccess.reportRoutedResolver(dns);
                 } catch (Throwable ex) {
                     Log.e(TAG, "addRoute DNS " + dns + ": " + ex);
                 }
 
         // Android 17 refuses local network traffic without ACCESS_LOCAL_NETWORK:
         // TCP times out, UDP fails with EPERM. A LAN resolver routed into the tun
-        // above is re-sent from our own socket, so it goes silent (#701).
-        // The symptom is "nothing resolves", which no one attributes to a
-        // permission — and the banner only reaches someone who opens the app.
+        // above is re-sent from our own socket (#701). Port 53 survives Android's
+        // exemption, so name resolution keeps working while the rest of that
+        // address — the router's web UI is the common one — goes silent for every
+        // app behind the tunnel (#785). Neither symptom is attributed to a
+        // permission, and the banner only reaches someone who opens the app.
         // Notify, so the reason meets the user where the failure appears.
         if (net.kollnig.missioncontrol.LocalNetworkAccess.isMissing(ServiceSinkhole.this)) {
-            Log.w(TAG, "Local network access not granted: configured LAN destinations" +
-                    " (custom DNS, Secure DNS resolver, WireGuard peer, proxy) are unreachable");
+            Log.w(TAG, "Local network access not granted: LAN destinations are" +
+                    " unreachable, whether configured (custom DNS, Secure DNS resolver," +
+                    " WireGuard peer, proxy) or routed into the tun as a resolver");
             showLocalNetworkNotification();
         } else
             clearLocalNetworkNotification();

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1826,19 +1826,23 @@ public class ServiceSinkhole extends VpnService {
         // ULA resolvers are outside the 2000::/3 global-unicast route below.
         // Keeping both inside the tunnel ensures DNS remains reachable and passes
         // through TC's filtering path.
+        List<InetAddress> routedDnsServers = new ArrayList<>();
         for (InetAddress dns : dnsServers != null ? dnsServers : getDns(ServiceSinkhole.this))
             if ((dns instanceof Inet4Address && dns.isSiteLocalAddress()) ||
                     dns instanceof Inet6Address)
                 try {
                     Log.i(TAG, "Adding DNS host route=" + dns.getHostAddress());
                     builder.addRoute(dns, dns instanceof Inet4Address ? 32 : 128);
-                    // The route covers the whole address, not just port 53, and
-                    // everything on it is now re-sent from our socket — so our
-                    // permission decides its reachability for every app (#785).
-                    net.kollnig.missioncontrol.LocalNetworkAccess.reportRoutedResolver(dns);
+                    routedDnsServers.add(dns);
                 } catch (Throwable ex) {
                     Log.e(TAG, "addRoute DNS " + dns + ": " + ex);
                 }
+
+        // The route covers the whole address, not just port 53, and everything
+        // on it is now re-sent from our socket — so our permission decides its
+        // reachability for every app (#785). Replace this state once per tunnel
+        // build; it must not share the process-local runtime observation latch.
+        net.kollnig.missioncontrol.LocalNetworkAccess.setRoutedResolvers(routedDnsServers);
 
         // Android 17 refuses local network traffic without ACCESS_LOCAL_NETWORK:
         // TCP times out, UDP fails with EPERM. A LAN resolver routed into the tun

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -42,16 +42,22 @@ import java.net.URI;
  * permission for apps targeting API 37 or higher. Without it, TCP connections
  * time out and UDP fails with {@code EPERM}.
  *
- * <p>Traffic other apps send to the LAN is unaffected by TrackerControl's
- * permission state: those are their own sockets, and TrackerControl keeps RFC
- * 1918 ranges out of its routes (see {@link eu.faircode.netguard.VpnRoutes}),
- * so that traffic never enters the tun. What does depend on this permission is
- * traffic TrackerControl itself sends to the local network:
+ * <p>Traffic other apps send to the LAN mostly stays unaffected by
+ * TrackerControl's permission state: those are their own sockets, and
+ * TrackerControl keeps RFC 1918 ranges out of its routes (see
+ * {@link eu.faircode.netguard.VpnRoutes}), so that traffic never enters the
+ * tun. The exception is an address a host route does pull in — a LAN resolver
+ * (see {@link #reportRoutedResolver(InetAddress)}) — where the whole address,
+ * not just port 53, is re-sent from TrackerControl's socket. What else depends
+ * on this permission is traffic TrackerControl itself sends to the local
+ * network:
  *
  * <ul>
  *   <li>a custom VPN DNS server on the LAN (Pi-hole, AdGuard Home, the router).
  *       Such resolvers get a host route into the tun, so the queries are
- *       re-sent from TrackerControl's own socket (#701);</li>
+ *       re-sent from TrackerControl's own socket (#701). Port 53 survives the
+ *       exemption below, but the host route covers every other port on that
+ *       address too, for every app behind the tunnel (#785);</li>
  *   <li>Secure DNS (DoH) pointed at a local resolver — an ordinary HTTPS
  *       connection, with no DNS exemption to fall back on;</li>
  *   <li>tethering compatibility mode, which installs a full-tunnel default
@@ -61,12 +67,14 @@ import java.net.URI;
  *       socket in the same way.</li>
  * </ul>
  *
- * <p>The system's own resolvers are deliberately not treated as needing the
- * permission: Android exempts port 53 traffic to the network's DNS servers, so
- * the common "router is the DNS server" setup keeps working untouched. Only
- * configuration that points TrackerControl somewhere else on the LAN triggers
- * the prompt, which keeps the permission request off the path of users who
- * never need it.
+ * <p>The system's own resolvers are deliberately absent from
+ * {@link #isConfigured(SharedPreferences)}: Android exempts port 53 traffic to
+ * the network's DNS servers, so name resolution keeps working in the common
+ * "router is the DNS server" setup, and a permission request must not be
+ * provoked by a stored setting nobody chose. They are instead reported at
+ * tunnel-build time by {@link #reportRoutedResolver(InetAddress)}, which fires
+ * only for the resolvers that actually receive a host route — so the prompt
+ * still stays off the path of users whose traffic never reaches the LAN.
  */
 public class LocalNetworkAccess {
     private LocalNetworkAccess() {
@@ -159,6 +167,23 @@ public class LocalNetworkAccess {
         }
     }
 
+    /**
+     * Report a resolver that {@link eu.faircode.netguard.ServiceSinkhole} pulls
+     * into the tunnel with a host route.
+     *
+     * <p>Android exempts port 53 to the network's own resolvers, so DNS keeps
+     * resolving without the permission and {@link #isConfigured(SharedPreferences)}
+     * rightly ignores such a resolver. The host route does not stop at port 53:
+     * it captures the address as a whole, so the router's web UI and anything
+     * else on that address goes silent for <em>every</em> app behind the tunnel
+     * (#785). Reporting here costs nothing per packet — the tunnel builder
+     * already iterates exactly these addresses.
+     */
+    public static void reportRoutedResolver(InetAddress dns) {
+        if (dns != null)
+            reportDestination(dns.getHostAddress());
+    }
+
     /** Whether a local destination has been seen since the last reset. */
     static boolean hasObservedLocalDestination() {
         return observedLocalDestination;
@@ -205,7 +230,8 @@ public class LocalNetworkAccess {
      * 1918 range, the RFC 6598 range some routers use on their LAN side, a
      * link-local address, or an IPv6 unique local address. Only literals are
      * considered — resolving a hostname here would mean a network lookup on the
-     * caller's (often main) thread.
+     * caller's (often main) thread. A LAN host reached over a global IPv6
+     * address is not recognised; that is a known gap.
      */
     static boolean isLocalAddress(String address) {
         if (TextUtils.isEmpty(address))

--- a/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/LocalNetworkAccess.java
@@ -47,10 +47,9 @@ import java.net.URI;
  * TrackerControl keeps RFC 1918 ranges out of its routes (see
  * {@link eu.faircode.netguard.VpnRoutes}), so that traffic never enters the
  * tun. The exception is an address a host route does pull in — a LAN resolver
- * (see {@link #reportRoutedResolver(InetAddress)}) — where the whole address,
- * not just port 53, is re-sent from TrackerControl's socket. What else depends
- * on this permission is traffic TrackerControl itself sends to the local
- * network:
+ * (see {@link #setRoutedResolvers(Iterable)}) — where the whole address, not
+ * just port 53, is re-sent from TrackerControl's socket. What else depends on
+ * this permission is traffic TrackerControl itself sends to the local network:
  *
  * <ul>
  *   <li>a custom VPN DNS server on the LAN (Pi-hole, AdGuard Home, the router).
@@ -72,9 +71,10 @@ import java.net.URI;
  * the network's DNS servers, so name resolution keeps working in the common
  * "router is the DNS server" setup, and a permission request must not be
  * provoked by a stored setting nobody chose. They are instead reported at
- * tunnel-build time by {@link #reportRoutedResolver(InetAddress)}, which fires
- * only for the resolvers that actually receive a host route — so the prompt
- * still stays off the path of users whose traffic never reaches the LAN.
+ * tunnel-build time by {@link #setRoutedResolvers(Iterable)}, which replaces
+ * the current-build state with only the resolvers that actually receive a host
+ * route — so the prompt still stays off the path of users whose traffic never
+ * reaches the LAN.
  */
 public class LocalNetworkAccess {
     private LocalNetworkAccess() {
@@ -122,30 +122,33 @@ public class LocalNetworkAccess {
     }
 
     /**
-     * Whether local network access is both needed by the current configuration
-     * and not granted — i.e. whether something the user configured is about to
-     * break, or has already broken.
+     * Whether local network access is needed by the current configuration,
+     * current tunnel-build resolver set, or runtime destination observations,
+     * and is not granted.
      */
     public static boolean isMissing(Context context) {
         // Cheapest checks first: nothing to do below Android 17, and parsing the
         // WireGuard config is pointless once the permission is granted.
         return isEnforced() && !isGranted(context)
-                && (observedLocalDestination || isConfigured(context));
+                && (observedLocalDestination || routedLocalResolver || isConfigured(context));
     }
 
     /**
-     * A destination we resolved to a local network address, seen while running.
-     * Covers what {@link #isConfigured(SharedPreferences)} structurally cannot:
-     * a configuration that names a <em>host</em> rather than an address —
-     * {@code https://pi.hole/dns-query}, a WireGuard endpoint on a dynamic DNS
-     * name — where classifying it up front would mean resolving a name on
-     * whichever thread asked, including the main one.
+     * A destination we resolved to a local network address, seen while running
+     * for DoH or WireGuard. Covers what {@link #isConfigured(SharedPreferences)}
+     * structurally cannot: a configuration that names a <em>host</em> rather
+     * than an address — {@code https://pi.hole/dns-query}, a WireGuard endpoint
+     * on a dynamic DNS name — where classifying it up front would mean resolving
+     * a name on whichever thread asked, including the main one.
      *
      * <p>Not persisted. A stale observation survives no longer than the
      * process, and anything still pointing at the LAN re-reports itself as soon
      * as it is used again.
      */
     private static volatile boolean observedLocalDestination;
+
+    /** Whether the current tunnel build routed at least one local resolver. */
+    private static volatile boolean routedLocalResolver;
 
     /**
      * Report an address TrackerControl is about to talk to. Callers pass what
@@ -168,20 +171,26 @@ public class LocalNetworkAccess {
     }
 
     /**
-     * Report a resolver that {@link eu.faircode.netguard.ServiceSinkhole} pulls
-     * into the tunnel with a host route.
+     * Replace the current tunnel-build resolver state.
      *
-     * <p>Android exempts port 53 to the network's own resolvers, so DNS keeps
-     * resolving without the permission and {@link #isConfigured(SharedPreferences)}
-     * rightly ignores such a resolver. The host route does not stop at port 53:
-     * it captures the address as a whole, so the router's web UI and anything
-     * else on that address goes silent for <em>every</em> app behind the tunnel
-     * (#785). Reporting here costs nothing per packet — the tunnel builder
-     * already iterates exactly these addresses.
+     * <p>The resolver set is scanned once while the tunnel is built, so a
+     * resolver from a previous network cannot keep the warning latched. Android
+     * exempts port 53 to the network's own resolvers, so DNS keeps resolving
+     * without the permission and {@link #isConfigured(SharedPreferences)} rightly
+     * ignores such a resolver. The host route does not stop at port 53: it
+     * captures the address as a whole, so the router's web UI and anything else
+     * on that address goes silent for <em>every</em> app behind the tunnel (#785).
+     * A null or empty set means that this build routed no local resolver.
      */
-    public static void reportRoutedResolver(InetAddress dns) {
-        if (dns != null)
-            reportDestination(dns.getHostAddress());
+    public static void setRoutedResolvers(Iterable<InetAddress> resolvers) {
+        boolean local = false;
+        if (resolvers != null)
+            for (InetAddress resolver : resolvers)
+                if (resolver != null && isLocalAddress(resolver.getHostAddress())) {
+                    local = true;
+                    break;
+                }
+        routedLocalResolver = local;
     }
 
     /** Whether a local destination has been seen since the last reset. */
@@ -189,10 +198,17 @@ public class LocalNetworkAccess {
         return observedLocalDestination;
     }
 
+    /** Whether the current tunnel build routed a local resolver. */
+    static boolean hasRoutedLocalResolver() {
+        return routedLocalResolver;
+    }
+
     /**
-     * Drop what we observed, so a configuration that no longer points at the
-     * LAN stops warning. Called when a relevant setting changes; anything still
-     * local reports itself again on next use.
+     * Drop runtime destinations we observed, so a configuration that no longer
+     * points at the LAN stops warning. Called when a relevant setting changes;
+     * anything still local reports itself again on next use. The current tunnel
+     * build's routed-resolver state is replaced separately by
+     * {@link #setRoutedResolvers(Iterable)}.
      */
     public static void forgetObservations() {
         observedLocalDestination = false;

--- a/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
@@ -30,6 +30,8 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
+import java.net.InetAddress;
+
 /**
  * Which configurations make TrackerControl talk to the local network, and thus
  * need the Android 17 {@code ACCESS_LOCAL_NETWORK} permission (#701). The SDK
@@ -86,6 +88,28 @@ public class LocalNetworkAccessTest {
         assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
 
         LocalNetworkAccess.forgetObservations();
+        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+    }
+
+    @Test
+    public void routedLanResolverIsObservedWithoutBeingConfigured() throws Exception {
+        // The network's own resolver: nothing in the preferences names it, so
+        // isConfigured() cannot see it — but the tunnel builder gives it a host
+        // route, which captures the whole address rather than only port 53.
+        LocalNetworkAccess.reportRoutedResolver(InetAddress.getByName("192.168.178.1"));
+
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+        assertFalse(LocalNetworkAccess.isConfigured(prefs));
+    }
+
+    @Test
+    public void routedPublicResolverIsNotObserved() throws Exception {
+        // Global resolvers get a host route too when they are IPv6; only the
+        // local ones depend on the permission.
+        LocalNetworkAccess.reportRoutedResolver(InetAddress.getByName("2620:fe::fe"));
+        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+
+        LocalNetworkAccess.reportRoutedResolver(null);
         assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
     }
 

--- a/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/LocalNetworkAccessTest.java
@@ -31,6 +31,8 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import java.net.InetAddress;
+import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Which configurations make TrackerControl talk to the local network, and thus
@@ -58,6 +60,7 @@ public class LocalNetworkAccessTest {
         prefs = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.getApplication());
         prefs.edit().clear().commit();
         LocalNetworkAccess.forgetObservations();
+        LocalNetworkAccess.setRoutedResolvers(null);
     }
 
     @Test
@@ -92,25 +95,49 @@ public class LocalNetworkAccessTest {
     }
 
     @Test
-    public void routedLanResolverIsObservedWithoutBeingConfigured() throws Exception {
+    public void routedLanResolverIsCurrentWithoutBeingConfigured() throws Exception {
         // The network's own resolver: nothing in the preferences names it, so
         // isConfigured() cannot see it — but the tunnel builder gives it a host
         // route, which captures the whole address rather than only port 53.
-        LocalNetworkAccess.reportRoutedResolver(InetAddress.getByName("192.168.178.1"));
+        LocalNetworkAccess.setRoutedResolvers(
+                Collections.singletonList(InetAddress.getByName("192.168.178.1")));
 
-        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+        assertTrue(LocalNetworkAccess.hasRoutedLocalResolver());
+        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
         assertFalse(LocalNetworkAccess.isConfigured(prefs));
     }
 
     @Test
-    public void routedPublicResolverIsNotObserved() throws Exception {
+    public void routedPublicResolverIsNotCurrent() throws Exception {
         // Global resolvers get a host route too when they are IPv6; only the
         // local ones depend on the permission.
-        LocalNetworkAccess.reportRoutedResolver(InetAddress.getByName("2620:fe::fe"));
+        LocalNetworkAccess.setRoutedResolvers(
+                Collections.singletonList(InetAddress.getByName("2620:fe::fe")));
+        assertFalse(LocalNetworkAccess.hasRoutedLocalResolver());
         assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
 
-        LocalNetworkAccess.reportRoutedResolver(null);
-        assertFalse(LocalNetworkAccess.hasObservedLocalDestination());
+        LocalNetworkAccess.setRoutedResolvers(null);
+        assertFalse(LocalNetworkAccess.hasRoutedLocalResolver());
+    }
+
+    @Test
+    public void routedResolverStateFollowsCurrentBuildWithoutClearingRuntimeObservation()
+            throws Exception {
+        LocalNetworkAccess.reportDestination("192.168.1.10");
+        LocalNetworkAccess.setRoutedResolvers(
+                Arrays.asList(InetAddress.getByName("192.168.178.1")));
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+        assertTrue(LocalNetworkAccess.hasRoutedLocalResolver());
+
+        LocalNetworkAccess.setRoutedResolvers(
+                Arrays.asList(InetAddress.getByName("9.9.9.9")));
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
+        assertFalse(LocalNetworkAccess.hasRoutedLocalResolver());
+
+        LocalNetworkAccess.setRoutedResolvers(Collections.emptyList());
+        assertFalse(LocalNetworkAccess.hasRoutedLocalResolver());
+        LocalNetworkAccess.setRoutedResolvers(null);
+        assertTrue(LocalNetworkAccess.hasObservedLocalDestination());
     }
 
     @Test


### PR DESCRIPTION
Closes #785.

## The gap

`getBuilder()` adds a `/32` (or `/128`) host route for every site-local IPv4
resolver and every IPv6 resolver, so DNS stays inside TrackerControl's
filtering path. That route covers the whole address, not only port 53. On
Android 17 without `ACCESS_LOCAL_NETWORK`, DNS to the network's resolver keeps
working through the platform exemption while non-DNS traffic to the same
address, commonly the router's web UI, silently fails for every app behind the
tunnel.

`isConfigured()` deliberately ignores the network's own resolver, so the
existing banner and notification could not diagnose this case.

## The change

The tunnel builder now records the resolver addresses whose host routes were
successfully installed and replaces `LocalNetworkAccess`'s routed-resolver
state once per build. A local routed resolver therefore triggers the existing
missing-permission warning immediately, while switching to a network with only
public resolvers clears that part of the warning state.

Routed-resolver state is separate from runtime DoH and WireGuard destination
observations, so a tunnel rebuild cannot erase those observations.

**Cost: zero work per packet.** Resolver classification remains O(number of
resolvers) at tunnel-build time. This avoids #798's unbounded address parsing
on the forwarded-flow path.

## Limits

- LAN destinations captured only by tethering compatibility mode's full-tunnel
  route are not detected.
- A LAN host reached over a global IPv6 address is not recognised as local.

## Verification

- `:app:compileGithubDebugJavaWithJavac`
- `:app:testGithubDebugUnitTest`
- Tests cover local and public routed resolvers, local-to-public replacement,
  empty/null resolver sets, and independence from runtime observations.
