### PR TITLE
Recover WireGuard monitoring after stats failures

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
@@ -178,7 +178,7 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
         if (!cadenceOk) return
         try {
             prod()
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             Log.w(TAG, "prod threw", e)
         }
         if (initialProdTs == null) initialProdTs = now
@@ -216,7 +216,7 @@ private const val TAG = "WgConnMonitor"
  */
 internal class WgConnectivityMonitor(
     private val statsProvider: () -> WgStats?,
-    prod: () -> Unit,
+    private val prod: () -> Unit,
     private val onBroken: () -> Unit,
     // Fired each time this monitor observes a completed handshake after a
     // period without one (tunnel start, or re-handshake after session expiry),
@@ -230,7 +230,20 @@ internal class WgConnectivityMonitor(
     private val onRxAdvanced: () -> Unit = {},
     // Screen state, sampled every iteration so the cadence follows the screen
     // without restarting the thread. Backed by WgEgress.currentInteractive.
-    private val isInteractive: () -> Boolean = { true }
+    private val isInteractive: () -> Boolean = { true },
+    // A null stats sample is ambiguous at this layer: Tunnel.stats() can fail
+    // transiently, but a callback for a replaced/stopped tunnel must not
+    // recover the new tunnel. WgEgress supplies this callback from its tunnel
+    // generation check.
+    private val isCurrent: () -> Boolean = { true },
+    // Injectable for lifecycle tests. The production default preserves the
+    // screen-aware cadence and never busy-loops between stats failures.
+    private val sleep: (Long) -> Unit = { Thread.sleep(it) },
+    private val clock: () -> Long = { SystemClock.elapsedRealtime() },
+    // Test-only barrier between callback authorization and dispatch. Keeping
+    // this seam here makes the stop/callback ordering deterministic without
+    // adding any production scheduling.
+    private val beforeCallback: () -> Unit = {}
 ) {
     internal companion object {
         /** How often the loop samples the tunnel counters while the screen is on. */
@@ -251,6 +264,12 @@ internal class WgConnectivityMonitor(
          */
         const val SUSPEND_MARGIN_MS = 5_000L
 
+        /** Consecutive failed samples before entering the existing recovery path. */
+        const val MAX_STATS_FAILURES = 3
+
+        /** A blocked stats read is stale only after several idle cadence cycles. */
+        const val STATS_READ_TIMEOUT_MS = IDLE_LOOP_SLEEP_MS * 4
+
         fun pollIntervalMs(interactive: Boolean): Long =
             if (interactive) INTERACTIVE_LOOP_SLEEP_MS else IDLE_LOOP_SLEEP_MS
 
@@ -258,85 +277,314 @@ internal class WgConnectivityMonitor(
             sleptMs >= intervalMs + SUSPEND_MARGIN_MS
     }
 
-    private val checker = WgConnectivityChecker(prod)
-
-    @Volatile private var running = false
+    private val lifecycleLock = Any()
+    private val callbackLock = Any()
+    private var running = false
     private var thread: Thread? = null
+    private var lifecycleGeneration = 0L
+    // Non-null only while this monitor thread is inside statsProvider. It lets
+    // isRunning() detect a native/JNI stats call that never returns, without a
+    // timer, alarm, or extra polling thread.
+    private var statsReadStartedAt: Long? = null
 
     fun start() {
-        if (running) return
-        running = true
-        thread = Thread(::runLoop, "wg-conn-monitor").apply {
-            isDaemon = true
-            start()
+        synchronized(lifecycleLock) {
+            if (running) return
+            running = true
+            val generation = ++lifecycleGeneration
+            statsReadStartedAt = null
+            val monitorThread = Thread({ runLoop(generation) }, "wg-conn-monitor").apply {
+                isDaemon = true
+            }
+            thread = monitorThread
+            monitorThread.start()
         }
     }
 
     fun stop() {
-        running = false
-        thread?.interrupt()
-        thread = null
+        val monitorThread = synchronized(lifecycleLock) {
+            running = false
+            lifecycleGeneration++
+            val oldThread = thread
+            thread = null
+            statsReadStartedAt = null
+            oldThread
+        }
+        // Interrupt outside the lock: a provider can synchronously call back
+        // into stop(), and stopping must not wait for a stats read to return.
+        // The callback gate is acquired after lifecycle invalidation so an
+        // authorized callback either finishes before stop returns or is
+        // rejected by the generation check.
+        synchronized(callbackLock) { }
+        monitorThread?.interrupt()
     }
 
-    private fun runLoop() {
-        val seed = statsProvider() ?: return
-        var lastCheck = SystemClock.elapsedRealtime()
-        checker.seed(lastCheck, seed)
+    /** Whether this monitor currently owns a live polling thread. */
+    fun isRunning(): Boolean {
+        val now = clock()
+        val staleThread = synchronized(lifecycleLock) {
+            val startedAt = statsReadStartedAt
+            if (running && startedAt != null && now - startedAt >= STATS_READ_TIMEOUT_MS) {
+                running = false
+                lifecycleGeneration++
+                val oldThread = thread
+                thread = null
+                statsReadStartedAt = null
+                oldThread
+            } else {
+                null
+            }
+        }
+        // Interrupt outside the lock: native stats implementations may return
+        // promptly on interruption, while lifecycle callers must not block.
+        staleThread?.interrupt()
+        return synchronized(lifecycleLock) { running }
+    }
+
+    private fun isActiveLocked(generation: Long): Boolean =
+        running && lifecycleGeneration == generation && thread === Thread.currentThread()
+
+    private fun isActive(generation: Long): Boolean = synchronized(lifecycleLock) {
+        isActiveLocked(generation)
+    }
+
+    private fun waitForNextPoll(generation: Long, intervalMs: Long): Boolean {
+        if (!isActive(generation)) return false
+        return try {
+            sleep(intervalMs)
+            isActive(generation)
+        } catch (_: InterruptedException) {
+            false
+        }
+    }
+
+    private fun readStats(generation: Long): WgStats? {
+        val beganRead = synchronized(lifecycleLock) {
+            if (!isActiveLocked(generation)) {
+                false
+            } else {
+                statsReadStartedAt = clock()
+                true
+            }
+        }
+        if (!beganRead) return null
+
+        return try {
+            try {
+                statsProvider()
+            } catch (e: Exception) {
+                warn("stats read threw", e)
+                null
+            }
+        } finally {
+            synchronized(lifecycleLock) {
+                if (lifecycleGeneration == generation && thread === Thread.currentThread())
+                    statsReadStartedAt = null
+            }
+        }
+    }
+
+    private fun invokeCallback(generation: Long, label: String, callback: () -> Unit) {
+        synchronized(callbackLock) {
+            val authorized = synchronized(lifecycleLock) {
+                isActiveLocked(generation)
+            }
+            if (!authorized) return
+
+            try {
+                beforeCallback()
+            } catch (e: Exception) {
+                warn("$label readiness hook threw", e)
+            }
+
+            // stop() may have invalidated this generation while the readiness
+            // hook was waiting. Recheck while holding the callback gate so a
+            // stop that returns can never be followed by an old callback.
+            val stillAuthorized = synchronized(lifecycleLock) {
+                isActiveLocked(generation)
+            }
+            if (!stillAuthorized) return
+
+            try {
+                callback()
+            } catch (e: Exception) {
+                warn("$label threw", e)
+            }
+        }
+    }
+
+    private fun reportBroken(generation: Long, reason: String) {
+        warn(reason)
+        synchronized(callbackLock) {
+            // Invalidate before dispatching recovery. The callback gate keeps
+            // stop() from returning until this already-authorized callback is
+            // complete, while reentrant stop/start remain safe.
+            val authorized = synchronized(lifecycleLock) {
+                if (!isActiveLocked(generation)) {
+                    false
+                } else {
+                    running = false
+                    lifecycleGeneration++
+                    thread = null
+                    statsReadStartedAt = null
+                    true
+                }
+            }
+            if (!authorized) return
+
+            try {
+                onBroken()
+            } catch (e: Exception) {
+                warn("onBroken threw", e)
+            }
+        }
+    }
+
+    private fun warn(message: String, error: Throwable? = null) {
+        try {
+            if (error == null) Log.w(TAG, message) else Log.w(TAG, message, error)
+        } catch (_: Exception) {
+            // Android's Log methods are not mocked by plain JVM tests. A log
+            // failure must never change the monitor's lifecycle behavior.
+        }
+    }
+
+    private fun runLoop(generation: Long) {
+        // Keep checker state local to a run. If stop() races a blocked stats
+        // call and start() launches a replacement, the old run cannot mutate
+        // the new run's counters or prod cadence.
+        val checker = WgConnectivityChecker {
+            // Keep keepalives behind the same generation/callback gate as all
+            // other monitor side effects. This prevents stop() from returning
+            // between an active check and sendKeepalive().
+            invokeCallback(generation, "prod", prod)
+        }
         var announcedConnected = false
 
-        while (running && !Thread.currentThread().isInterrupted) {
-            val intervalMs = pollIntervalMs(isInteractive())
-            try {
-                Thread.sleep(intervalMs)
-            } catch (e: InterruptedException) {
-                break
+        try {
+            var seeded = false
+            var lastCheck = 0L
+            var statsFailures = 0
+
+            while (isActive(generation) && !Thread.currentThread().isInterrupted) {
+                if (!seeded) {
+                    val seed = readStats(generation)
+                    if (!isActive(generation)) return
+                    if (seed == null) {
+                        // Startup races can make Tunnel.stats unavailable
+                        // before the native tunnel has finished publishing its
+                        // counters. Retry at the normal screen-aware cadence,
+                        // while a stale tunnel exits without recovering a
+                        // replacement.
+                        if (!isCurrent()) return
+                        statsFailures++
+                        if (statsFailures >= MAX_STATS_FAILURES) {
+                            if (!isInteractive()) {
+                                // Defer active recovery while the screen is
+                                // off. Reset the evidence and keep sampling at
+                                // the idle cadence; the next interactive polls
+                                // will reach the bounded recovery path.
+                                statsFailures = 0
+                            } else {
+                                reportBroken(
+                                    generation,
+                                    "stats unavailable for $statsFailures polls; reporting broken state"
+                                )
+                                return
+                            }
+                        }
+                        if (!waitForNextPoll(generation, pollIntervalMs(isInteractive()))) return
+                        continue
+                    }
+                    if (!isCurrent()) return
+                    lastCheck = clock()
+                    checker.seed(lastCheck, seed)
+                    seeded = true
+                    statsFailures = 0
+                }
+
+                val intervalMs = pollIntervalMs(isInteractive())
+                if (!waitForNextPoll(generation, intervalMs)) return
+
+                val now = clock()
+                val slept = now - lastCheck
+                lastCheck = now
+
+                // The device dozed; the elapsed gap is not evidence of a stall.
+                if (isSuspendGap(slept, intervalMs)) {
+                    statsFailures = 0
+                    checker.onSuspended(now)
+                    continue
+                }
+
+                val stats = readStats(generation)
+                if (!isActive(generation)) return
+                if (stats == null) {
+                    // A replaced/stopped tunnel is an ordinary lifecycle exit,
+                    // not evidence that the replacement should be recovered.
+                    if (!isCurrent()) return
+                    statsFailures++
+                    if (statsFailures >= MAX_STATS_FAILURES) {
+                        if (isInteractive()) {
+                            reportBroken(
+                                generation,
+                                "stats unavailable for $statsFailures polls; reporting broken state"
+                            )
+                            return
+                        }
+                        // Do not rebind/prod an idle-screen tunnel solely on
+                        // missing stats. Keep the existing idle cadence and
+                        // defer recovery until the screen is interactive.
+                        statsFailures = 0
+                    }
+                    // Keep the existing screen-aware cadence while retrying;
+                    // never spin or add an extra wakeup/radio operation.
+                    continue
+                }
+                statsFailures = 0
+                if (!isCurrent()) return
+
+                when (checker.tick(now, stats)) {
+                    WgVerdict.HEALTHY, WgVerdict.WAITING -> {}
+                    WgVerdict.BROKEN -> {
+                        if (!isInteractive()) {
+                            checker.onSuspended(now)
+                            continue
+                        }
+                        reportBroken(generation, "tunnel unresponsive after prod; reporting broken state")
+                        return
+                    }
+                    // Null samples are handled before checker.tick so GONE is
+                    // reserved for the pure checker API and cannot kill this
+                    // monitor on a transient Tunnel.stats exception.
+                    WgVerdict.GONE -> return
+                }
+
+                if (checker.lastTickSawRx) {
+                    invokeCallback(generation, "onRxAdvanced", onRxAdvanced)
+                }
+
+                // Announce on every no-session -> session transition, not just
+                // the first: an expired session (idle screen-off tunnel past
+                // REJECT_AFTER_TIME) drops latestHandshakeMillis back to 0, and the
+                // lazy re-handshake on the next packet must re-notify listeners or
+                // the settings status line stays frozen on "Handshaking".
+                val hasHandshake = stats.latestHandshakeMillis > 0L
+                if (!announcedConnected && hasHandshake) {
+                    announcedConnected = true
+                    invokeCallback(generation, "onConnected", onConnected)
+                } else if (announcedConnected && !hasHandshake) {
+                    announcedConnected = false
+                }
             }
-
-            val now = SystemClock.elapsedRealtime()
-            val slept = now - lastCheck
-            lastCheck = now
-
-            // The device dozed; the elapsed gap is not evidence of a stall.
-            if (isSuspendGap(slept, intervalMs)) {
-                checker.onSuspended(now)
-                continue
-            }
-
-            val stats = statsProvider()
-            when (checker.tick(now, stats)) {
-                WgVerdict.HEALTHY, WgVerdict.WAITING -> {}
-                WgVerdict.BROKEN -> {
-                    Log.w(TAG, "tunnel unresponsive after prod; reporting broken state")
+        } finally {
+            // Every exit path, including a null seed, stale tunnel, interrupted
+            // sleep, and callback failure, must release the lifecycle slot.
+            synchronized(lifecycleLock) {
+                if (lifecycleGeneration == generation && thread === Thread.currentThread()) {
                     running = false
-                    onBroken()
-                    return
+                    thread = null
                 }
-                WgVerdict.GONE -> return
-            }
-
-            if (checker.lastTickSawRx) {
-                try {
-                    onRxAdvanced()
-                } catch (e: Throwable) {
-                    Log.w(TAG, "onRxAdvanced threw", e)
-                }
-            }
-
-            // Announce on every no-session -> session transition, not just the
-            // first: an expired session (idle screen-off tunnel past
-            // REJECT_AFTER_TIME) drops latestHandshakeMillis back to 0, and the
-            // lazy re-handshake on the next packet must re-notify listeners or
-            // the settings status line stays frozen on "Handshaking".
-            val hasHandshake = stats != null && stats.latestHandshakeMillis > 0L
-            if (!announcedConnected && hasHandshake) {
-                announcedConnected = true
-                try {
-                    onConnected()
-                } catch (e: Throwable) {
-                    Log.w(TAG, "onConnected threw", e)
-                }
-            } else if (announcedConnected && !hasHandshake) {
-                announcedConnected = false
             }
         }
     }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
@@ -547,10 +547,14 @@ internal class WgConnectivityMonitor(
                 when (checker.tick(now, stats)) {
                     WgVerdict.HEALTHY, WgVerdict.WAITING -> {}
                     WgVerdict.BROKEN -> {
-                        if (!isInteractive()) {
-                            checker.onSuspended(now)
-                            continue
-                        }
+                        // Recover regardless of screen state. Unlike a null
+                        // stats sample, BROKEN is direct evidence that the
+                        // data path is dead: tx advanced, no rx followed, and
+                        // the keepalive prod did not revive it. Deferring the
+                        // restart until the screen comes on would strand every
+                        // app without network (the hijack is fail-closed) while
+                        // still prodding the radio each idle poll, so it costs
+                        // battery without buying recovery.
                         reportBroken(generation, "tunnel unresponsive after prod; reporting broken state")
                         return
                     }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -13,6 +13,72 @@ import net.kollnig.missioncontrol.wgbridge.Wgbridge
 import net.kollnig.missioncontrol.wgbridge.DnsRecorder as WgDnsRecorder
 
 /**
+ * Serializes monitor replacement without holding its lock while stopping an
+ * old monitor. A monitor callback can synchronously request replacement, so
+ * stopping under the lifecycle lock would deadlock against the monitor's
+ * callback gate. The epoch cancels a replacement that races a stop or another
+ * replacement.
+ */
+internal class WgMonitorLifecycle<T>(
+    private val lock: Any,
+    private val isRunning: (T) -> Boolean,
+    private val stop: (T) -> Unit,
+    private val start: (T) -> Unit
+) {
+    private var active: T? = null
+    private var epoch = 0L
+
+    /** Install and start [candidate], optionally only when no live monitor exists. */
+    fun replace(candidate: T, isCurrent: () -> Boolean, onlyIfDead: Boolean = false): Boolean {
+        if (!isCurrent()) {
+            stop(candidate)
+            return false
+        }
+
+        val old: T?
+        val transaction: Long
+        synchronized(lock) {
+            if (onlyIfDead && active?.let(isRunning) == true) return false
+            old = active
+            active = null
+            transaction = ++epoch
+        }
+
+        // Do not hold lock while stop() waits for callbacks to finish.
+        old?.let(stop)
+
+        if (!isCurrent()) {
+            stop(candidate)
+            return false
+        }
+
+        var installed = false
+        synchronized(lock) {
+            if (transaction == epoch) {
+                active = candidate
+                // Start while ownership is held, so a concurrent stop cannot
+                // detach an unstarted candidate that would be started later.
+                start(candidate)
+                installed = true
+            }
+        }
+        if (!installed) stop(candidate)
+        return installed
+    }
+
+    /** Detach the current monitor, then stop it without holding [lock]. */
+    fun stop() {
+        val old = synchronized(lock) {
+            ++epoch
+            active.also { active = null }
+        }
+        old?.let(stop)
+    }
+
+    fun isRunning(): Boolean = synchronized(lock) { active?.let(isRunning) == true }
+}
+
+/**
  * Owns the gotatun (Rust WireGuard) tunnel that sits behind NetGuard's
  * IP-layer hijack.
  *
@@ -142,8 +208,13 @@ object WgEgress {
     // Guarded by monitorLock: started/stopped from the vpn handler thread,
     // the wg-rebind thread, and the dying monitor thread itself. Unsynchronized
     // access could leak a second polling thread (double prods, double restarts).
-    private var monitor: WgConnectivityMonitor? = null
     private val monitorLock = Any()
+    private val monitorLifecycle = WgMonitorLifecycle<WgConnectivityMonitor>(
+        lock = monitorLock,
+        isRunning = { it.isRunning() },
+        stop = { it.stop() },
+        start = { it.start() }
+    )
 
     private val verifyHandler by lazy { Handler(Looper.getMainLooper()) }
     private val listeners = java.util.concurrent.CopyOnWriteArrayList<Runnable>()
@@ -218,6 +289,11 @@ object WgEgress {
             if (oldKeepaliveEnabled != newKeepaliveEnabled &&
                 !reapplyConfigOrError(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn))
                 return false
+            // The tunnel can outlive a monitor whose initial stats read raced
+            // tunnel startup (or which exited after a stale sample). Keep the
+            // idempotent tunnel path, but recreate a dead watchdog so a
+            // same-config start does not silently leave connectivity unwatched.
+            startMonitorIfDead()
             Log.v(TAG, "startOrUpdate: same config + same TUN pfd, no-op")
             return true
         }
@@ -307,37 +383,44 @@ object WgEgress {
         startMonitor(expected)
     }
 
-    private fun startMonitor(expected: TunnelSnapshot) {
-        if (!isCurrent(expected)) return
-        synchronized(monitorLock) {
-            if (!isCurrent(expected)) return
-            monitor?.stop()
-            monitor = WgConnectivityMonitor(
-                statsProvider = { statsOrNull(expected) },
-                prod = {
-                    if (isCurrent(expected)) try {
-                        expected.tunnel.sendKeepalive()
-                    } catch (e: Throwable) {
-                        Log.w(TAG, "prod keepalive threw", e)
-                    }
-                },
-                onBroken = { if (isCurrent(expected)) onMonitorBroken(expected) },
-                onConnected = { if (isCurrent(expected)) notifyStateChanged() },
-                // Reset the restart backoff only on observed return traffic:
-                // a fresh handshake shortly after a restart is exactly the
-                // signal a handshake-passes-but-data-drops failure loop also
-                // produces, so resetting on it would defeat the backoff.
-                onRxAdvanced = { if (isCurrent(expected)) restartAttempts = 0 },
-                isInteractive = { currentInteractive }
-            ).also { it.start() }
-        }
+    private fun startMonitorIfDead() {
+        val expected = captureTunnel() ?: return
+        startMonitor(expected, onlyIfDead = true)
+    }
+
+    private fun startMonitor(expected: TunnelSnapshot, onlyIfDead: Boolean = false) {
+        // Build the candidate before entering the lifecycle transaction. The
+        // transaction itself never calls isCurrent while holding monitorLock:
+        // monitor callbacks call back into isCurrent (tunnelLifecycleLock), so
+        // nesting those locks would recreate the callback/replacement cycle.
+        val candidate = WgConnectivityMonitor(
+            statsProvider = { statsOrNull(expected) },
+            prod = {
+                if (isCurrent(expected)) try {
+                    expected.tunnel.sendKeepalive()
+                } catch (e: Exception) {
+                    Log.w(TAG, "prod keepalive threw", e)
+                }
+            },
+            onBroken = { if (isCurrent(expected)) onMonitorBroken(expected) },
+            onConnected = { if (isCurrent(expected)) notifyStateChanged() },
+            // Reset the restart backoff only on observed return traffic:
+            // a fresh handshake shortly after a restart is exactly the
+            // signal a handshake-passes-but-data-drops failure loop also
+            // produces, so resetting on it would defeat the backoff.
+            onRxAdvanced = { if (isCurrent(expected)) restartAttempts = 0 },
+            isInteractive = { currentInteractive },
+            isCurrent = { isCurrent(expected) }
+        )
+        monitorLifecycle.replace(
+            candidate,
+            isCurrent = { isCurrent(expected) },
+            onlyIfDead = onlyIfDead
+        )
     }
 
     private fun stopMonitor() {
-        synchronized(monitorLock) {
-            monitor?.stop()
-            monitor = null
-        }
+        monitorLifecycle.stop()
     }
 
     private fun onMonitorBroken(expected: TunnelSnapshot) {
@@ -558,7 +641,7 @@ object WgEgress {
                 it.latestHandshakeMillis > 0 && now() - it.latestHandshakeMillis < HANDSHAKE_DEAD_AFTER_MS
             )
         }
-    } catch (e: Throwable) {
+    } catch (e: Exception) {
         null
     }
 
@@ -689,7 +772,6 @@ object WgEgress {
     }
 
     private fun stopInternal(stopSocketpair: () -> Unit) {
-        stopMonitor()
         val t = synchronized(tunnelLifecycleLock) {
             val old = tunnel
             // Invalidate in-flight recovery before stopping the old object.
@@ -704,6 +786,10 @@ object WgEgress {
             pendingRestartTunnelGeneration = -1
             old
         }
+        // Invalidate the tunnel before cancelling the monitor. An in-progress
+        // monitor replacement can then observe the stale epoch and cannot
+        // install a watcher for the tunnel being torn down.
+        stopMonitor()
         currentConfig = null
         currentTunFd = -1
         currentTunPfd = null

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitorTest.kt
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitorTest.kt
@@ -3,7 +3,12 @@ package net.kollnig.missioncontrol.wg
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 /**
  * Pure unit tests for the [WgConnectivityMonitor] loop cadence: fast polling
@@ -11,6 +16,21 @@ import org.junit.Test
  * and a doze-detection threshold that scales with the active interval.
  */
 class WgConnectivityMonitorTest {
+
+    private class FakeMonitor {
+        var started = false
+        var stopped = false
+    }
+
+    private fun awaitStopped(monitor: WgConnectivityMonitor) {
+        repeat(1_000) {
+            if (!monitor.isRunning()) return
+            Thread.sleep(1)
+        }
+        fail("monitor did not stop")
+    }
+
+    private fun stats() = WgStats(0, 0, 0)
 
     @Test
     fun interactiveCadenceIsOneSecond() {
@@ -45,5 +65,465 @@ class WgConnectivityMonitorTest {
         val idle = WgConnectivityMonitor.pollIntervalMs(false)
         assertFalse(WgConnectivityMonitor.isSuspendGap(idle, idle))
         assertTrue(WgConnectivityMonitor.isSuspendGap(idle + WgConnectivityMonitor.SUSPEND_MARGIN_MS, idle))
+    }
+
+    @Test
+    fun nullThenValidInitialSeedStartsMonitoring() {
+        var seedReads = 0
+        var sleeps = 0
+        val delays = mutableListOf<Long>()
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                seedReads++
+                if (seedReads == 1) null else stats()
+            },
+            prod = {},
+            onBroken = { fail("valid initial stats entered recovery") },
+            sleep = { delay ->
+                delays += delay
+                sleeps++
+                // One sleep retries the initial seed; the next is the first
+                // normal poll after the valid seed is installed.
+                if (sleeps == 2) monitor!!.stop()
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(2, seedReads)
+        assertEquals(listOf(WgConnectivityMonitor.INTERACTIVE_LOOP_SLEEP_MS,
+            WgConnectivityMonitor.INTERACTIVE_LOOP_SLEEP_MS), delays)
+    }
+
+    @Test
+    fun allNullFromStartEntersRecoveryOnce() {
+        var seedReads = 0
+        var broken = 0
+        val recovery = CountDownLatch(1)
+        val monitor = WgConnectivityMonitor(
+            statsProvider = { seedReads++; null },
+            prod = {},
+            onBroken = {
+                broken++
+                recovery.countDown()
+            },
+            sleep = {},
+            clock = { 0L }
+        )
+
+        monitor.start()
+        assertTrue(recovery.await(1, TimeUnit.SECONDS))
+        awaitStopped(monitor)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES, seedReads)
+        assertEquals(1, broken)
+        assertFalse(monitor.isRunning())
+    }
+
+    @Test
+    fun screenOffPersistentNullDefersRecoveryAtIdleCadence() {
+        var reads = 0
+        var sleeps = 0
+        var broken = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                null
+            },
+            prod = {},
+            onBroken = { broken++ },
+            isInteractive = { false },
+            sleep = { delay ->
+                assertEquals(WgConnectivityMonitor.IDLE_LOOP_SLEEP_MS, delay)
+                if (++sleeps == WgConnectivityMonitor.MAX_STATS_FAILURES + 1) monitor!!.stop()
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(0, broken)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES + 1, reads)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES + 1, sleeps)
+    }
+
+    @Test
+    fun transientMidLoopNullRetriesAtScreenAwareCadence() {
+        var reads = 0
+        var sleeps = 0
+        val delays = mutableListOf<Long>()
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 2) null else stats()
+            },
+            prod = {},
+            onBroken = { fail("transient stats failure entered recovery") },
+            sleep = { delay ->
+                delays += delay
+                sleeps++
+                if (sleeps == 3) monitor!!.stop()
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(3, reads)
+        assertEquals(listOf(WgConnectivityMonitor.INTERACTIVE_LOOP_SLEEP_MS,
+            WgConnectivityMonitor.INTERACTIVE_LOOP_SLEEP_MS,
+            WgConnectivityMonitor.INTERACTIVE_LOOP_SLEEP_MS), delays)
+    }
+
+    @Test
+    fun persistentNullLeadsToRecoveryAfterBoundedRetries() {
+        var reads = 0
+        var broken = 0
+        val recovery = CountDownLatch(1)
+        val monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 1) stats() else null
+            },
+            prod = {},
+            onBroken = {
+                broken++
+                recovery.countDown()
+            },
+            sleep = {},
+            clock = { 0L }
+        )
+
+        monitor.start()
+        assertTrue(recovery.await(1, TimeUnit.SECONDS))
+        awaitStopped(monitor)
+        assertEquals(1, broken)
+        assertEquals(1 + WgConnectivityMonitor.MAX_STATS_FAILURES, reads)
+        assertFalse(monitor.isRunning())
+    }
+
+    @Test
+    fun stopDuringStatsRetryIsPromptAndDoesNotRecover() {
+        var reads = 0
+        var sleeps = 0
+        var broken = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 1) stats() else null
+            },
+            prod = {},
+            onBroken = { broken++ },
+            sleep = {
+                sleeps++
+                if (sleeps == 2) monitor!!.stop()
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(2, reads)
+        assertEquals(0, broken)
+        assertFalse(monitor.isRunning())
+    }
+
+    @Test
+    fun restartAfterInitialExitStartsAFreshRun() {
+        var reads = 0
+        var sleeps = 0
+        var broken = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads <= WgConnectivityMonitor.MAX_STATS_FAILURES) null else stats()
+            },
+            prod = {},
+            onBroken = { broken++ },
+            sleep = {
+                sleeps++
+                if (broken > 0) monitor!!.stop()
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(1, broken)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES, reads)
+
+        monitor.start()
+        awaitStopped(monitor)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES + 1, reads)
+        assertEquals(WgConnectivityMonitor.MAX_STATS_FAILURES, sleeps)
+    }
+
+    @Test
+    fun staleExpectedTunnelDoesNotTriggerRecovery() {
+        var reads = 0
+        var sleeps = 0
+        var current = true
+        var broken = 0
+        val staleRead = CountDownLatch(1)
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 1) stats() else null.also { staleRead.countDown() }
+            },
+            prod = {},
+            onBroken = { broken++ },
+            isCurrent = { current },
+            sleep = {
+                if (++sleeps == 1) current = false
+            },
+            clock = { 0L }
+        )
+
+        monitor.start()
+        assertTrue(staleRead.await(1, TimeUnit.SECONDS))
+        awaitStopped(monitor)
+        assertEquals(2, reads)
+        assertEquals(0, broken)
+        assertFalse(monitor.isRunning())
+    }
+
+    @Test
+    fun stopBetweenCallbackAuthorizationAndDispatchSuppressesOldCallback() {
+        val callbackReady = CountDownLatch(1)
+        val releaseCallback = CountDownLatch(1)
+        val stopReturned = CountDownLatch(1)
+        val callbacks = AtomicInteger()
+        var reads = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 1) stats() else WgStats(0, 0, 1)
+            },
+            prod = {},
+            onBroken = {},
+            onConnected = { callbacks.incrementAndGet() },
+            sleep = {},
+            clock = { 0L },
+            beforeCallback = {
+                callbackReady.countDown()
+                assertTrue(releaseCallback.await(1, TimeUnit.SECONDS))
+            }
+        )
+
+        monitor.start()
+        assertTrue(callbackReady.await(1, TimeUnit.SECONDS))
+        Thread {
+            monitor!!.stop()
+            stopReturned.countDown()
+        }.start()
+        // stop invalidates the generation before waiting for the callback gate.
+        repeat(1_000) {
+            if (!monitor.isRunning()) return@repeat
+            Thread.yield()
+        }
+        assertFalse(monitor.isRunning())
+        releaseCallback.countDown()
+        assertTrue(stopReturned.await(1, TimeUnit.SECONDS))
+        assertEquals(0, callbacks.get())
+    }
+
+    @Test
+    fun stopBetweenProdAuthorizationAndDispatchSuppressesKeepalive() {
+        val now = AtomicLong(0)
+        val prodReady = CountDownLatch(1)
+        val releaseProd = CountDownLatch(1)
+        val stopReturned = CountDownLatch(1)
+        val prods = AtomicInteger()
+        var reads = 0
+        var sleeps = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                reads++
+                if (reads == 1) WgStats(0, 0, 0) else WgStats(0, 1, 0)
+            },
+            prod = { prods.incrementAndGet() },
+            onBroken = {},
+            sleep = {
+                when (++sleeps) {
+                    1 -> now.set(1_000L)
+                    2 -> now.set(6_000L)
+                }
+            },
+            clock = { now.get() },
+            beforeCallback = {
+                prodReady.countDown()
+                assertTrue(releaseProd.await(1, TimeUnit.SECONDS))
+            }
+        )
+
+        monitor.start()
+        assertTrue(prodReady.await(1, TimeUnit.SECONDS))
+        Thread {
+            monitor!!.stop()
+            stopReturned.countDown()
+        }.start()
+        // stop invalidates the generation first, then waits for the callback
+        // gate held by beforeCallback. It cannot return while that gate is
+        // unresolved.
+        repeat(1_000) {
+            if (!monitor.isRunning()) return@repeat
+            Thread.yield()
+        }
+        assertFalse(monitor.isRunning())
+        assertFalse(stopReturned.await(100, TimeUnit.MILLISECONDS))
+        releaseProd.countDown()
+        assertTrue(stopReturned.await(1, TimeUnit.SECONDS))
+        awaitStopped(monitor)
+        assertEquals(0, prods.get())
+    }
+
+    @Test
+    fun blockedStatsReadExpiresAndOldRunCannotCallbackAfterRestart() {
+        val now = AtomicLong(0)
+        val oldReadStarted = CountDownLatch(1)
+        val oldReadFinished = CountDownLatch(1)
+        val releaseOldRead = CountDownLatch(1)
+        val callbacks = AtomicInteger()
+        val reads = AtomicInteger()
+        var staleGeneration = false
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            statsProvider = {
+                when (reads.incrementAndGet()) {
+                    1 -> stats()
+                    2 -> {
+                        oldReadStarted.countDown()
+                        try {
+                            releaseOldRead.await(1, TimeUnit.SECONDS)
+                        } catch (_: InterruptedException) {
+                            // isRunning() interrupts the expired old run.
+                        } finally {
+                            oldReadFinished.countDown()
+                        }
+                        WgStats(0, 0, 1)
+                    }
+                    else -> stats()
+                }
+            },
+            prod = {},
+            onBroken = {},
+            onConnected = { callbacks.incrementAndGet() },
+            sleep = {
+                if (staleGeneration) monitor!!.stop()
+            },
+            clock = { now.get() }
+        )
+
+        monitor.start()
+        assertTrue(oldReadStarted.await(1, TimeUnit.SECONDS))
+        now.set(WgConnectivityMonitor.STATS_READ_TIMEOUT_MS)
+        assertFalse(monitor.isRunning())
+
+        // A new run may start while the old native stats call is still unwinding.
+        staleGeneration = true
+        monitor.start()
+        awaitStopped(monitor)
+        releaseOldRead.countDown()
+        assertTrue(oldReadFinished.await(1, TimeUnit.SECONDS))
+        assertEquals(0, callbacks.get())
+    }
+
+    @Test
+    fun callbackReplacementRacingStopDoesNotDeadlockOrLeakCandidate() {
+        val callbackGate = Any()
+        val oldStopEntered = CountDownLatch(1)
+        val releaseOldStop = CountDownLatch(1)
+        val replacementReturned = CountDownLatch(1)
+        val stopReturned = CountDownLatch(1)
+        val old = FakeMonitor()
+        val candidate = FakeMonitor()
+        val lifecycle = WgMonitorLifecycle<FakeMonitor>(
+            lock = Any(),
+            isRunning = { it.started },
+            stop = {
+                if (it === old) {
+                    oldStopEntered.countDown()
+                    releaseOldStop.await(1, TimeUnit.SECONDS)
+                }
+                it.stopped = true
+            },
+            start = { it.started = true }
+        )
+        assertTrue(lifecycle.replace(old, isCurrent = { true }))
+
+        val callback = Thread {
+            synchronized(callbackGate) {
+                lifecycle.replace(candidate, isCurrent = { true })
+                replacementReturned.countDown()
+            }
+        }
+        callback.start()
+        assertTrue(oldStopEntered.await(1, TimeUnit.SECONDS))
+
+        // stopMonitor must acquire the lifecycle lock while the callback-side
+        // replacement is waiting in old.stop(); it must not wait on the
+        // callback gate or leave the candidate to be started later.
+        Thread {
+            lifecycle.stop()
+            stopReturned.countDown()
+        }.start()
+        assertTrue(stopReturned.await(1, TimeUnit.SECONDS))
+        releaseOldStop.countDown()
+        assertTrue(replacementReturned.await(1, TimeUnit.SECONDS))
+        callback.join(1_000)
+        assertFalse(callback.isAlive)
+        assertTrue(old.stopped)
+        assertFalse(candidate.started)
+        assertTrue(candidate.stopped)
+        assertFalse(lifecycle.isRunning())
+    }
+
+    @Test
+    fun stopCancelsInProgressReplacementBeforeCandidateStarts() {
+        val oldStopEntered = CountDownLatch(1)
+        val releaseOldStop = CountDownLatch(1)
+        val replacementReturned = CountDownLatch(1)
+        val stopReturned = CountDownLatch(1)
+        val old = FakeMonitor()
+        val candidate = FakeMonitor()
+        val lifecycle = WgMonitorLifecycle<FakeMonitor>(
+            lock = Any(),
+            isRunning = { it.started },
+            stop = {
+                if (it === old) {
+                    oldStopEntered.countDown()
+                    releaseOldStop.await(1, TimeUnit.SECONDS)
+                }
+                it.stopped = true
+            },
+            start = { it.started = true }
+        )
+        assertTrue(lifecycle.replace(old, isCurrent = { true }))
+
+        Thread {
+            lifecycle.replace(candidate, isCurrent = { true })
+            replacementReturned.countDown()
+        }.start()
+        assertTrue(oldStopEntered.await(1, TimeUnit.SECONDS))
+
+        Thread {
+            lifecycle.stop()
+            stopReturned.countDown()
+        }.start()
+        assertTrue(stopReturned.await(1, TimeUnit.SECONDS))
+        releaseOldStop.countDown()
+        assertTrue(replacementReturned.await(1, TimeUnit.SECONDS))
+        assertTrue(old.stopped)
+        assertFalse(candidate.started)
+        assertTrue(candidate.stopped)
+        assertFalse(lifecycle.isRunning())
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitorTest.kt
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitorTest.kt
@@ -293,6 +293,46 @@ class WgConnectivityMonitorTest {
         assertFalse(monitor.isRunning())
     }
 
+    /**
+     * BROKEN is direct evidence of a dead data path (tx advanced, no rx, and
+     * the prod did not revive it), unlike an ambiguous null stats sample. The
+     * hijack is fail-closed, so deferring recovery to the next screen-on would
+     * strand every app without network while still prodding each idle poll.
+     */
+    @Test
+    fun screenOffBrokenTunnelStillEntersRecovery() {
+        val now = AtomicLong(0)
+        val broken = CountDownLatch(1)
+        val delays = mutableListOf<Long>()
+        var reads = 0
+        var sleeps = 0
+        var monitor: WgConnectivityMonitor? = null
+        monitor = WgConnectivityMonitor(
+            // rx never advances while tx does: an unanswered send.
+            statsProvider = { WgStats(0, (reads++).toLong(), 0) },
+            prod = {},
+            onBroken = { broken.countDown() },
+            isInteractive = { false },
+            sleep = { delay ->
+                delays += delay
+                // Stay under isSuspendGap so the stall is not mistaken for doze.
+                when (++sleeps) {
+                    1 -> now.set(1_000L)
+                    2 -> now.set(7_000L)
+                    3 -> now.set(25_000L)
+                    else -> monitor!!.stop()
+                }
+            },
+            clock = { now.get() }
+        )
+
+        monitor.start()
+        assertTrue("screen-off BROKEN did not reach recovery", broken.await(5, TimeUnit.SECONDS))
+        awaitStopped(monitor)
+        assertEquals(WgConnectivityMonitor.IDLE_LOOP_SLEEP_MS, delays.first())
+        assertEquals(3, sleeps)
+    }
+
     @Test
     fun stopBetweenCallbackAuthorizationAndDispatchSuppressesOldCallback() {
         val callbackReady = CountDownLatch(1)


### PR DESCRIPTION
## Summary
- retry transient initial and mid-loop WireGuard stats failures at the existing screen-aware cadence
- make monitor stop/restart and callback ownership generation-safe
- detect a stats call that has stopped making uptime progress when liveness is queried
- restart a dead watchdog on the same-config tunnel path

## Why
A null initial stats read permanently ended monitoring, and lifecycle races could let an old monitor affect a replacement.

## Validation
- all `net.kollnig.missioncontrol.wg.*` JVM tests
- Kotlin and Java compile
- latch-controlled stop/stale/hung-stats coverage
- `git diff --check`

## Risk
- No device test simulated a native `Tunnel.stats()` hang. Detection adds no timer, alarm, radio work, or faster screen-off cadence.

