### PR TITLE
Publish tracker cache entries atomically

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -126,7 +126,6 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.zip.GZIPInputStream;
 
@@ -906,10 +905,7 @@ public class ServiceSinkhole extends VpnService {
             DatabaseHelper.getInstance(ServiceSinkhole.this).cleanupDns();
 
             // Refresh mappings regularly
-            ipToHost.clear();
-            ipToTracker.clear();
-            // Same race as dnsResolved(): invalidate after clearing.
-            trackerCacheGeneration.incrementAndGet();
+            trackerCache.clear();
             uidToApp.clear();
             uidToPackage.clear();
 
@@ -2344,6 +2340,7 @@ public class ServiceSinkhole extends VpnService {
 
         // Reload TrackerList to ensure it stays in sync with updated hosts
         TrackerList.reloadTrackerData(c);
+        clearTrackerCaches();
     }
 
     private void prepareUidIPFilters(String dname) {
@@ -2607,20 +2604,12 @@ public class ServiceSinkhole extends VpnService {
 
             if (outcome == DatabaseHelper.DnsInsertOutcome.INSERTED) {
                 if (Util.isNumericAddress(rr.Resource)) { // make sure correct format
-                    ipToHost.remove(rr.Resource);
-                    ipToTracker.remove(rr.Resource);
-                    // Bump *after* the removes: a blockKnownTracker() read that
-                    // started before this new mapping (and so may have missed
-                    // this row) can still be mid-flight. Invalidating the
-                    // generation here, after the cache is actually clear, is
-                    // what makes its stale put() get discarded below instead
-                    // of pinning pre-insert attribution behind this remove.
+                    trackerCache.invalidate(rr.Resource);
                     // Pure refreshes deliberately skip invalidation: the cached
                     // entry simply expires on the earlier deadline it was stored
                     // with and is re-read then, so a stale-put race with a
-                    // refresh is harmless. The generation guard remains for new
-                    // mappings, where the verdict can actually change.
-                    trackerCacheGeneration.incrementAndGet();
+                    // refresh is harmless. The atomic cache generation guard
+                    // remains for new mappings, where the verdict can change.
                 }
             }
         }
@@ -2670,13 +2659,9 @@ public class ServiceSinkhole extends VpnService {
 
     static ConcurrentHashMap<Integer, String> uidToApp = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<Integer, String> uidToPackage = new ConcurrentHashMap<>();
-    static ConcurrentHashMap<String, Expiring<String>> ipToHost = new ConcurrentHashMap<>();
-    static ConcurrentHashMap<String, Expiring<Tracker>> ipToTracker = new ConcurrentHashMap<>();
-    // Bumped by dnsResolved() whenever it invalidates an ipToHost/ipToTracker
-    // entry, so blockKnownTracker() can detect a DB read that raced a
-    // concurrent insert and drop its (possibly stale) result instead of
-    // caching it. See the comments at both call sites.
-    private static final AtomicLong trackerCacheGeneration = new AtomicLong();
+    // Hostname and tracker verdict are one immutable snapshot. Keeping them in
+    // one cache entry prevents a reader from observing only half a publication.
+    static final TrackerCache trackerCache = new TrackerCache();
     static String NO_DNAME = "null"; // use a String, unequal the real null
     static Tracker NO_TRACKER = new Tracker(null, null, 0);
     // Negative results (no tracker / no dname for an IP) are cached only
@@ -2685,11 +2670,7 @@ public class ServiceSinkhole extends VpnService {
     private static final long NEGATIVE_TRACKER_CACHE_TTL_MS = 60 * 1000L;
 
     public static void clearTrackerCaches() {
-        ipToHost.clear();
-        ipToTracker.clear();
-        // Same race as dnsResolved(): invalidate after clearing, so a
-        // blockKnownTracker() put in flight under the old mode is dropped.
-        trackerCacheGeneration.incrementAndGet();
+        trackerCache.clear();
     }
 
     // Called from native code
@@ -2837,25 +2818,13 @@ public class ServiceSinkhole extends VpnService {
         String blockingMode = BlockingMode.getMode(this);
         boolean blockAmbiguousTrackers = BlockingModeLogic.blocksAmbiguousTrackerIp(blockingMode);
         Tracker tracker = null;
-        Expiring<Tracker> expiringTracker = ipToTracker.get(daddr);
-        if (expiringTracker != null) {
-            tracker = expiringTracker.getOrExpired();
-
-            if (tracker == null) // expired
-                ipToTracker.remove(daddr);
-        }
+        TrackerCache.Entry cached = trackerCache.get(daddr, System.currentTimeMillis());
+        if (cached != null)
+            tracker = cached.getTracker();
 
         if (tracker == null) {
             // Check if IP known
             String dname = null;
-            Expiring<String> expiringHost = ipToHost.get(daddr);
-            if (expiringHost != null) {
-                dname = expiringHost.getOrExpired();
-
-                if (dname == null) // expired
-                    ipToHost.remove(daddr);
-            }
-
             if (dname == null) { // TODO: Note that this does not implement any SNI code
                 // Snapshot before the DB read: if dnsResolved() invalidates this
                 // IP's cache entry while we're mid-read below, our result may be
@@ -2863,7 +2832,7 @@ public class ServiceSinkhole extends VpnService {
                 // that no longer applies). Comparing after the read lets us
                 // drop the put and let the next packet re-read instead of
                 // pinning a possibly-wrong verdict.
-                long generationBefore = trackerCacheGeneration.get();
+                long generationBefore = trackerCache.generation();
                 // Retrieve dname from DB
                 DatabaseHelper dh = DatabaseHelper.getInstance(ServiceSinkhole.this);
                 long now = new Date().getTime();
@@ -2967,10 +2936,11 @@ public class ServiceSinkhole extends VpnService {
                 // stale verdict that a racing insert already made obsolete.
                 // Skipping is cheap and correct: the next packet to this IP
                 // simply re-reads the DB.
-                if (trackerCacheGeneration.get() == generationBefore) {
-                    ipToHost.put(daddr, new Expiring<>(dname, expiry));
-                    ipToTracker.put(daddr, new Expiring<>(tracker, expiry));
-                }
+                TrackerCache.Entry cacheEntry = new TrackerCache.Entry(dname, tracker, expiry);
+                trackerCache.putIfGeneration(daddr, cacheEntry, generationBefore);
+                // Keep the exact snapshot used for the decision for logging;
+                // the shared cache may be invalidated or replaced meanwhile.
+                cached = cacheEntry;
             }
 
             // Do not block based on IP-only tracker evidence.
@@ -2985,17 +2955,12 @@ public class ServiceSinkhole extends VpnService {
                 app = Common.getAppName(pm, uid);
                 uidToApp.put(uid, app);
             }
-            // tracker can be null here when the host cache had an entry but the
-            // tracker cache was empty/expired, and ipToHost.get(daddr) can be
-            // null on an ipToTracker cache hit (the ipToHost.put(...) block is
-            // skipped). Guard both so log_logcat never NPEs the packet path.
             if (tracker != null) {
-                Expiring<String> expiringHost = ipToHost.get(daddr);
-                String host = (expiringHost == null ? null : expiringHost.getOrExpired());
+                String host = (cached == null ? null : cached.getHostname());
                 Log.i("TC-Log", app + " " + daddr + " " + host + " " + tracker.getName());
             }
         } else {
-            if (tracker != NO_TRACKER) {
+            if (tracker != null && tracker != NO_TRACKER) {
                 boolean blockedByGranularRule = false;
                 if (!BlockingMode.MODE_MINIMAL.equals(blockingMode)) {
                     TrackerBlocklist b = TrackerBlocklist.getInstance(ServiceSinkhole.this);
@@ -4489,27 +4454,6 @@ public class ServiceSinkhole extends VpnService {
         @Override
         public String toString() {
             return "v" + version + " p" + protocol + " port=" + dport + " uid=" + uid;
-        }
-    }
-
-    private class Expiring<T> {
-        private T t;
-        private long expires;
-
-        public Expiring(T t, long expires) {
-            this.t = t;
-            this.expires = expires;
-        }
-
-        public boolean isExpired() {
-            return System.currentTimeMillis() > this.expires;
-        }
-
-        public T getOrExpired() {
-            if (isExpired())
-                return null;
-
-            return t;
         }
     }
 

--- a/app/src/main/java/eu/faircode/netguard/TrackerCache.java
+++ b/app/src/main/java/eu/faircode/netguard/TrackerCache.java
@@ -1,0 +1,93 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package eu.faircode.netguard;
+
+import net.kollnig.missioncontrol.data.Tracker;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Atomically publishes the hostname and tracker verdict for an IP address.
+ *
+ * <p>The generation is advanced together with invalidation. Writers that read
+ * the database outside this cache can publish only when their generation is
+ * still current. The lock makes that check and publication atomic with
+ * invalidation, so a stale database result cannot be reintroduced after a
+ * cache clear.</p>
+ */
+final class TrackerCache {
+    static final class Entry {
+        private final String hostname;
+        private final Tracker tracker;
+        private final long expires;
+
+        Entry(String hostname, Tracker tracker, long expires) {
+            this.hostname = Objects.requireNonNull(hostname);
+            this.tracker = Objects.requireNonNull(tracker);
+            this.expires = expires;
+        }
+
+        String getHostname() {
+            return hostname;
+        }
+
+        Tracker getTracker() {
+            return tracker;
+        }
+
+        boolean isExpired(long now) {
+            return now > expires;
+        }
+    }
+
+    private final ConcurrentHashMap<String, Entry> entries = new ConcurrentHashMap<>();
+    private final Object mutationLock = new Object();
+    private final AtomicLong generation = new AtomicLong();
+
+    Entry get(String address, long now) {
+        Entry entry = entries.get(address);
+        if (entry != null && entry.isExpired(now)) {
+            entries.remove(address, entry);
+            return null;
+        }
+        return entry;
+    }
+
+    long generation() {
+        return generation.get();
+    }
+
+    boolean putIfGeneration(String address, Entry entry, long expectedGeneration) {
+        Objects.requireNonNull(entry);
+        synchronized (mutationLock) {
+            if (generation.get() != expectedGeneration)
+                return false;
+
+            entries.put(address, entry);
+            return true;
+        }
+    }
+
+    void invalidate(String address) {
+        synchronized (mutationLock) {
+            entries.remove(address);
+            generation.incrementAndGet();
+        }
+    }
+
+    void clear() {
+        synchronized (mutationLock) {
+            entries.clear();
+            generation.incrementAndGet();
+        }
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/TrackerCacheTest.java
+++ b/app/src/test/java/eu/faircode/netguard/TrackerCacheTest.java
@@ -1,0 +1,227 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import net.kollnig.missioncontrol.data.Tracker;
+
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class TrackerCacheTest {
+    private static final String ADDRESS = "192.0.2.1";
+    private static final long NEVER_EXPIRES = Long.MAX_VALUE;
+
+    @Test
+    public void publicationNeverExposesHalfEntry() throws Exception {
+        TrackerCache cache = new TrackerCache();
+        Tracker tracker = tracker("Example");
+        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker, NEVER_EXPIRES);
+        CountDownLatch readerReady = new CountDownLatch(1);
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch published = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+
+        Thread reader = new Thread(() -> {
+            try {
+                readerReady.countDown();
+                assertTrue(start.await(5, TimeUnit.SECONDS));
+                while (published.getCount() != 0) {
+                    TrackerCache.Entry observed = cache.get(ADDRESS, System.currentTimeMillis());
+                    if (observed != null) {
+                        assertEquals("tracker.example", observed.getHostname());
+                        assertSame(tracker, observed.getTracker());
+                    }
+                }
+                TrackerCache.Entry observed = cache.get(ADDRESS, System.currentTimeMillis());
+                assertNotNull(observed);
+                assertEquals("tracker.example", observed.getHostname());
+                assertSame(tracker, observed.getTracker());
+            } catch (Throwable ex) {
+                failure.set(ex);
+            }
+        });
+        reader.start();
+        assertTrue(readerReady.await(5, TimeUnit.SECONDS));
+
+        Thread writer = new Thread(() -> {
+            try {
+                assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
+            } catch (Throwable ex) {
+                failure.set(ex);
+            } finally {
+                published.countDown();
+            }
+        });
+        writer.start();
+        start.countDown();
+        writer.join(5_000);
+        reader.join(5_000);
+
+        assertFalse("writer did not finish", writer.isAlive());
+        assertFalse("reader did not finish", reader.isAlive());
+        if (failure.get() != null)
+            throw new AssertionError(failure.get());
+    }
+
+    @Test
+    public void expiredEntryIsRemovedAsOneSnapshot() {
+        TrackerCache cache = new TrackerCache();
+        TrackerCache.Entry entry = new TrackerCache.Entry(
+                "tracker.example", tracker("Example"), System.currentTimeMillis() - 1);
+
+        assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
+        assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void expiryBoundaryIsStillValid() {
+        TrackerCache cache = new TrackerCache();
+        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker("Example"), 100L);
+
+        assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
+        assertNotNull(cache.get(ADDRESS, 100L));
+        assertNull(cache.get(ADDRESS, 101L));
+    }
+
+    @Test
+    public void invalidationRejectsStalePublication() {
+        TrackerCache cache = new TrackerCache();
+        TrackerCache.Entry entry = new TrackerCache.Entry("old.example", tracker("Old"), NEVER_EXPIRES);
+        long generationBefore = cache.generation();
+        assertTrue(cache.putIfGeneration(ADDRESS, entry, generationBefore));
+
+        cache.invalidate(ADDRESS);
+
+        assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
+        assertFalse(cache.putIfGeneration(
+                ADDRESS,
+                new TrackerCache.Entry("stale.example", tracker("Stale"), NEVER_EXPIRES),
+                generationBefore));
+        assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
+        assertEquals(generationBefore + 1, cache.generation());
+    }
+
+    @Test
+    public void clearInvalidatesAllEntries() {
+        TrackerCache cache = new TrackerCache();
+        long generationBefore = cache.generation();
+        assertTrue(cache.putIfGeneration(
+                ADDRESS,
+                new TrackerCache.Entry("one.example", tracker("One"), NEVER_EXPIRES),
+                generationBefore));
+        assertTrue(cache.putIfGeneration(
+                "192.0.2.2",
+                new TrackerCache.Entry("two.example", tracker("Two"), NEVER_EXPIRES),
+                generationBefore));
+
+        cache.clear();
+
+        assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
+        assertNull(cache.get("192.0.2.2", System.currentTimeMillis()));
+        assertEquals(generationBefore + 1, cache.generation());
+    }
+
+    @Test
+    public void invalidateCannotLoseRaceToPublication() throws Exception {
+        assertRaceLeavesAddressEmpty(false);
+    }
+
+    @Test
+    public void clearCannotLoseRaceToPublication() throws Exception {
+        assertRaceLeavesAddressEmpty(true);
+    }
+
+    @Test
+    public void blockingSnapshotAlwaysContainsTracker() {
+        TrackerCache cache = new TrackerCache();
+        TrackerCache.Entry entry = new TrackerCache.Entry(
+                ServiceSinkhole.NO_DNAME, ServiceSinkhole.NO_TRACKER, NEVER_EXPIRES);
+
+        assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
+        TrackerCache.Entry blockingSnapshot = cache.get(ADDRESS, System.currentTimeMillis());
+        assertNotNull(blockingSnapshot);
+        assertSame(ServiceSinkhole.NO_DNAME, blockingSnapshot.getHostname());
+        assertSame(ServiceSinkhole.NO_TRACKER, blockingSnapshot.getTracker());
+    }
+
+    @Test
+    public void nullTrackerCannotEnterCache() {
+        try {
+            new TrackerCache.Entry("tracker.example", null, NEVER_EXPIRES);
+            fail("null tracker must not be cacheable");
+        } catch (NullPointerException expected) {
+            // The blocking path can only read entries made through this value.
+        }
+    }
+
+    @Test
+    public void nullHostnameCannotEnterCache() {
+        try {
+            new TrackerCache.Entry(null, tracker("Example"), NEVER_EXPIRES);
+            fail("null hostname must not be cacheable");
+        } catch (NullPointerException expected) {
+            // The blocking path can only read complete snapshots.
+        }
+    }
+
+    private static void assertRaceLeavesAddressEmpty(boolean clear) throws Exception {
+        for (int attempt = 0; attempt < 128; attempt++) {
+            TrackerCache cache = new TrackerCache();
+            long generation = cache.generation();
+            assertTrue(cache.putIfGeneration(
+                    ADDRESS,
+                    new TrackerCache.Entry("old.example", tracker("Old"), NEVER_EXPIRES),
+                    generation));
+            CyclicBarrier barrier = new CyclicBarrier(3);
+            AtomicReference<Throwable> failure = new AtomicReference<>();
+
+            Thread publisher = new Thread(() -> {
+                try {
+                    barrier.await();
+                    cache.putIfGeneration(
+                            ADDRESS,
+                            new TrackerCache.Entry("stale.example", tracker("Stale"), NEVER_EXPIRES),
+                            generation);
+                } catch (Throwable ex) {
+                    failure.compareAndSet(null, ex);
+                }
+            });
+            Thread invalidator = new Thread(() -> {
+                try {
+                    barrier.await();
+                    if (clear)
+                        cache.clear();
+                    else
+                        cache.invalidate(ADDRESS);
+                } catch (Throwable ex) {
+                    failure.compareAndSet(null, ex);
+                }
+            });
+            publisher.start();
+            invalidator.start();
+            barrier.await();
+            publisher.join(5_000);
+            invalidator.join(5_000);
+
+            assertFalse("publisher did not finish", publisher.isAlive());
+            assertFalse("invalidator did not finish", invalidator.isAlive());
+            if (failure.get() != null)
+                throw new AssertionError(failure.get());
+            assertNull("stale publication survived invalidation", cache.get(ADDRESS, System.currentTimeMillis()));
+        }
+    }
+
+    private static Tracker tracker(String name) {
+        return new Tracker(name, "Advertising", 0);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the parallel IP-to-host and IP-to-tracker maps with one immutable cache entry
- make invalidation atomic with generation-checked publication
- preserve the exact cache snapshot through tracker decisions and log output
- clear verdicts after tracker-data reloads

## Why
The old two-map cache could expose a hostname without its tracker verdict (or vice versa), and an in-flight database read could republish stale attribution after invalidation.

## Validation
- `./gradlew :app:testGithubDebugUnitTest -q`
- focused `TrackerCacheTest` race, expiry, null, and invalidation coverage
- `git diff --check`

## Risk
- No device packet-path profiling was performed. Live hits remain a single `ConcurrentHashMap.get`; mutation serialization occurs only on misses and invalidation.

