### PR TITLE
Skip tracker-cache invalidation for refreshed DNS rows

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -52,6 +52,8 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     public static final int ACCESS_UNCERTAIN_MIXED_TRACKER_AND_NON_TRACKER = 2;
     public static final int ACCESS_UNCERTAIN_MULTIPLE_TRACKERS = 3;
 
+    public enum DnsInsertOutcome { FAILED, INSERTED, REFRESHED }
+
     public Cursor getHosts(int uid) {
         flushAccessBatch();
         flushUsageBatch();
@@ -1076,7 +1078,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         return (name == null ? null : name.toLowerCase(Locale.ROOT));
     }
 
-    public boolean insertDns(ResourceRecord rr) {
+    public DnsInsertOutcome insertDns(ResourceRecord rr) {
         lock.writeLock().lock();
         try {
             SQLiteDatabase db = this.getWritableDatabase();
@@ -1109,21 +1111,27 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                 int rows = db.update("dns", cv, "qname = ? AND aname = ? AND resource = ?",
                         new String[] { qname, aname, rr.Resource });
 
+                DnsInsertOutcome outcome;
                 if (rows == 0) {
                     cv.put("qname", qname);
                     cv.put("aname", aname);
                     cv.put("resource", rr.Resource);
 
                     if (db.insert("dns", null, cv) == -1)
-                        Log.e(TAG, "Insert dns failed");
+                        outcome = DnsInsertOutcome.FAILED;
                     else
-                        rows = 1;
-                } else if (rows != 1)
-                    Log.e(TAG, "Update dns failed rows=" + rows);
+                        outcome = DnsInsertOutcome.INSERTED;
+                    if (outcome == DnsInsertOutcome.FAILED)
+                        Log.e(TAG, "Insert dns failed");
+                } else {
+                    if (rows != 1)
+                        Log.e(TAG, "Update dns failed rows=" + rows);
+                    outcome = DnsInsertOutcome.REFRESHED;
+                }
 
                 db.setTransactionSuccessful();
 
-                return (rows > 0);
+                return outcome;
             } finally {
                 db.endTransaction();
             }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2596,20 +2596,31 @@ public class ServiceSinkhole extends VpnService {
 
     // Called from native code
     private void dnsResolved(ResourceRecord rr) {
-        if (DatabaseHelper.getInstance(ServiceSinkhole.this).insertDns(rr)) {
-            Log.i(TAG, "New IP " + rr);
+        DatabaseHelper.DnsInsertOutcome outcome =
+                DatabaseHelper.getInstance(ServiceSinkhole.this).insertDns(rr);
+        if (outcome != DatabaseHelper.DnsInsertOutcome.FAILED) {
+            if (outcome == DatabaseHelper.DnsInsertOutcome.INSERTED) {
+                Log.i(TAG, "New IP " + rr);
+            }
             prepareUidIPFilters(rr.QName);
 
-            if (Util.isNumericAddress(rr.Resource)) { // make sure correct format
-                ipToHost.remove(rr.Resource);
-                ipToTracker.remove(rr.Resource);
-                // Bump *after* the removes: a blockKnownTracker() read that
-                // started before this insert (and so may have missed this row)
-                // can still be mid-flight. Invalidating the generation here,
-                // after the cache is actually clear, is what makes its stale
-                // put() get discarded below instead of pinning pre-insert
-                // attribution behind this remove.
-                trackerCacheGeneration.incrementAndGet();
+            if (outcome == DatabaseHelper.DnsInsertOutcome.INSERTED) {
+                if (Util.isNumericAddress(rr.Resource)) { // make sure correct format
+                    ipToHost.remove(rr.Resource);
+                    ipToTracker.remove(rr.Resource);
+                    // Bump *after* the removes: a blockKnownTracker() read that
+                    // started before this new mapping (and so may have missed
+                    // this row) can still be mid-flight. Invalidating the
+                    // generation here, after the cache is actually clear, is
+                    // what makes its stale put() get discarded below instead
+                    // of pinning pre-insert attribution behind this remove.
+                    // Pure refreshes deliberately skip invalidation: the cached
+                    // entry simply expires on the earlier deadline it was stored
+                    // with and is re-read then, so a stale-put race with a
+                    // refresh is harmless. The generation guard remains for new
+                    // mappings, where the verdict can actually change.
+                    trackerCacheGeneration.incrementAndGet();
+                }
             }
         }
     }

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
@@ -23,6 +23,42 @@ public class DatabaseHelperDnsAttributionTest {
     private static final long NOW = System.currentTimeMillis();
 
     @Test
+    public void firstDnsInsertReportsInserted() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        assertEquals(DatabaseHelper.DnsInsertOutcome.INSERTED,
+                dh.insertDns(rr(NOW, "tracker.example.com", "tracker.example.com",
+                        "203.0.113.1", 3600)));
+    }
+
+    @Test
+    public void repeatedDnsInsertReportsRefreshed() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        ResourceRecord record = rr(NOW - 2_000L, "tracker.example.com", "tracker.example.com",
+                "203.0.113.2", 3600);
+        assertEquals(DatabaseHelper.DnsInsertOutcome.INSERTED, dh.insertDns(record));
+        assertEquals(DatabaseHelper.DnsInsertOutcome.REFRESHED,
+                dh.insertDns(rr(NOW, "tracker.example.com", "tracker.example.com",
+                        "203.0.113.2", 120)));
+    }
+
+    @Test
+    public void differentResourceReportsInserted() {
+        DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
+        dh.clearDns();
+
+        assertEquals(DatabaseHelper.DnsInsertOutcome.INSERTED,
+                dh.insertDns(rr(NOW, "tracker.example.com", "tracker.example.com",
+                        "203.0.113.3", 3600)));
+        assertEquals(DatabaseHelper.DnsInsertOutcome.INSERTED,
+                dh.insertDns(rr(NOW, "tracker.example.com", "tracker.example.com",
+                        "203.0.113.4", 120)));
+    }
+
+    @Test
     public void mostRecentlyObservedQnameIsReturnedFirst() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
         dh.clearDns();
@@ -67,8 +103,10 @@ public class DatabaseHelperDnsAttributionTest {
         dh.clearDns();
 
         String ip = "203.0.113.25";
-        dh.insertDns(rr(NOW - 5_000L, "Graph.Facebook.Com", "Alias.Example.Com", ip, 3600));
-        dh.insertDns(rr(NOW - 1_000L, "graph.facebook.com", "alias.example.com", ip, 3600));
+        assertEquals(DatabaseHelper.DnsInsertOutcome.INSERTED,
+                dh.insertDns(rr(NOW - 5_000L, "graph.facebook.com", "alias.example.com", ip, 3600)));
+        assertEquals(DatabaseHelper.DnsInsertOutcome.REFRESHED,
+                dh.insertDns(rr(NOW - 1_000L, "Graph.Facebook.Com", "Alias.Example.Com", ip, 3600)));
 
         try (Cursor c = dh.getQAName(-1, ip)) {
             assertEquals("case variants must share one stored qname", 1, c.getCount());


### PR DESCRIPTION
Follow-up to #800, second of the two deferred review findings (sibling of #801).

## Problem

`DatabaseHelper.insertDns` returned `true` for both a brand-new `dns` row and a refresh of an existing one — and a refresh (an UPDATE keyed on `qname, aname, resource` that only touches `time`/`ttl`) can never change what the row maps. `ServiceSinkhole.dnsResolved` treated every `true` as a new mapping: `"New IP"` log, `ipToHost`/`ipToTracker` eviction, and a `trackerCacheGeneration` bump, per answer record.

Most DNS answers on a running device are repeats (short-TTL CDN records, apps re-resolving the same domains), so the generation bump ran near-constantly under load — discarding in-flight `blockKnownTracker()` cache fills exactly when traffic is densest, driving extra per-connection `getQAName` reads. Pure browse-time overhead; decisions were never wrong.

## Change

- `insertDns` now returns `DnsInsertOutcome { FAILED, INSERTED, REFRESHED }` (UPDATE hit → `REFRESHED`; INSERT → `INSERTED`; failed INSERT → `FAILED`; the existing error logs are kept). It's the only production caller-visible change — `dnsResolved` is the sole caller.
- `dnsResolved` still calls `prepareUidIPFilters` for **both** non-failure outcomes — the refresh path is load-bearing there (it extends IP-rule TTLs via `IPRule.updateExpires`).
- Only `INSERTED` now logs, evicts the per-IP cache entries, and bumps the generation. A pure refresh leaves the cached entry to expire on the earlier deadline it was stored with and be re-read then — safe, because a refresh cannot change the verdict. The remove-then-bump ordering and its race comment are preserved and extended to document this.

## Tests

New `DatabaseHelperDnsAttributionTest` cases: first insert → `INSERTED`; repeat of the same `(qname, aname, resource)` with different time/ttl → `REFRESHED`; same names with a different resource → `INSERTED`; and the existing case-normalization test now asserts a case-variant qname (`Graph.Facebook.Com`) refreshes the lowercase row rather than inserting a duplicate.

## Verification

Implemented via a delegated agent against a pinned design, then diff-reviewed. No Android SDK in this environment, so compilation and the Robolectric suite run in the PR's `test.yml` workflow; I'll follow up on any failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh

---
_Generated by [Claude Code](https://claude.ai/code/session_01N8DS7ti2MwHdp44ZbhqEYh)_