### PR TITLE
Fix alarm timebase, guard numeric prefs, and small correctness nits

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -1084,7 +1084,12 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             try {
                 int ttl = rr.TTL;
 
-                int min = Integer.parseInt(prefs.getString("ttl", "259200"));
+                int min = 259200;
+                try {
+                    min = Integer.parseInt(prefs.getString("ttl", "259200"));
+                } catch (NumberFormatException ex) {
+                    // Keep the default minimum TTL.
+                }
                 if (ttl < min)
                     ttl = min;
 

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -134,6 +134,17 @@ import javax.net.ssl.HttpsURLConnection;
 public class ServiceSinkhole extends VpnService {
     private static final String TAG = "TrackerControl.VPN";
 
+    private static int getIntPref(SharedPreferences prefs, String key, int def) {
+        String value = prefs.getString(key, null);
+        if (TextUtils.isEmpty(value))
+            return def;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException ex) {
+            return def;
+        }
+    }
+
     // Safety net for the per-command wakelock: a command that hangs or throws
     // before reaching the release in CommandHandler's finally block (or a
     // future code path that forgets to release) auto-releases instead of
@@ -602,11 +613,12 @@ public class ServiceSinkhole extends VpnService {
                 am.cancel(pi);
 
                 if (cmd != Command.stop) {
-                    int watchdog = Integer.parseInt(prefs.getString("watchdog", "0"));
+                    int watchdog = getIntPref(prefs, "watchdog", 0);
                     if (watchdog > 0) {
                         Log.i(TAG, "Watchdog " + watchdog + " minutes");
-                        am.setInexactRepeating(AlarmManager.RTC, SystemClock.elapsedRealtime() + watchdog * 60 * 1000,
-                                watchdog * 60 * 1000, pi);
+                        am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME,
+                                SystemClock.elapsedRealtime() + watchdog * 60 * 1000L,
+                                watchdog * 60 * 1000L, pi);
                     }
                 }
             }
