### PR TITLE
Retry failed WireGuard startup

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -260,6 +260,49 @@ public class ServiceSinkhole extends VpnService {
         ServiceSinkhole.reload("native tunnel recovery", ServiceSinkhole.this, false);
     };
 
+    private static final int WG_STARTUP_RECOVERY_MAX_RETRIES = 5;
+    private static final long WG_STARTUP_RECOVERY_INITIAL_DELAY_MS = 1_000L;
+    private static final long WG_STARTUP_RECOVERY_STABLE_WINDOW_MS = 2 * 60_000L;
+    private static final String EXTRA_WG_STARTUP_RETRY = "WireGuardStartupRetry";
+    private final WireGuardStartupRecoveryPolicy wgStartupRecoveryPolicy =
+            new WireGuardStartupRecoveryPolicy(
+                    WG_STARTUP_RECOVERY_MAX_RETRIES,
+                    WG_STARTUP_RECOVERY_INITIAL_DELAY_MS,
+                    WG_STARTUP_RECOVERY_STABLE_WINDOW_MS);
+    private final Object wgStartupRecoveryLock = new Object();
+    private final Handler wgStartupRecoveryHandler = new Handler(Looper.getMainLooper());
+    private final Runnable wgStartupRecoveryRunnable = () -> {
+        synchronized (ServiceSinkhole.this) {
+            synchronized (wgStartupRecoveryLock) {
+                if (!wgStartupRecoveryPolicy.claim())
+                    return;
+            }
+
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
+            if (destroying || !initialized || commandHandler == null || state != State.enforcing
+                    || !user_foreground || !prefs.getBoolean("enabled", false)
+                    || temporarilyStopped || vpn == null) {
+                Log.i(TAG, "Skipping WireGuard startup recovery because protection is no longer active");
+                cancelWireGuardStartupRecovery(true);
+                return;
+            }
+            if (VpnService.prepare(ServiceSinkhole.this) != null) {
+                Log.i(TAG, "Skipping WireGuard startup recovery because VPN consent was revoked");
+                cancelWireGuardStartupRecovery(true);
+                return;
+            }
+
+            Log.i(TAG, "Queueing WireGuard startup recovery");
+            getLock(ServiceSinkhole.this).acquire(WAKELOCK_TIMEOUT_MS);
+            Intent intent = new Intent(ServiceSinkhole.this, ServiceSinkhole.class);
+            intent.putExtra(EXTRA_COMMAND, Command.reload);
+            intent.putExtra(EXTRA_REASON, "WireGuard startup recovery");
+            intent.putExtra(EXTRA_WG_STARTUP_RETRY, true);
+            intent.putExtra(EXTRA_INTERACTIVE, false);
+            commandHandler.queue(intent);
+        }
+    };
+
     private static final int VPN_REPLACEMENT_RECOVERY_MAX_RETRIES = 5;
     private static final long VPN_REPLACEMENT_RECOVERY_INITIAL_DELAY_MS = 1_000L;
     // The ladder above spans about half a minute. A failure this long after the
