### PR TITLE
Publish tracker-list reloads atomically

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2931,7 +2931,7 @@ public class ServiceSinkhole extends VpnService {
         }
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        String blockingMode = BlockingMode.getMode(this);
+        String blockingMode = TrackerList.getBlockingMode(this);
         boolean blockAmbiguousTrackers = BlockingModeLogic.blocksAmbiguousTrackerIp(blockingMode);
         Tracker tracker = null;
         TrackerCache.Entry cached = trackerCache.get(daddr, System.currentTimeMillis());

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
@@ -247,8 +247,12 @@ public class BlockingMode {
         if (trackerBlocklist.applyStrictModeToAll(isStrictMode(c)))
             trackerBlocklist.saveSettings(c);
 
-        ServiceSinkhole.clearTrackerCaches();
-        TrackerList.reloadTrackerData(c);
+        if (TrackerList.reloadTrackerData(c)) {
+            // Clear caches only after the new tracker snapshot is published. A
+            // pre-reload clear allows packet-path lookups during asset loading
+            // to repopulate stale entries from the old mode.
+            ServiceSinkhole.clearTrackerCaches();
+        }
         ServiceSinkhole.reload("changed " + PREF_BLOCKING_MODE, c, false);
     }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -69,12 +69,11 @@ public class TrackerList {
             "cloudfront.net",
             "fastly.net",
             "cloudflare.com"));
-    private static final Map<String, Tracker> hostnameToTracker = new ConcurrentHashMap<>();
+    private static volatile TrackerSnapshot trackerSnapshot = new TrackerSnapshot(
+            new ConcurrentHashMap<>(), false, false, BlockingMode.getDefaultMode());
     public static String TRACKER_HOSTLIST = "TRACKER_HOSTLIST";
     private static final Tracker hostlistTracker = new Tracker(TRACKER_HOSTLIST, UNCATEGORISED);
-    private static TrackerList instance;
-    private static boolean domainBasedBlocking;
-    private static boolean minimalBlockingMode;
+    private static volatile TrackerList instance;
     private final DatabaseHelper databaseHelper;
     
     // Lock for synchronizing tracker data reload operations
