### PR TITLE
Run the network validation probe off the ConnectivityManager thread

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -121,6 +121,7 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -3120,6 +3121,7 @@ public class ServiceSinkhole extends VpnService {
 
     ConnectivityManager.NetworkCallback networkMonitorCallback = new ConnectivityManager.NetworkCallback() {
         private String TAG = "TrackerControl.Monitor";
+        private final Set<Network> validating = ConcurrentHashMap.newKeySet();
 
         // https://android.googlesource.com/platform/frameworks/base/+/master/services/core/java/com/android/server/connectivity/NetworkMonitor.java
 
@@ -3182,33 +3184,58 @@ public class ServiceSinkhole extends VpnService {
                     }
                 }
 
-                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
-                String host = prefs.getString("validate", "www.f-droid.org");
-                Log.i(TAG, "Validating " + network + " " + ni + " host=" + host);
+                if (!validating.add(network))
+                    return;
 
-                Socket socket = null;
                 try {
-                    socket = network.getSocketFactory().createSocket();
-                    socket.connect(new InetSocketAddress(host, 443), 10000);
-                    Log.i(TAG, "Validated " + network + " " + ni + " host=" + host);
-                    synchronized (mapValidated) {
-                        mapValidated.put(network, new Date().getTime());
-                    }
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-                        cm.reportNetworkConnectivity(network, true);
-                        Log.i(TAG, "Reported " + network + " " + ni);
-                    }
-                } catch (IOException ex) {
-                    Log.e(TAG, ex.toString());
-                    Log.i(TAG, "No connectivity " + network + " " + ni);
-                } finally {
-                    if (socket != null)
-                        try {
-                            socket.close();
-                        } catch (IOException ex) {
-                            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                    executor.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
+                                String host = prefs.getString("validate", "www.f-droid.org");
+                                Log.i(TAG, "Validating " + network + " " + ni + " host=" + host);
+
+                                synchronized (mapValidated) {
+                                    if (mapValidated.containsKey(network) &&
+                                            mapValidated.get(network) + 20 * 1000 > new Date().getTime()) {
+                                        Log.i(TAG, "Already validated " + network + " " + ni);
+                                        return;
+                                    }
+                                }
+
+                                Socket socket = null;
+                                try {
+                                    socket = network.getSocketFactory().createSocket();
+                                    socket.connect(new InetSocketAddress(host, 443), 10000);
+                                    Log.i(TAG, "Validated " + network + " " + ni + " host=" + host);
+                                    synchronized (mapValidated) {
+                                        mapValidated.put(network, new Date().getTime());
+                                    }
+                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+                                        cm.reportNetworkConnectivity(network, true);
+                                        Log.i(TAG, "Reported " + network + " " + ni);
+                                    }
+                                } catch (IOException ex) {
+                                    Log.e(TAG, ex.toString());
+                                    Log.i(TAG, "No connectivity " + network + " " + ni);
+                                } finally {
+                                    if (socket != null)
+                                        try {
+                                            socket.close();
+                                        } catch (IOException ex) {
+                                            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                                        }
+                                }
+                            } finally {
+                                validating.remove(network);
+                            }
                         }
+                    });
+                } catch (RejectedExecutionException ex) {
+                    validating.remove(network);
+                    Log.e(TAG, ex.toString());
                 }
             }
         }


### PR DESCRIPTION
Follow-up to #800, first of the two deferred review findings.

## Problem

`networkMonitorCallback` is registered without a Handler, so its callbacks arrive on the process-wide ConnectivityManager callback thread — the same thread that delivers the network-change callbacks driving `reloadAfterNetworkChange` and the WireGuard socket rebind. `checkConnectivity` blocked that thread with `socket.connect(host:443, 10000)` for up to 10 s per probe. The probe only fires for active-but-unvalidated networks (captive portals, handoffs, networks whose Android validation the VPN confuses), which is exactly when the VPN also needs to react fastest to network changes — so its reaction could lag up to ~10 s behind the event, plus a probe every ~20 s while stuck on a dead network.

## Change

- The cheap eligibility checks (active network, detailed state, NOT_VPN, not-VALIDATED) and the 20-second per-network `mapValidated` throttle stay on the callback thread.
- The blocking connect — plus the `mapValidated` update and `reportNetworkConnectivity` — moves to the service's existing cached-thread-pool `executor`.
- A per-network in-flight set (`ConcurrentHashMap.newKeySet()`) prevents overlapping probes for the same network, which the callback thread's serialization used to guarantee implicitly; it is released in an outer `finally` covering the whole task.
- The throttle is re-checked inside the task under the same `synchronized (mapValidated)` discipline, closing the gap between the outer check and task execution.
- `RejectedExecutionException` (a callback racing `onDestroy`'s `executor.shutdownNow()`) is caught, logged, and the in-flight entry released, instead of crashing the service.

Probe semantics are otherwise byte-identical: same host/port/timeout, same log lines, same success/failure handling, socket always closed. A probe completing after `onLost` can re-insert the network into `mapValidated`; that was already possible ordering-wise and is harmless (entries self-expire via the 20 s window).

## Verification

Implemented via a delegated agent against a pinned design, then diff-reviewed against the invariants above. No Android SDK is available in this environment, so compilation and the unit-test suite run in the PR's `test.yml` workflow; I'll follow up on any failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh)_