@@ -498,6 +541,9 @@ public class ServiceSinkhole extends VpnService {
                     handleIntent((Intent) msg.obj);
                 }
             } catch (Throwable ex) {
+                Intent intent = (Intent) msg.obj;
+                if (intent != null && intent.getBooleanExtra(EXTRA_WG_STARTUP_RETRY, false))
+                    cancelWireGuardStartupRecovery(true);
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             } finally {
                 synchronized (this) {
@@ -522,8 +568,22 @@ public class ServiceSinkhole extends VpnService {
 
             Command cmd = (Command) intent.getSerializableExtra(EXTRA_COMMAND);
             String reason = intent.getStringExtra(EXTRA_REASON);
+            final boolean wireGuardStartupRetry =
+                    intent.getBooleanExtra(EXTRA_WG_STARTUP_RETRY, false);
             Log.i(TAG, "Executing intent=" + intent + " command=" + cmd + " reason=" + reason +
                     " vpn=" + (vpn != null) + " user=" + (Process.myUid() / 100000));
+
+            // Consume the dispatch marker before any preflight gate can return.
+            // Otherwise a background-user or temporary-stop return strands the
+            // retry in the dispatched state and blocks all later failures.
+            if (wireGuardStartupRetry) {
+                synchronized (wgStartupRecoveryLock) {
+                    if (!wgStartupRecoveryPolicy.begin()) {
+                        Log.i(TAG, "Ignoring stale WireGuard startup recovery");
+                        return;
+                    }
+                }
+            }
 
             // Check if foreground
             if (cmd != Command.stop)
@@ -534,6 +594,8 @@ public class ServiceSinkhole extends VpnService {
                         user_foreground = true;
                         Log.i(TAG, "User-initiated start, clearing background user state");
                     } else {
+                        if (wireGuardStartupRetry)
+                            cancelWireGuardStartupRecovery(true);
                         Log.i(TAG, "Command " + cmd + " ignored for background user");
                         return;
                     }
@@ -546,6 +608,8 @@ public class ServiceSinkhole extends VpnService {
                 temporarilyStopped = false;
             else if (cmd == Command.reload && temporarilyStopped) {
                 // Prevent network/interactive changes from restarting the VPN
+                if (wireGuardStartupRetry)
+                    cancelWireGuardStartupRecovery(true);
                 Log.i(TAG, "Command " + cmd + " ignored because of temporary stop");
                 return;
             }
@@ -634,10 +698,16 @@ public class ServiceSinkhole extends VpnService {
                             cancelNativeRecovery(true);
                         if (vpn == null)
                             cancelVpnReplacementRecovery(true);
+                        if (vpn == null)
+                            cancelWireGuardStartupRecovery(true);
                         start();
                         break;
 
                     case reload:
+                        // The startup-retry dispatch marker was consumed before
+                        // preflight; ordinary reloads cancel stale retries.
+                        if (!wireGuardStartupRetry)
+                            cancelWireGuardStartupRecovery(false);
                         if (!intent.getBooleanExtra(EXTRA_REPLACEMENT_RETRY, false))
                             cancelVpnReplacementRecovery(false);
                         reload(intent.getBooleanExtra(EXTRA_INTERACTIVE, false));
@@ -646,6 +716,7 @@ public class ServiceSinkhole extends VpnService {
                     case stop:
                         cancelNativeRecovery(true);
                         cancelVpnReplacementRecovery(true);
+                        cancelWireGuardStartupRecovery(true);
                         stop(temporarilyStopped);
                         break;
 
@@ -692,6 +763,8 @@ public class ServiceSinkhole extends VpnService {
                         !prefs.getBoolean("show_stats", false))
                     stopForeground(true);
             } catch (Throwable ex) {
+                if (wireGuardStartupRetry)
+                    cancelWireGuardStartupRecovery(true);
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
 
                 if (cmd == Command.start || cmd == Command.reload) {
@@ -840,6 +913,7 @@ public class ServiceSinkhole extends VpnService {
         }
 
         private void stop(boolean temporary) {
+            cancelWireGuardStartupRecovery(true);
             if (vpn != null) {
                 stopNative(vpn);
                 stopVPN(vpn);
@@ -2081,8 +2155,10 @@ public class ServiceSinkhole extends VpnService {
             String wgError = net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.getLastError();
             Log.w(TAG, "WireGuard egress failed to start; blocking traffic: " + wgError);
             showWireGuardErrorNotification(wgError);
+            scheduleWireGuardStartupRecovery();
             return false;
         }
+        cancelWireGuardStartupRecovery(true);
         net.kollnig.missioncontrol.wg.VpnKeyRotationManager.maybeRotateDue(ServiceSinkhole.this);
 
         if (tunnelThread == null) {
@@ -2545,6 +2621,46 @@ public class ServiceSinkhole extends VpnService {
         nativeRecoveryHandler.removeCallbacks(nativeRecoveryRunnable);
         if (resetBudget)
             nativeRecoveryPolicy.reset();
+    }
+
+    private void scheduleWireGuardStartupRecovery() {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean active = !destroying && initialized && commandHandler != null
+                && state == State.enforcing && user_foreground
+                && prefs.getBoolean("enabled", false) && !temporarilyStopped
+                && vpn != null && VpnService.prepare(this) == null;
+        synchronized (wgStartupRecoveryLock) {
+            long delayMs = wgStartupRecoveryPolicy.onFailure(
+                    // Handler.postDelayed uses uptime; matching its clock
+                    // prevents deep sleep from aging a failure episode into
+                    // the stable window without a successful startup.
+                    SystemClock.uptimeMillis(), active);
+            if (!active) {
+                Log.i(TAG, "Skipping WireGuard startup recovery because protection is no longer active");
+                wgStartupRecoveryHandler.removeCallbacks(wgStartupRecoveryRunnable);
+                return;
+            }
+            if (delayMs == FailureRecoveryPolicy.NO_RETRY) {
+                if (wgStartupRecoveryPolicy.isPending())
+                    Log.i(TAG, "WireGuard startup recovery already pending");
+                else
+                    Log.e(TAG, "WireGuard startup recovery retry budget exhausted");
+                return;
+            }
+            if (!wgStartupRecoveryHandler.postDelayed(wgStartupRecoveryRunnable, delayMs)) {
+                wgStartupRecoveryPolicy.cancel(false);
+                Log.e(TAG, "Could not schedule WireGuard startup recovery");
+                return;
+            }
+            Log.w(TAG, "Scheduled WireGuard startup recovery in " + delayMs + " ms");
+        }
+    }
+
+    private void cancelWireGuardStartupRecovery(boolean resetBudget) {
+        synchronized (wgStartupRecoveryLock) {
+            wgStartupRecoveryHandler.removeCallbacks(wgStartupRecoveryRunnable);
+            wgStartupRecoveryPolicy.cancel(resetBudget);
+        }
     }
 
     private void scheduleVpnReplacementRecovery() {
@@ -3824,6 +3940,7 @@ public class ServiceSinkhole extends VpnService {
     @Override
     public void onRevoke() {
         Log.i(TAG, "Revoke");
+        cancelWireGuardStartupRecovery(true);
         cancelVpnReplacementRecovery(false);
 
         // Preserve the enabled state only while Android still designates us as
@@ -3885,6 +4002,7 @@ public class ServiceSinkhole extends VpnService {
             // Cancel any debounced network-change reload so it doesn't fire post-teardown
             networkReloadDebounceHandler.removeCallbacksAndMessages(NETWORK_RELOAD_TOKEN);
             cancelNativeRecovery(true);
+            cancelWireGuardStartupRecovery(true);
             cancelVpnReplacementRecovery(true);
 
             // onCreate can stopSelf() before creating the handler threads when

--- a/app/src/main/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicy.java
@@ -1,0 +1,84 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation.
+ */
+
+package eu.faircode.netguard;
+
+/**
+ * Bounded retry state for a WireGuard startup that left the VPN descriptor
+ * active but could not start the packet engine.
+ *
+ * <p>This policy deliberately has its own budget: a failed startup is not a
+ * native-thread failure or a failed VPN replacement, and those recovery
+ * episodes must not consume one another's retries.</p>
+ */
+final class WireGuardStartupRecoveryPolicy {
+    static final long NO_RETRY = FailureRecoveryPolicy.NO_RETRY;
+
+    private final FailureRecoveryPolicy retryPolicy;
+    private boolean pending;
+    private boolean dispatched;
+
+    WireGuardStartupRecoveryPolicy(int maxRetries, long initialDelayMs, long stableWindowMs) {
+        retryPolicy = new FailureRecoveryPolicy(maxRetries, initialDelayMs, stableWindowMs);
+    }
+
+    /**
+     * Records a failure and claims a single pending retry slot. A disabled
+     * service never schedules work, even if a stale failure callback arrives.
+     */
+    synchronized long onFailure(long nowMs, boolean active) {
+        if (!active) {
+            pending = false;
+            dispatched = false;
+            return NO_RETRY;
+        }
+        if (pending || dispatched)
+            return NO_RETRY;
+
+        long delayMs = retryPolicy.onFailure(nowMs);
+        if (delayMs != NO_RETRY)
+            pending = true;
+        return delayMs;
+    }
+
+    /** Claims the queued retry so a callback can dispatch at most once. */
+    synchronized boolean claim() {
+        if (!pending)
+            return false;
+        pending = false;
+        dispatched = true;
+        return true;
+    }
+
+    /** Marks the tagged command as running and consumes its dispatch marker. */
+    synchronized boolean begin() {
+        if (!dispatched)
+            return false;
+        dispatched = false;
+        return true;
+    }
+
+    /** Successful startup clears a pending callback and restores the budget. */
+    synchronized void onSuccess() {
+        pending = false;
+        dispatched = false;
+        retryPolicy.reset();
+    }
+
+    /** Cancels queued work; callers choose whether this is a new episode. */
+    synchronized void cancel(boolean resetBudget) {
+        pending = false;
+        dispatched = false;
+        if (resetBudget)
+            retryPolicy.reset();
+    }
+
+    synchronized boolean isPending() {
+        return pending || dispatched;
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicyTest.java
@@ -1,0 +1,88 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class WireGuardStartupRecoveryPolicyTest {
+    @Test
+    public void firstFailureAndBackoffClaimOneRetry() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(5, 1_000L, 120_000L);
+
+        assertEquals(1_000L, policy.onFailure(0L, true));
+        assertTrue(policy.isPending());
+        assertEquals(WireGuardStartupRecoveryPolicy.NO_RETRY, policy.onFailure(0L, true));
+        assertTrue(policy.claim());
+        assertTrue(policy.begin());
+        assertFalse(policy.claim());
+        assertEquals(2_000L, policy.onFailure(1_000L, true));
+    }
+
+    @Test
+    public void successfulStartupResetsBackoff() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        assertEquals(500L, policy.onFailure(0L, true));
+        assertTrue(policy.claim());
+        policy.onSuccess();
+        assertEquals(500L, policy.onFailure(1L, true));
+    }
+
+    @Test
+    public void uptimeClockDoesNotResetBeforeStableWindow() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        // ServiceSinkhole uses SystemClock.uptimeMillis() because the retry is
+        // dispatched by Handler.postDelayed, whose delay also excludes sleep.
+        assertEquals(500L, policy.onFailure(0L, true));
+        assertTrue(policy.claim());
+        assertTrue(policy.begin());
+        assertEquals(1_000L, policy.onFailure(9_999L, true));
+    }
+
+    @Test
+    public void exhaustionStopsFurtherRetries() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        assertEquals(500L, policy.onFailure(0L, true));
+        assertTrue(policy.claim());
+        assertTrue(policy.begin());
+        assertEquals(1_000L, policy.onFailure(500L, true));
+        assertTrue(policy.claim());
+        assertTrue(policy.begin());
+        assertEquals(WireGuardStartupRecoveryPolicy.NO_RETRY, policy.onFailure(1_500L, true));
+        assertFalse(policy.isPending());
+    }
+
+    @Test
+    public void cancellationRemovesPendingRetryAndResetsBudget() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        assertEquals(500L, policy.onFailure(0L, true));
+        policy.cancel(true);
+        assertFalse(policy.isPending());
+        assertEquals(500L, policy.onFailure(1L, true));
+    }
+
+    @Test
+    public void cancellationRemovesDispatchedRetry() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        assertEquals(500L, policy.onFailure(0L, true));
+        assertTrue(policy.claim());
+        policy.cancel(true);
+        assertFalse(policy.begin());
+        assertEquals(500L, policy.onFailure(1L, true));
+    }
+
+    @Test
+    public void disabledServiceNeverSchedulesRetry() {
+        WireGuardStartupRecoveryPolicy policy = new WireGuardStartupRecoveryPolicy(2, 500L, 10_000L);
+
+        assertEquals(WireGuardStartupRecoveryPolicy.NO_RETRY, policy.onFailure(0L, false));
+        assertFalse(policy.isPending());
+        assertEquals(500L, policy.onFailure(1L, true));
+    }
+}


### PR DESCRIPTION
## Summary
- retry failed WireGuard startup with a separate five-attempt exponential-backoff budget
- keep captured traffic fail-closed while startup is unavailable
- cancel/reset retries across success, stop, revoke, destroy, inactive users, and stale commands
- use uptime consistently so deep sleep cannot reset the budget

## Why
A transient `WgEgress.startOrUpdate` failure left the VPN descriptor active and traffic blocked, but never attempted automatic recovery.

## Validation
- focused startup, native recovery, VPN replacement, and sequencing JVM tests
- Java compile
- `git diff --check`

## Risk
- No device lifecycle/wake-lock test was run. Retries are bounded and use no polling loop or forced keepalive; the existing error remains visible after exhaustion.