@@ -85,9 +84,29 @@ public class TrackerList {
     private long lastTrackerCountComputeTime = 0;
     private static final long TRACKER_COUNT_CACHE_TTL_MS = 2000; // 2 second cache
 
+    /**
+     * The map and the mode flags must be published together. The map remains a
+     * concurrent map because findTracker caches hosts-file-derived entries in
+     * the active snapshot, while the snapshot reference itself is immutable
+     * after publication.
+     */
+    private static final class TrackerSnapshot {
+        private final Map<String, Tracker> hostnameToTracker;
+        private final boolean domainBasedBlocking;
+        private final boolean minimalBlockingMode;
+        private final String blockingMode;
+
+        private TrackerSnapshot(Map<String, Tracker> hostnameToTracker,
+                boolean domainBasedBlocking, boolean minimalBlockingMode, String blockingMode) {
+            this.hostnameToTracker = hostnameToTracker;
+            this.domainBasedBlocking = domainBasedBlocking;
+            this.minimalBlockingMode = minimalBlockingMode;
+            this.blockingMode = blockingMode;
+        }
+    }
+
     private TrackerList(Context c) {
         databaseHelper = DatabaseHelper.getInstance(c);
-        loadTrackers(c);
     }
 
     /**
@@ -97,10 +116,32 @@ public class TrackerList {
      * @return Instance of the tracker database
      */
     public static TrackerList getInstance(Context c) {
-        if (instance == null)
-            instance = new TrackerList(c);
+        TrackerList current = instance;
+        if (current != null)
+            return current;
 
-        return instance;
+        synchronized (reloadLock) {
+            current = instance;
+            if (current == null) {
+                TrackerList created = new TrackerList(c);
+                created.loadTrackers(c);
+                instance = created;
+                current = created;
+            }
+
+            return current;
+        }
+    }
+
+    /**
+     * Return the blocking mode published with the active tracker snapshot.
+     * Initialising through getInstance ensures the map and mode are never read
+     * from two different lifecycle states by packet-path callers.
+     */
+    public static String getBlockingMode(Context c) {
+        if (instance == null)
+            getInstance(c);
+        return trackerSnapshot.blockingMode;
     }
 
     static boolean isIgnoredDomain(String domain) {
@@ -121,6 +162,9 @@ public class TrackerList {
         // would slip past detection and blocking.
         hostname = hostname.toLowerCase(Locale.ROOT);
 
+        TrackerSnapshot snapshot = trackerSnapshot;
+        Map<String, Tracker> hostnameToTracker = snapshot.hostnameToTracker;
+
         Tracker t = null;
 
         if (hostnameToTracker.containsKey(hostname)) {
@@ -136,39 +180,44 @@ public class TrackerList {
         }
 
         // In minimal mode, skip hosts-file based lookups (only use DDG tracker list)
-        if (t == null && !minimalBlockingMode
+        if (t == null && !snapshot.minimalBlockingMode
                 && ServiceSinkhole.mapHostsBlocked.containsKey(hostname))
-            if (domainBasedBlocking)
+            if (snapshot.domainBasedBlocking)
                 return hostlistTracker;
             else {
                 t = new Tracker(hostname, UNCATEGORISED);
-                hostnameToTracker.put(hostname, t);
-                return t;
+                Tracker existing = hostnameToTracker.putIfAbsent(hostname, t);
+                return existing != null ? existing : t;
             }
 
         return t;
     }
 
     /**
-     * Reload tracker data by clearing all existing data and reloading from assets.
-     * This should be called when the hosts blocklist is updated to ensure TrackerList
-     * stays in sync with the updated hosts.
+     * Reload tracker data from assets and publish a complete snapshot if loading
+     * succeeds. This should be called when the hosts blocklist is updated to
+     * ensure TrackerList stays in sync with the updated hosts.
      *
      * @param c Context
+     * @return true if a complete new snapshot was published, false if the
+     *         previous snapshot was retained after a loading failure
      */
-    public static void reloadTrackerData(Context c) {
+    public static boolean reloadTrackerData(Context c) {
         Log.i(TAG, "Reloading tracker data");
-        
-        // Synchronize the entire reload operation to prevent race conditions
+
+        // loadTrackers builds and publishes under reloadLock. Readers do not
+        // take the lock and continue to use the old complete snapshot while
+        // assets are being parsed.
         synchronized (reloadLock) {
-            // Clear existing data (both are thread-safe collections)
-            hostnameToTracker.clear();
-            
-            // Ensure instance exists and reload trackers from assets
-            TrackerList trackerList = getInstance(c);
-            trackerList.loadTrackers(c);
-            // Invalidate cached tracker counts since tracker data has changed
-            trackerList.invalidateTrackerCountCache();
+            // Initialise and load once on the first reload call. Do not
+            // immediately load the same assets a second time.
+            if (instance == null) {
+                TrackerList created = new TrackerList(c);
+                boolean loaded = created.loadTrackers(c);
+                instance = created;
+                return loaded;
+            }
+            return instance.loadTrackers(c);
         }
     }
 
@@ -176,21 +225,37 @@ public class TrackerList {
      * Load tracker domain database
      *
      * @param c Context
+     * @return true if all selected assets loaded successfully, false otherwise
      */
-    public void loadTrackers(Context c) {
-        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
-        domainBasedBlocking = prefs.getBoolean("domain_based_blocking",
-                prefs.getBoolean("domain_based_blocked", false));
-        minimalBlockingMode = BlockingMode.isMinimalMode(c);
+    public boolean loadTrackers(Context c) {
+        synchronized (reloadLock) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
+            boolean domainBasedBlocking = prefs.getBoolean("domain_based_blocking",
+                    prefs.getBoolean("domain_based_blocked", false));
+            String blockingMode = BlockingMode.getMode(c);
+            boolean minimalBlockingMode = BlockingMode.MODE_MINIMAL.equals(blockingMode);
+            Map<String, Tracker> loadedTrackers = new ConcurrentHashMap<>();
 
-        if (minimalBlockingMode) {
-            // In minimal mode, only load DDG trackers (skip X-Ray and Disconnect)
-            // This ensures only confirmed, breakage-tested trackers are blocked
-            loadDuckDuckGoTrackers(c);
-        } else {
-            loadXrayTrackers(c);
-            loadDisconnectTrackers(c); // loaded last to overwrite X-Ray hosts with extra category information
-            loadDuckDuckGoTrackers(c); // DuckDuckGo tracker list for additional mobile-specific trackers
+            boolean loaded;
+            if (minimalBlockingMode) {
+                // In minimal mode, only load DDG trackers (skip X-Ray and Disconnect)
+                // This ensures only confirmed, breakage-tested trackers are blocked
+                loaded = loadDuckDuckGoTrackers(c, loadedTrackers, domainBasedBlocking);
+            } else {
+                loaded = loadXrayTrackers(c, loadedTrackers, domainBasedBlocking);
+                loaded = loaded && loadDisconnectTrackers(c, loadedTrackers, domainBasedBlocking);
+                loaded = loaded && loadDuckDuckGoTrackers(c, loadedTrackers, domainBasedBlocking);
+            }
+
+            if (!loaded) {
+                Log.w(TAG, "Keeping previous tracker snapshot after asset loading failure");
+                return false;
+            }
+
+            trackerSnapshot = new TrackerSnapshot(
+                    loadedTrackers, domainBasedBlocking, minimalBlockingMode, blockingMode);
+            invalidateTrackerCountCache();
+            return true;
         }
     }
 
@@ -399,7 +464,8 @@ public class TrackerList {
      *
      * @param c Context
      */
-    private void loadXrayTrackers(Context c) {
+    private boolean loadXrayTrackers(Context c, Map<String, Tracker> hostnameToTracker,
+            boolean domainBasedBlocking) {
         // Keep track of parent companies
         Map<String, Tracker> rootParents = new HashMap<>();
 
@@ -472,12 +538,14 @@ public class TrackerList {
                     if (isIgnoredDomain(dom))
                         continue;
 
-                    addTrackerDomain(tracker, dom);
+                    addTrackerDomain(tracker, dom, hostnameToTracker, domainBasedBlocking);
                 }
             }
             reader.endArray();
+            return true;
         } catch (IOException | IllegalStateException e) {
             Log.e(TAG, "Loading X-Ray list failed.. ", e);
+            return false;
         }
     }
 
@@ -486,7 +554,8 @@ public class TrackerList {
      *
      * @param c Context
      */
-    private void loadDuckDuckGoTrackers(Context c) {
+    private boolean loadDuckDuckGoTrackers(Context c, Map<String, Tracker> hostnameToTracker,
+            boolean domainBasedBlocking) {
         // Stream-parse to avoid materialising the whole file as a String plus a
         // JSONObject DOM. Produces the exact same map as the previous DOM-based
         // parse (this list is loaded in every mode, so it also helps minimal mode).
@@ -559,13 +628,15 @@ public class TrackerList {
                     Tracker tracker = new Tracker(displayName, category);
 
                     // Add domain to tracker map
-                    addTrackerDomain(tracker, domain);
+                    addTrackerDomain(tracker, domain, hostnameToTracker, domainBasedBlocking);
                 }
                 reader.endObject();
             }
             reader.endObject();
+            return true;
         } catch (IOException | IllegalStateException e) {
             Log.e(TAG, "Loading DuckDuckGo list failed.. ", e);
+            return false;
         }
     }
 
@@ -574,7 +645,8 @@ public class TrackerList {
      *
      * @param c Context
      */
-    private void loadDisconnectTrackers(Context c) {
+    private boolean loadDisconnectTrackers(Context c, Map<String, Tracker> hostnameToTracker,
+            boolean domainBasedBlocking) {
         /*
          * Read domain list:
          *
@@ -652,7 +724,7 @@ public class TrackerList {
                                         if (isIgnoredDomain(dom))
                                             continue;
 
-                                        addTrackerDomain(tracker, dom);
+                                        addTrackerDomain(tracker, dom, hostnameToTracker, domainBasedBlocking);
                                     }
                                     reader.endArray();
                                 }
@@ -666,8 +738,10 @@ public class TrackerList {
                 }
                 reader.endObject();
             }
+            return true;
         } catch (IOException | IllegalStateException e) {
             Log.e(TAG, "Loading Disconnect.me list failed.. ", e);
+            return false;
         }
     }
 
@@ -678,7 +752,8 @@ public class TrackerList {
      * @param tracker Tracker to be added
      * @param dom     Domain to be added
      */
-    private void addTrackerDomain(Tracker tracker, String dom) {
+    private void addTrackerDomain(Tracker tracker, String dom, Map<String, Tracker> hostnameToTracker,
+            boolean domainBasedBlocking) {
         if (domainBasedBlocking) {
             Tracker t = new Tracker(dom + " (" + tracker.getName() + ")", tracker.category);
             t.country = tracker.country;

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
@@ -1,0 +1,223 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package net.kollnig.missioncontrol.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.AssetManager;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import eu.faircode.netguard.ServiceSinkhole;
+
+@RunWith(RobolectricTestRunner.class)
+public class TrackerListReloadTest {
+    private static final String BLOCKING_MODE = BlockingMode.PREF_BLOCKING_MODE;
+    private Context context;
+
+    @Before
+    public void setUp() throws Exception {
+        context = RuntimeEnvironment.getApplication();
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .clear().commit();
+        ServiceSinkhole.mapHostsBlocked.clear();
+        resetTrackerList();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        ServiceSinkhole.mapHostsBlocked.clear();
+        resetTrackerList();
+    }
+
+    @Test
+    public void successfulReloadPublishesADistinctSnapshotWithoutMutatingTheOldOne() throws Exception {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD)
+                .putBoolean("domain_based_blocking", false).commit();
+        TrackerList.getInstance(context);
+        ServiceSinkhole.mapHostsBlocked.put("dynamic.example", true);
+        Tracker cachedDynamicTracker = TrackerList.findTracker("dynamic.example");
+        assertNotNull(cachedDynamicTracker);
+
+        Object oldSnapshot = getPrivateStaticField("trackerSnapshot");
+        Map<String, Tracker> oldMap = getSnapshotMap(oldSnapshot);
+        int oldMapSize = oldMap.size();
+
+        assertTrue(TrackerList.reloadTrackerData(context));
+
+        Object newSnapshot = getPrivateStaticField("trackerSnapshot");
+        Map<String, Tracker> newMap = getSnapshotMap(newSnapshot);
+
+        assertNotSame(oldSnapshot, newSnapshot);
+        assertNotSame(oldMap, newMap);
+        assertEquals(oldMapSize, oldMap.size());
+        assertSame(cachedDynamicTracker, oldMap.get("dynamic.example"));
+        assertNull(newMap.get("dynamic.example"));
+        assertNotNull(TrackerList.findTracker("crashlytics.com"));
+    }
+
+    @Test
+    public void concurrentInitialisationReturnsOneSingleton() throws Exception {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_MINIMAL).commit();
+        int callers = 8;
+        TrackerList[] results = new TrackerList[callers];
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch finished = new CountDownLatch(callers);
+        Thread[] threads = new Thread[callers];
+        for (int i = 0; i < callers; i++) {
+            final int index = i;
+            threads[i] = new Thread(() -> {
+                try {
+                    start.await();
+                    results[index] = TrackerList.getInstance(context);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    finished.countDown();
+                }
+            });
+            threads[i].start();
+        }
+        start.countDown();
+        assertTrue(finished.await(10, TimeUnit.SECONDS));
+        for (Thread thread : threads)
+            thread.join(1000);
+
+        for (int i = 1; i < callers; i++)
+            assertSame(results[0], results[i]);
+    }
+
+    @Test
+    public void failedReloadRetainsPreviousSnapshot() throws Exception {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD).commit();
+        TrackerList.getInstance(context);
+        Tracker oldTracker = TrackerList.findTracker("crashlytics.com");
+        assertNotNull(oldTracker);
+        assertEquals(BlockingMode.MODE_STANDARD, TrackerList.getBlockingMode(context));
+
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_MINIMAL).commit();
+
+        Constructor<AssetManager> assetConstructor = AssetManager.class.getDeclaredConstructor();
+        assetConstructor.setAccessible(true);
+        AssetManager brokenAssets = assetConstructor.newInstance();
+        Context brokenContext = new ContextWrapper(context) {
+            @Override
+            public AssetManager getAssets() {
+                return brokenAssets;
+            }
+        };
+
+        assertFalse(TrackerList.reloadTrackerData(brokenContext));
+
+        assertSame(oldTracker, TrackerList.findTracker("crashlytics.com"));
+        assertEquals(BlockingMode.MODE_STANDARD, TrackerList.getBlockingMode(context));
+    }
+
+    @Test
+    public void modeSelectionPublishesOnlyTheSelectedLists() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_MINIMAL).commit();
+        TrackerList.getInstance(context);
+        assertNotNull(TrackerList.findTracker("creativecdn.com"));
+        assertNull(TrackerList.findTracker("crashlytics.com"));
+
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD).commit();
+        assertTrue(TrackerList.reloadTrackerData(context));
+        assertNotNull(TrackerList.findTracker("crashlytics.com"));
+    }
+
+    @Test
+    public void dynamicHostEntriesAreCachedInTheActiveSnapshot() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD)
+                .putBoolean("domain_based_blocking", false).commit();
+        TrackerList.getInstance(context);
+        ServiceSinkhole.mapHostsBlocked.put("dynamic.example", true);
+
+        Tracker first = TrackerList.findTracker("DYNAMIC.EXAMPLE");
+        Tracker second = TrackerList.findTracker("dynamic.example");
+
+        assertNotNull(first);
+        assertSame(first, second);
+        assertEquals("dynamic.example", first.getName());
+    }
+
+    @Test
+    public void domainBasedDynamicHostsUseTheSharedHostlistTracker() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD)
+                .putBoolean("domain_based_blocking", true).commit();
+        TrackerList.getInstance(context);
+        ServiceSinkhole.mapHostsBlocked.put("dynamic.example", true);
+
+        Tracker first = TrackerList.findTracker("dynamic.example");
+        Tracker second = TrackerList.findTracker("dynamic.example");
+
+        assertNotNull(first);
+        assertSame(first, second);
+        assertEquals(TrackerList.TRACKER_HOSTLIST, first.getName());
+    }
+
+    private static void resetTrackerList() throws Exception {
+        Field instance = TrackerList.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+
+        Class<?> snapshotClass = Class.forName(
+                "net.kollnig.missioncontrol.data.TrackerList$TrackerSnapshot");
+        Constructor<?> constructor = snapshotClass.getDeclaredConstructor(
+                Map.class, boolean.class, boolean.class, String.class);
+        constructor.setAccessible(true);
+        Object emptySnapshot = constructor.newInstance(
+                new ConcurrentHashMap<String, Tracker>(), false, false,
+                BlockingMode.getDefaultMode());
+        Field snapshot = TrackerList.class.getDeclaredField("trackerSnapshot");
+        snapshot.setAccessible(true);
+        snapshot.set(null, emptySnapshot);
+    }
+
+    private static Object getPrivateStaticField(String name) throws Exception {
+        Field field = TrackerList.class.getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Tracker> getSnapshotMap(Object snapshot) throws Exception {
+        Field map = snapshot.getClass().getDeclaredField("hostnameToTracker");
+        map.setAccessible(true);
+        return (Map<String, Tracker>) map.get(snapshot);
+    }
+}


### PR DESCRIPTION
## Summary
- build tracker assets in a private map and publish map, mode flags, and effective blocking mode as one snapshot
- retain the previous complete snapshot when an asset load fails
- make singleton initialization safe and avoid double-loading assets
- clear service verdict caches only after successful publication

## Why
The previous reload cleared the live tracker map before rebuilding it, so packet-path readers could observe partial data and cache a false non-tracker verdict for a DNS TTL.

## Validation
- focused data, cache, DNS-attribution, and blocking-mode JVM tests
- concurrent singleton and failed-reload mode-retention coverage
- `git diff --check`

## Dependency
- Stacked on #804 because atomic reload publication also requires epoch-safe verdict-cache invalidation.

## Risk
- The hosts-file map itself remains independently managed; this PR makes tracker-list publication atomic and does not redesign hosts-file loading.