@@ -3488,7 +3500,7 @@ public class ServiceSinkhole extends VpnService {
             pi = PendingIntentCompat.getService(this, 0, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         AlarmManager am = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
-        am.setInexactRepeating(AlarmManager.RTC, SystemClock.elapsedRealtime() + 60 * 1000,
+        am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME, SystemClock.elapsedRealtime() + 60 * 1000,
                 AlarmManager.INTERVAL_HALF_DAY, pi);
 
         // Marks that onCreate ran to completion; onDestroy uses this to decide
@@ -3924,7 +3936,7 @@ public class ServiceSinkhole extends VpnService {
         i.setPackage(this.getPackageName());
         PendingIntent pauseIntent = PendingIntentCompat.getBroadcast(this, 0, i, PendingIntent.FLAG_UPDATE_CURRENT);
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
-        int pause = Integer.parseInt(prefs.getString("pause", "10"));
+        int pause = getIntPref(prefs, "pause", 10);
 
         NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "foreground");
         builder.setSmallIcon(R.drawable.ic_rocket_white)
@@ -4420,7 +4432,9 @@ public class ServiceSinkhole extends VpnService {
 
         @Override
         public int hashCode() {
-            return (version << 40) | (protocol << 32) | (dport << 16) | uid;
+            // The previous (version << 40) | (protocol << 32) shifts wrapped
+            // mod 32 and collapsed fields onto each other.
+            return Objects.hash(version, protocol, dport, uid);
         }
 
         @Override

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -673,8 +673,16 @@ object WgEgress {
             return
         }
 
+        val oldKeepaliveEnabled = currentInteractive || currentKeepaliveAlwaysOn
+        val newKeepaliveEnabled = interactive || keepaliveAlwaysOn
+        if (oldKeepaliveEnabled == newKeepaliveEnabled) {
+            currentInteractive = interactive
+            currentKeepaliveAlwaysOn = keepaliveAlwaysOn
+            return
+        }
+
         try {
-            reapplyConfig(configText!!, interactive || keepaliveAlwaysOn, interactive, keepaliveAlwaysOn)
+            reapplyConfig(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn)
         } catch (e: Throwable) {
             Log.w(TAG, "could not update WG keepalive for screen state", e)
         }

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -950,6 +950,8 @@ jint get_uid_sub(const int version, const int protocol,
             uid_cache[c].time = now;
         } else {
             log_android(ANDROID_LOG_ERROR, "Invalid field #%d: %s", fields, line);
+            if (fclose(fd))
+                log_android(ANDROID_LOG_ERROR, "fclose %s error %d: %s", fn, errno, strerror(errno));
             return -2;
         }
     }


### PR DESCRIPTION
Five small fixes from a battery/correctness review of the VPN core:

## Alarm timebase (`ServiceSinkhole`)

The watchdog and house-holding alarms passed a `SystemClock.elapsedRealtime()` trigger to an `AlarmManager.RTC` alarm. RTC reads the trigger as epoch millis, so a value based on time-since-boot lies decades in the past and the alarm fires immediately:

- house holding — log/DNS cleanup and, on GitHub builds, the HTTPS update check — ran at **every service create** (boot, VPN toggle, process restart) instead of a minute in, then every 12 h;
- with the watchdog enabled, every start/reload got an immediate extra foreground-service start on top of the intended periodic one.

Both now use `AlarmManager.ELAPSED_REALTIME` with the same base, preserving the non-wakeup semantics. The watchdog interval arithmetic is widened to `long`.

## Defensive parsing for clearable numeric preferences

`watchdog`, `pause` and `ttl` are `EditTextPreference`s with `inputType="number"`, which still allows clearing the field. An empty value threw `NumberFormatException` on three unpleasant paths:

- `watchdog` is parsed in `handleIntent` *before* the command switch, so every start/reload/stop command silently aborted;
- `pause` is parsed inside `getEnforcingNotification`, reachable from `onStartCommand`'s `startForeground`, where a throw kills the service;
- `ttl` is parsed in `DatabaseHelper.insertDns`, on the per-DNS-record upcall path.

Valid stored values parse exactly as before; only null/empty/unparseable input falls back to the previous defaults (0 / 10 / 259200).

## WireGuard: skip config re-apply when the effective keepalive is unchanged

`WgEgress.onInteractiveStateChanged` re-applied the full config on every screen on/off — config parse, peer endpoint re-resolution (a blocking DNS query once the 5-minute cache expired, including right as the screen goes off), and a full UAPI `set_config` — even when `interactive || keepaliveAlwaysOn` didn't change, e.g. with `wg_keepalive_when_screen_off` enabled. It now uses the same guard `startOrUpdate` already has. On the skip path `currentInteractive`/`currentKeepaliveAlwaysOn` are still updated so the connectivity monitor keeps the correct 1 s/15 s poll cadence, and `lastError`/state listeners are untouched.

## Native: `FILE*` leak in `get_uid_sub` (`ip.c`)

The malformed-`/proc/net` -line branch returned `-2` without `fclose(fd)`, leaking a file handle per UID lookup on affected devices (SDK ≤ 28 path). The close failure is logged the same way as the function's existing `fclose`.

## `IPKey.hashCode`

`(version << 40) | (protocol << 32) | ...` shifts an `int` by ≥ 32 bits, which wraps mod 32 and collapsed fields onto each other. Replaced with `Objects.hash(...)`, matching `DatabaseHelper.AccessKey`. No behavioral dependency on the old value — nothing persists the hash and `equals` is unchanged.

## Verification

Implemented via a delegated Codex agent against a reviewed spec, then diff-reviewed. Local Gradle verification was not possible in this environment (no Android SDK); the `test.yml` PR workflow compiles the app and runs the JVM unit and Rust tests, and I'll follow up on any failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh)_