### PR TITLE
Fix direct DNS-over-TCP stream framing

### DIFF
--- a/app/src/main/jni/netguard/dns_frame.c
+++ b/app/src/main/jni/netguard/dns_frame.c
@@ -19,39 +19,333 @@
 
 #include "dns_frame.h"
 
-struct dns_frame_decision dns_frame_decide(size_t bytes, size_t frame_len) {
-    struct dns_frame_decision d;
-    d.frame_len = frame_len;
+#include <string.h>
 
-    if (frame_len == 0) {
-        // A zero-length declared frame is not something the parser can
-        // act on; skip it entirely, matching the original "if (frame_len
-        // > 0)" guard.
-        d.should_parse = 0;
-        d.isolated = 0;
-        d.dlen = 0;
-        return d;
-    }
-
-    d.should_parse = 1;
-    d.isolated = (frame_len + 2 == bytes) ? 1 : 0;
-
-    // avail is the payload available in this recv() after the 2-byte
-    // prefix. The caller guarantees bytes > 2, so avail >= 1.
-    size_t avail = bytes - 2;
-    // isolated implies frame_len == avail.
-    d.dlen = (frame_len < avail) ? frame_len : avail;
-
-    return d;
+static void dns_frame_stream_clear_frame(struct dns_frame_stream *stream) {
+    stream->buffered = 0;
+    stream->expected = 0;
+    stream->split = 0;
 }
 
-void dns_frame_apply_rewrite(uint8_t *buffer,
-                              const struct dns_frame_decision *decision,
-                              size_t post_parse_dlen,
-                              ssize_t *bytes) {
-    if (decision->isolated && post_parse_dlen != decision->frame_len) {
-        buffer[0] = (uint8_t) (post_parse_dlen >> 8);
-        buffer[1] = (uint8_t) post_parse_dlen;
-        *bytes = (ssize_t) post_parse_dlen + 2;
+void dns_frame_stream_init(struct dns_frame_stream *stream,
+                           uint8_t *storage, size_t capacity) {
+    memset(stream, 0, sizeof(*stream));
+    stream->buffer = storage;
+    stream->capacity = capacity;
+}
+
+void dns_frame_stream_reset(struct dns_frame_stream *stream) {
+    dns_frame_stream_clear_frame(stream);
+    stream->pending_offset = 0;
+    stream->pending_length = 0;
+    stream->pending_passthrough = 0;
+}
+
+void dns_frame_stream_disable(struct dns_frame_stream *stream) {
+    stream->disabled = 1;
+}
+
+static int dns_frame_pending_reserve(struct dns_frame_stream *stream,
+                                     size_t additional,
+                                     dns_frame_pending_reserve_fn reserve,
+                                     void *ctx) {
+    if (stream->pending_offset != 0 &&
+        additional > stream->pending_capacity - stream->pending_length) {
+        const size_t retained = stream->pending_length - stream->pending_offset;
+        memmove(stream->pending, stream->pending + stream->pending_offset,
+                retained);
+        stream->pending_offset = 0;
+        stream->pending_length = retained;
     }
+
+    if (additional > SIZE_MAX - stream->pending_length)
+        return -1;
+    const size_t required = stream->pending_length + additional;
+    if (required <= stream->pending_capacity)
+        return 0;
+    if (reserve == NULL || reserve(ctx, stream, required) < 0 ||
+        stream->pending == NULL || stream->pending_capacity < required)
+        return -1;
+    return 0;
+}
+
+static int dns_frame_pending_append(struct dns_frame_stream *stream,
+                                    const uint8_t *data, size_t bytes,
+                                    dns_frame_pending_reserve_fn reserve,
+                                    void *ctx) {
+    if (bytes == 0)
+        return 0;
+    if (dns_frame_pending_reserve(stream, bytes, reserve, ctx) < 0)
+        return -1;
+    memcpy(stream->pending + stream->pending_length, data, bytes);
+    stream->pending_length += bytes;
+    return 0;
+}
+
+/* Allocation failure must not lose a prefix or bytes already retained from a
+ * preceding recv(). If rewritten output is queued, report a terminal error
+ * instead of mixing raw bytes after it; otherwise queue the held bytes first,
+ * then the unread part of this recv(), and enter fail-open mode. */
+static int dns_frame_fail_open(struct dns_frame_stream *stream,
+                               uint8_t *data, size_t pos, size_t input_len,
+                               dns_frame_pending_reserve_fn reserve, void *ctx) {
+    stream->disabled = 1;
+    /* Never mix raw fail-open bytes after already-rewritten output. The owner
+     * must terminate so queued bytes cannot be observed in a different order. */
+    if (dns_frame_stream_has_pending(stream) && !stream->pending_passthrough)
+        return -1;
+    stream->pending_passthrough = 1;
+    if (dns_frame_pending_append(stream, stream->buffer, stream->buffered,
+                                 reserve, ctx) < 0)
+        return -1;
+    if (pos < input_len &&
+        dns_frame_pending_append(stream, data + pos, input_len - pos,
+                                 reserve, ctx) < 0)
+        return -1;
+    dns_frame_stream_clear_frame(stream);
+    return 0;
+}
+
+int dns_frame_stream_feed(struct dns_frame_stream *stream,
+                          uint8_t *data, size_t *bytes,
+                          dns_frame_parse_fn parser,
+                          dns_frame_reserve_fn reserve,
+                          dns_frame_pending_reserve_fn pending_reserve,
+                          void *ctx,
+                          struct dns_frame_stream_result *result) {
+    if (stream == NULL || bytes == NULL || (data == NULL && *bytes != 0))
+        return -1;
+
+    if (result != NULL)
+        memset(result, 0, sizeof(*result));
+
+    const size_t input_len = *bytes;
+
+    if (stream->disabled) {
+        /* dns_frame_stream_disable() can be called while a prefix is held.
+         * Preserve that prefix before switching to raw fail-open forwarding. */
+        return dns_frame_fail_open(stream, data, 0, input_len,
+                                   pending_reserve, ctx);
+    }
+
+    size_t pos = 0;
+
+    while (pos < input_len) {
+        /* Gather the two-byte prefix. A one-byte prefix at the end of this
+         * feed remains in stream->buffer and is never interpreted as payload
+         * or as a future prefix. */
+        if (stream->expected == 0) {
+            if (stream->buffer == NULL || stream->capacity < 2) {
+                if (reserve == NULL || reserve(ctx, stream, 2) < 0 ||
+                    stream->buffer == NULL || stream->capacity < 2)
+                    return dns_frame_fail_open(stream, data, pos, input_len,
+                                               pending_reserve, ctx);
+            }
+            size_t needed = 2 - stream->buffered;
+            size_t available = input_len - pos;
+            size_t copied = needed < available ? needed : available;
+            memcpy(stream->buffer + stream->buffered, data + pos, copied);
+            stream->buffered += copied;
+            pos += copied;
+
+            if (stream->buffered < 2) {
+                stream->split = 1;
+                continue;
+            }
+
+            size_t payload_len = ((size_t) stream->buffer[0] << 8) |
+                                 stream->buffer[1];
+            stream->expected = payload_len + 2;
+
+            if (payload_len == 0) {
+                if (dns_frame_pending_append(stream, stream->buffer, 2,
+                                             pending_reserve, ctx) < 0)
+                    return dns_frame_fail_open(stream, data, pos, input_len,
+                                               pending_reserve, ctx);
+                if (result != NULL)
+                    result->skipped++;
+                dns_frame_stream_clear_frame(stream);
+                continue;
+            }
+
+            if (stream->expected > stream->capacity) {
+                if (reserve != NULL && reserve(ctx, stream, stream->expected) == 0 &&
+                    stream->buffer != NULL && stream->capacity >= stream->expected)
+                    continue;
+
+                /* The prefix cannot be retained at the declared size. Queue
+                 * it and all remaining bytes unchanged, then disable further
+                 * inspection: without a frame-sized buffer, treating a later
+                 * prefix as inspectable could reorder or drop the stream. */
+                return dns_frame_fail_open(stream, data, pos, input_len,
+                                           pending_reserve, ctx);
+            }
+        }
+
+        size_t needed = stream->expected - stream->buffered;
+        size_t available = input_len - pos;
+        size_t copied = needed < available ? needed : available;
+        memcpy(stream->buffer + stream->buffered, data + pos, copied);
+        stream->buffered += copied;
+        pos += copied;
+
+        if (stream->buffered < stream->expected) {
+            stream->split = 1;
+            continue;
+        }
+
+        /* Reserve before calling the parser. If queuing the frame can fail,
+         * parser mutations must not be allowed to alter fail-open bytes. */
+        if (dns_frame_pending_reserve(stream, stream->expected,
+                                      pending_reserve, ctx) < 0)
+            return dns_frame_fail_open(stream, data, pos, input_len,
+                                       pending_reserve, ctx);
+
+        const size_t payload_len = stream->expected - 2;
+        size_t parsed_len = payload_len;
+        if (parser != NULL)
+            parsed_len = parser(ctx, stream->buffer + 2, payload_len);
+        if (parsed_len > payload_len)
+            parsed_len = payload_len;
+
+        if (parsed_len != payload_len) {
+            stream->buffer[0] = (uint8_t) (parsed_len >> 8);
+            stream->buffer[1] = (uint8_t) parsed_len;
+        }
+        if (dns_frame_pending_append(stream, stream->buffer, parsed_len + 2,
+                                     pending_reserve, ctx) < 0)
+            return -1;
+
+        if (result != NULL)
+            result->parsed++;
+        dns_frame_stream_clear_frame(stream);
+    }
+
+    return 0;
+}
+
+int dns_frame_stream_flush(struct dns_frame_stream *stream, size_t max_bytes,
+                           dns_frame_emit_fn emitter, void *ctx,
+                           struct dns_frame_stream_result *result) {
+    if (stream == NULL)
+        return -1;
+    if (result != NULL)
+        memset(result, 0, sizeof(*result));
+    if (max_bytes == 0 || !dns_frame_stream_has_pending(stream))
+        return 0;
+    if (emitter == NULL)
+        return -1;
+
+    size_t bytes = stream->pending_length - stream->pending_offset;
+    if (bytes > max_bytes)
+        bytes = max_bytes;
+    if (emitter(ctx, stream->pending + stream->pending_offset, bytes) < 0)
+        return -1;
+    stream->pending_offset += bytes;
+    if (result != NULL)
+        result->emitted = bytes;
+    if (stream->pending_offset == stream->pending_length) {
+        stream->pending_offset = 0;
+        stream->pending_length = 0;
+        stream->pending_passthrough = 0;
+    }
+    return 0;
+}
+
+int dns_frame_stream_has_pending(const struct dns_frame_stream *stream) {
+    return stream != NULL && stream->pending_offset < stream->pending_length;
+}
+
+void dns_frame_stream_release_pending(struct dns_frame_stream *stream,
+                                      dns_frame_pending_release_fn release,
+                                      void *ctx) {
+    if (stream == NULL || dns_frame_stream_has_pending(stream) ||
+        stream->pending == NULL || release == NULL)
+        return;
+    release(ctx, stream);
+    stream->pending = NULL;
+    stream->pending_capacity = 0;
+    stream->pending_offset = 0;
+    stream->pending_length = 0;
+    stream->pending_passthrough = 0;
+}
+
+uint32_t dns_frame_send_window(uint32_t acked, uint32_t local_seq,
+                               uint16_t unconfirmed, uint32_t send_window) {
+    uint32_t behind;
+    if (acked <= local_seq)
+        behind = local_seq - acked;
+    else
+        behind = 0x10000 + local_seq - acked;
+    behind += ((uint32_t) unconfirmed + 1) * 40;
+    return behind < send_window ? send_window - behind : 0;
+}
+
+size_t dns_frame_send_budget(uint32_t send_window, uint16_t mss) {
+    if (mss == 0)
+        return 0;
+    return send_window < mss ? send_window : mss;
+}
+
+int dns_frame_should_read(int terminal, int pending, uint32_t send_window) {
+    return !terminal && !pending && send_window != 0;
+}
+
+int dns_frame_should_flush_ack(int has_ack, int terminal, int pending) {
+    return has_ack && (terminal || pending);
+}
+
+int dns_frame_should_resume_hup(int terminal, int pending,
+                                uint32_t send_window) {
+    return terminal == DNS_FRAME_TERMINAL_HUP_PENDING && !pending &&
+           send_window != 0;
+}
+
+int dns_frame_hup_rearm_failure_state(int terminal) {
+    return terminal == DNS_FRAME_TERMINAL_HUP_PENDING
+           ? DNS_FRAME_TERMINAL_DRAIN
+           : terminal;
+}
+
+int dns_frame_eof_terminal_state(int pending, int buffered, int forward_pending) {
+    if (buffered || forward_pending)
+        return pending ? DNS_FRAME_TERMINAL_DRAIN : DNS_FRAME_TERMINAL_NONE;
+    return DNS_FRAME_TERMINAL_FIN_DRAIN;
+}
+
+int dns_frame_socket_terminal_event(int has_error, int has_hup, int has_read,
+                                    int pending) {
+    return has_error || (has_hup && (pending || !has_read));
+}
+
+int dns_frame_hup_pending_state(int has_error, int has_hup, int pending) {
+    return !has_error && has_hup && pending
+           ? DNS_FRAME_TERMINAL_HUP_PENDING
+           : DNS_FRAME_TERMINAL_NONE;
+}
+
+int dns_frame_recheck_due(long long now, long long last_check, long long interval) {
+    return interval <= 0 || (now >= last_check && now - last_check > interval);
+}
+
+int dns_frame_requires_recheck(uint32_t send_window) {
+    return send_window == 0;
+}
+
+int dns_frame_flush_chunk_allowed(size_t chunks) {
+    return chunks < DNS_FRAME_MAX_FLUSH_CHUNKS;
+}
+
+int dns_frame_terminal_timeout(int terminal, int close_timeout) {
+    return terminal != DNS_FRAME_TERMINAL_NONE ? close_timeout : 0;
+}
+
+int dns_frame_terminal_next(int state, int pending, uint32_t acked,
+                            uint32_t local_seq) {
+    if (state == DNS_FRAME_TERMINAL_DRAIN && !pending)
+        return acked == local_seq ? DNS_FRAME_TERMINAL_NONE
+                                  : DNS_FRAME_TERMINAL_WAIT_ACK;
+    if (state == DNS_FRAME_TERMINAL_WAIT_ACK && acked == local_seq)
+        return DNS_FRAME_TERMINAL_NONE;
+    return state;
 }

--- a/app/src/main/jni/netguard/dns_frame.h
+++ b/app/src/main/jni/netguard/dns_frame.h
@@ -21,70 +21,157 @@
 #define DNS_FRAME_H
 
 /*
- * Pure decision logic for DNS-over-TCP framing, extracted out of
+ * DNS-over-TCP framing helpers, extracted out of
  * check_tcp_socket() (tcp.c) so it can be unit-tested on the host without
  * pulling in JNI/session dependencies. This header and its implementation
  * (dns_frame.c) must only depend on libc: no netguard.h, no JNI.
  *
- * A single recv() on a DNS-over-TCP (port 53) socket may contain:
- *   - an isolated complete frame (2-byte length prefix + exactly one
- *     DNS message, with nothing left over);
- *   - a coalesced read (that frame plus additional bytes -- the start of
- *     the next frame, or more);
- *   - a split/partial frame (fewer bytes than the prefix declares).
- *
- * Policy: every frame's DNS payload is handed to the DNS parser so header
- * blanking/policy enforcement always applies, but only an isolated
- * complete frame may be shortened afterward (with its 2-byte length
- * prefix rewritten to match). Shortening a coalesced or split read would
- * discard bytes that still belong to the TCP stream.
+ * DNS-over-TCP is a byte stream, rather than a packet protocol. A frame can
+ * be split over any number of recv() calls, and one recv() can contain any
+ * number of complete frames. The stream helper below retains at most one
+ * frame under construction (the maximum DNS-over-TCP payload is 65535 bytes).
+ * Complete frames are parsed exactly once, copied to a bounded pending-output
+ * queue, and emitted later by dns_frame_stream_flush(). This lets the owner
+ * respect its current TCP send window even when a response is larger than
+ * that window.
  */
 
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/types.h>
+
+/* DNS-over-TCP's two-byte length prefix is an unsigned 16-bit value. */
+#define DNS_FRAME_MAX_PAYLOAD ((size_t) 0xFFFF)
+#define DNS_FRAME_MAX_BUFFER (DNS_FRAME_MAX_PAYLOAD + 2)
+/* One maximum frame plus one maximum-sized socket read. */
+#define DNS_FRAME_MAX_PENDING (DNS_FRAME_MAX_BUFFER * 2)
+/* Reassembly plus pending output in steady state. A geometric pending
+ * replacement keeps the old allocation at or below half the pending cap, so
+ * one replacement peaks at this bound (including the reassembly buffer). */
+#define DNS_FRAME_MAX_SESSION_STORAGE (DNS_FRAME_MAX_BUFFER + DNS_FRAME_MAX_PENDING)
+#define DNS_FRAME_MAX_TRANSIENT_STORAGE \
+    (DNS_FRAME_MAX_SESSION_STORAGE + DNS_FRAME_MAX_PENDING / 2)
+/* tcp.c emits at most this many MSS/window-bounded chunks per invocation;
+ * later ACKs resume the queue without allowing unconfirmed to run away. */
+#define DNS_FRAME_MAX_FLUSH_CHUNKS ((size_t) 16)
+
+#define DNS_FRAME_TERMINAL_NONE 0
+#define DNS_FRAME_TERMINAL_DRAIN 1
+#define DNS_FRAME_TERMINAL_WAIT_ACK 2
+/* Upstream HUP: pending output drains before the fd is read again. */
+#define DNS_FRAME_TERMINAL_HUP_PENDING 3
+/* Upstream EOF: drain rewritten bytes, then send a downstream FIN. */
+#define DNS_FRAME_TERMINAL_FIN_DRAIN 4
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-struct dns_frame_decision {
-    /* Whether the DNS parser should be invoked at all for this recv(). */
-    int should_parse;
-    /* Whether this recv() held exactly one complete frame (frame_len + 2
-     * == bytes). Only an isolated frame's prefix may be rewritten. */
-    int isolated;
-    /* The frame length taken verbatim from the 2-byte prefix. */
-    size_t frame_len;
-    /* The payload length to hand to the DNS parser: at most bytes - 2,
-     * so a split/partial read is never over-read. */
-    size_t dlen;
+struct dns_frame_stream;
+
+typedef size_t (*dns_frame_parse_fn)(void *ctx, uint8_t *payload, size_t length);
+typedef int (*dns_frame_emit_fn)(void *ctx, const uint8_t *frame, size_t length);
+typedef int (*dns_frame_reserve_fn)(void *ctx, struct dns_frame_stream *stream,
+                                    size_t required);
+typedef int (*dns_frame_pending_reserve_fn)(void *ctx,
+                                            struct dns_frame_stream *stream,
+                                            size_t required);
+typedef void (*dns_frame_pending_release_fn)(void *ctx,
+                                             struct dns_frame_stream *stream);
+
+struct dns_frame_stream {
+    /* Storage is supplied by the owner so Android can use ng_malloc/ng_free. */
+    uint8_t *buffer;
+    size_t capacity;
+    /* Bytes retained for the current frame, including its prefix. */
+    size_t buffered;
+    /* Total frame size including prefix after a complete prefix is known. */
+    size_t expected;
+    /* A frame has received bytes from more than one feed call. */
+    int split;
+    /* Set by the owner when allocation fails; parsing stays disabled. */
+    int disabled;
+    /* Complete, rewritten frames waiting for the downstream send window. */
+    uint8_t *pending;
+    size_t pending_capacity;
+    size_t pending_offset;
+    size_t pending_length;
+    /* Pending bytes are raw fail-open data rather than rewritten frames. */
+    int pending_passthrough;
 };
 
-/*
- * Computes the framing decision for one recv() on a DNS-over-TCP socket.
- *
- * bytes: total bytes read by recv(); the caller guarantees bytes > 2
- *        (there is at least a full 2-byte length prefix plus one byte).
- * frame_len: the 16-bit frame length taken from the first two bytes of
- *        the buffer (buffer[0] << 8 | buffer[1]), before this call.
- */
-struct dns_frame_decision dns_frame_decide(size_t bytes, size_t frame_len);
+struct dns_frame_stream_result {
+    /* Number of complete, non-zero frames handed to the parser. */
+    size_t parsed;
+    /* Number of zero-length frames consumed without invoking the parser. */
+    size_t skipped;
+    /* Number of bytes emitted by dns_frame_stream_flush(). */
+    size_t emitted;
+};
 
-/*
- * Applies the post-parse rewrite to buffer, if any. buffer must point at
- * the full recv() buffer, including the 2-byte length prefix, and must be
- * at least *bytes long. post_parse_dlen is the (possibly shrunk) payload
- * length the DNS parser reported. *bytes is updated in place when a
- * rewrite happens; otherwise it is left untouched.
- *
- * No-op unless decision->isolated and post_parse_dlen differs from
- * decision->frame_len -- matching the original inline check.
- */
-void dns_frame_apply_rewrite(uint8_t *buffer,
-                              const struct dns_frame_decision *decision,
-                              size_t post_parse_dlen,
-                              ssize_t *bytes);
+/* Initializes an empty stream state. storage may be NULL; feed() calls reserve
+ * when it needs storage for a declared frame. */
+void dns_frame_stream_init(struct dns_frame_stream *stream,
+                           uint8_t *storage, size_t capacity);
+
+/* Drops a partial frame and any pending output, starting the next feed at a
+ * fresh prefix. Storage remains owned by the caller and is not freed. */
+void dns_frame_stream_reset(struct dns_frame_stream *stream);
+
+/* Disables inspection after an allocation failure. This is fail-open; a
+ * subsequent feed queues any held bytes followed by its input unchanged. */
+void dns_frame_stream_disable(struct dns_frame_stream *stream);
+
+/* Feeds one recv() buffer. The input is held until each declared frame is
+ * complete, then parsed once and appended to the pending output queue. The
+ * parser may shorten a frame; the helper rewrites its prefix before queueing
+ * it. The input is never retained by the helper and *bytes is not changed. On
+ * reserve failure, held/current bytes are queued unchanged and inspection is
+ * disabled unless rewritten output is already queued; in that mixed case it
+ * returns -1 so the owner can terminate atomically. */
+int dns_frame_stream_feed(struct dns_frame_stream *stream,
+                          uint8_t *data, size_t *bytes,
+                          dns_frame_parse_fn parser,
+                          dns_frame_reserve_fn reserve,
+                          dns_frame_pending_reserve_fn pending_reserve,
+                          void *ctx,
+                          struct dns_frame_stream_result *result);
+
+/* Emits at most max_bytes from the pending queue. The caller chooses a budget
+ * that accounts for the current TCP send window and MSS. Bytes are removed
+ * only after the emitter succeeds, so an emitter error cannot duplicate data
+ * on a later flush. */
+int dns_frame_stream_flush(struct dns_frame_stream *stream, size_t max_bytes,
+                           dns_frame_emit_fn emitter, void *ctx,
+                           struct dns_frame_stream_result *result);
+
+int dns_frame_stream_has_pending(const struct dns_frame_stream *stream);
+
+/* Releases pending storage after the queue has drained. The owner supplies
+ * the matching allocator because Android uses ng_malloc/ng_free. */
+void dns_frame_stream_release_pending(struct dns_frame_stream *stream,
+                                      dns_frame_pending_release_fn release,
+                                      void *ctx);
+
+/* Shared TCP-output arithmetic used by the production path and host tests. */
+uint32_t dns_frame_send_window(uint32_t acked, uint32_t local_seq,
+                               uint16_t unconfirmed, uint32_t send_window);
+size_t dns_frame_send_budget(uint32_t send_window, uint16_t mss);
+
+/* Shared lifecycle decisions used by tcp.c and host tests. */
+int dns_frame_should_read(int terminal, int pending, uint32_t send_window);
+int dns_frame_should_flush_ack(int has_ack, int terminal, int pending);
+int dns_frame_should_resume_hup(int terminal, int pending, uint32_t send_window);
+int dns_frame_hup_rearm_failure_state(int terminal);
+int dns_frame_eof_terminal_state(int pending, int buffered, int forward_pending);
+int dns_frame_socket_terminal_event(int has_error, int has_hup, int has_read,
+                                    int pending);
+int dns_frame_hup_pending_state(int has_error, int has_hup, int pending);
+int dns_frame_recheck_due(long long now, long long last_check, long long interval);
+int dns_frame_requires_recheck(uint32_t send_window);
+int dns_frame_flush_chunk_allowed(size_t chunks);
+int dns_frame_terminal_timeout(int terminal, int close_timeout);
+int dns_frame_terminal_next(int state, int pending, uint32_t acked,
+                            uint32_t local_seq);
 
 #ifdef __cplusplus
 }

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -34,6 +34,7 @@
 #include <sys/system_properties.h>
 
 #include "tcdns.h"
+#include "dns_frame.h"
 
 #define TAG "TrackerControl.JNI"
 
@@ -218,6 +219,8 @@ struct tcp_session {
     int checkedHostname;
     uint8_t *tls_data; // buffered ClientHello for cross-segment SNI reassembly (research mode)
     uint16_t tls_len;  // bytes currently buffered in tls_data
+    struct dns_frame_stream dns_frames; // DNS-over-TCP response reassembly
+    uint8_t dns_terminal; // upstream terminal; drain/wait-for-ACK state
 };
 
 struct ng_session {

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -27,6 +27,325 @@ extern char socks5_password[127 + 1];
 
 extern FILE *pcap_file;
 
+struct dns_frame_parse_context {
+    const struct arguments *args;
+    struct ng_session *session;
+};
+
+static size_t parse_dns_frame(void *opaque, uint8_t *payload, size_t length) {
+    const struct dns_frame_parse_context *ctx =
+            (const struct dns_frame_parse_context *) opaque;
+    size_t parsed_length = length;
+    parse_dns_response(ctx->args, ctx->session, payload, &parsed_length);
+    return parsed_length;
+}
+
+static int reserve_dns_frame(void *opaque, struct dns_frame_stream *stream,
+                             size_t required) {
+    (void) opaque;
+    if (required > DNS_FRAME_MAX_BUFFER)
+        return -1;
+    if (stream->buffer != NULL && stream->capacity >= required)
+        return 0;
+
+    uint8_t *storage = ng_malloc(required, "dns tcp reassembly");
+    if (storage == NULL)
+        return -1;
+    if (stream->buffer != NULL) {
+        memcpy(storage, stream->buffer, stream->buffered);
+        ng_free(stream->buffer, __FILE__, __LINE__);
+    }
+    stream->buffer = storage;
+    stream->capacity = required;
+    return 0;
+}
+
+static int reserve_dns_pending(void *opaque, struct dns_frame_stream *stream,
+                               size_t required) {
+    (void) opaque;
+    if (required > DNS_FRAME_MAX_PENDING)
+        return -1;
+    if (stream->pending != NULL && stream->pending_capacity >= required)
+        return 0;
+
+    /* Grow geometrically, but stop at half the cap before promoting to the
+     * final capacity. This bounds an old+new replacement allocation. */
+    size_t capacity = stream->pending_capacity;
+    const size_t half = DNS_FRAME_MAX_PENDING / 2;
+    if (capacity < 2)
+        capacity = 2;
+    while (capacity < required) {
+        if (capacity >= half) {
+            capacity = DNS_FRAME_MAX_PENDING;
+            break;
+        }
+        if (capacity > half / 2)
+            capacity = half;
+        else
+            capacity *= 2;
+    }
+    if (capacity < required)
+        return -1;
+
+    uint8_t *storage = ng_malloc(capacity, "dns tcp pending");
+    if (storage == NULL)
+        return -1;
+    if (stream->pending != NULL) {
+        const size_t pending = stream->pending_length - stream->pending_offset;
+        memcpy(storage, stream->pending + stream->pending_offset, pending);
+        ng_free(stream->pending, __FILE__, __LINE__);
+        stream->pending_offset = 0;
+        stream->pending_length = pending;
+    }
+    stream->pending = storage;
+    stream->pending_capacity = capacity;
+    return 0;
+}
+
+static void release_dns_pending(void *opaque, struct dns_frame_stream *stream) {
+    (void) opaque;
+    ng_free(stream->pending, __FILE__, __LINE__);
+}
+
+static int emit_dns_frame_chunk(void *opaque, const uint8_t *frame, size_t length) {
+    const struct dns_frame_parse_context *ctx =
+            (const struct dns_frame_parse_context *) opaque;
+    struct tcp_session *tcp = &ctx->session->tcp;
+    if (length == 0 || length > tcp->mss)
+        return -1;
+    if (write_data(ctx->args, tcp, frame, length) < 0)
+        return -1;
+    tcp->local_seq += length;
+    tcp->unconfirmed++;
+    return 0;
+}
+
+static void release_dns_frame_storage(struct tcp_session *tcp) {
+    if (tcp->dns_frames.buffer == NULL || tcp->dns_frames.buffered != 0)
+        return;
+
+    ng_free(tcp->dns_frames.buffer, __FILE__, __LINE__);
+    tcp->dns_frames.buffer = NULL;
+    tcp->dns_frames.capacity = 0;
+}
+
+static void release_dns_pending_storage(struct tcp_session *tcp) {
+    dns_frame_stream_release_pending(&tcp->dns_frames, release_dns_pending, NULL);
+}
+
+static void discard_dns_frame_state(struct tcp_session *tcp) {
+    dns_frame_stream_reset(&tcp->dns_frames);
+    release_dns_frame_storage(tcp);
+    release_dns_pending_storage(tcp);
+}
+
+static void terminate_dns_session(const struct arguments *args,
+                                  struct ng_session *session) {
+    write_rst(args, &session->tcp);
+    discard_dns_frame_state(&session->tcp);
+    session->tcp.state = TCP_CLOSING;
+    session->tcp.dns_terminal = DNS_FRAME_TERMINAL_NONE;
+}
+
+static int begin_dns_terminal(struct ng_session *session, int epoll_fd,
+                              int terminal_state) {
+    if ((terminal_state != DNS_FRAME_TERMINAL_FIN_DRAIN &&
+         !dns_frame_stream_has_pending(&session->tcp.dns_frames)) ||
+        session->tcp.dns_terminal != DNS_FRAME_TERMINAL_NONE)
+        return -1;
+    if (session->socket < 0)
+        return -1;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, session->socket, NULL)) {
+        log_android(ANDROID_LOG_WARN, "DNS TCP terminal epoll delete error %d: %s",
+                    errno, strerror(errno));
+        /* Closing the descriptor still removes HUP from epoll if deletion
+         * failed because the event was already detached. Keep queued output
+         * and use the reset-drain state; a failed detach cannot prove EOF. */
+        if (close(session->socket))
+            log_android(ANDROID_LOG_WARN, "DNS TCP terminal close error %d: %s",
+                        errno, strerror(errno));
+        session->socket = -1;
+        session->tcp.dns_terminal = DNS_FRAME_TERMINAL_DRAIN;
+        return 0;
+    }
+    if (close(session->socket))
+        log_android(ANDROID_LOG_WARN, "DNS TCP terminal close error %d: %s",
+                    errno, strerror(errno));
+    session->socket = -1;
+    session->tcp.dns_terminal = (uint8_t) terminal_state;
+    return 0;
+}
+
+/* HUP can arrive together with readable bytes. Detach it from epoll while
+ * downstream output drains, but retain the fd so those bytes can be consumed
+ * after an ACK reopens the downstream window. */
+static int begin_dns_hup_pending(struct ng_session *session, int epoll_fd) {
+    if (!dns_frame_stream_has_pending(&session->tcp.dns_frames) ||
+        session->tcp.dns_terminal != DNS_FRAME_TERMINAL_NONE ||
+        session->socket < 0)
+        return -1;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, session->socket, NULL)) {
+        log_android(ANDROID_LOG_WARN, "DNS TCP HUP epoll delete error %d: %s",
+                    errno, strerror(errno));
+        /* The pending response remains valid. Closing guarantees HUP cannot
+         * wake the loop forever; treat unread bytes as an explicit reset. */
+        if (close(session->socket))
+            log_android(ANDROID_LOG_WARN, "DNS TCP HUP close error %d: %s",
+                        errno, strerror(errno));
+        session->socket = -1;
+        session->tcp.dns_terminal = DNS_FRAME_TERMINAL_DRAIN;
+        return 0;
+    }
+    session->ev.events = EPOLLERR;
+    session->tcp.dns_terminal = DNS_FRAME_TERMINAL_HUP_PENDING;
+    return 0;
+}
+
+static int resume_dns_hup(struct ng_session *session, int epoll_fd) {
+    struct tcp_session *tcp = &session->tcp;
+    if (!dns_frame_should_resume_hup(
+                tcp->dns_terminal,
+                dns_frame_stream_has_pending(&tcp->dns_frames),
+                get_send_window(tcp)))
+        return 0;
+    if (session->socket < 0)
+        return -1;
+
+    session->ev.events = EPOLLIN | EPOLLERR;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, session->socket, &session->ev)) {
+        log_android(ANDROID_LOG_WARN, "DNS TCP HUP epoll add error %d: %s",
+                    errno, strerror(errno));
+        if (close(session->socket))
+            log_android(ANDROID_LOG_WARN, "DNS TCP HUP resume close error %d: %s",
+                        errno, strerror(errno));
+        session->socket = -1;
+        /* The final emitted bytes are still valid. Wait for their ACKs and
+         * use the reset terminal path instead of sending an immediate RST. */
+        tcp->dns_terminal = dns_frame_hup_rearm_failure_state(tcp->dns_terminal);
+        return 0;
+    }
+    tcp->dns_terminal = DNS_FRAME_TERMINAL_NONE;
+    return 0;
+}
+
+static void finish_dns_terminal(const struct arguments *args,
+                                struct ng_session *session) {
+    terminate_dns_session(args, session);
+}
+
+static void finish_dns_fin(const struct arguments *args,
+                           struct ng_session *session) {
+    struct tcp_session *tcp = &session->tcp;
+    /* A FIN consumes sequence space and must not be sent into a closed
+     * downstream window. The next ACK/window update retries this path. */
+    if (get_send_window(tcp) == 0)
+        return;
+    if (write_fin_ack(args, tcp) < 0) {
+        tcp->dns_terminal = DNS_FRAME_TERMINAL_NONE;
+        return;
+    }
+    tcp->local_seq++; // local FIN
+    if (tcp->state == TCP_ESTABLISHED)
+        tcp->state = TCP_FIN_WAIT1;
+    else if (tcp->state == TCP_CLOSE_WAIT)
+        tcp->state = TCP_LAST_ACK;
+    else {
+        log_android(ANDROID_LOG_ERROR, "DNS TCP invalid EOF state %d", tcp->state);
+        write_rst(args, tcp);
+        tcp->dns_terminal = DNS_FRAME_TERMINAL_NONE;
+        return;
+    }
+    discard_dns_frame_state(tcp);
+    tcp->dns_terminal = DNS_FRAME_TERMINAL_NONE;
+}
+
+static int flush_dns_frames(const struct arguments *args, struct ng_session *session) {
+    struct tcp_session *tcp = &session->tcp;
+    if (!dns_frame_stream_has_pending(&tcp->dns_frames)) {
+        release_dns_pending_storage(tcp);
+        return 0;
+    }
+
+    struct dns_frame_parse_context context = {
+            .args = args,
+            .session = session,
+    };
+    size_t chunks = 0;
+    while (dns_frame_stream_has_pending(&tcp->dns_frames) &&
+           dns_frame_flush_chunk_allowed(chunks)) {
+        if (tcp->mss == 0)
+            return -1;
+        uint32_t window = get_send_window(tcp);
+        if (window == 0)
+            break;
+        size_t budget = dns_frame_send_budget(window, tcp->mss);
+        struct dns_frame_stream_result result;
+        if (dns_frame_stream_flush(&tcp->dns_frames, budget,
+                                   emit_dns_frame_chunk, &context, &result) < 0)
+            return -1;
+        if (result.emitted == 0)
+            break;
+        chunks++;
+    }
+    release_dns_pending_storage(tcp);
+    return 0;
+}
+
+static void flush_dns_ack(const struct arguments *args,
+                          struct ng_session *session, int epoll_fd) {
+    struct tcp_session *tcp = &session->tcp;
+    if (tcp->dns_terminal == DNS_FRAME_TERMINAL_WAIT_ACK) {
+        if (dns_frame_terminal_next(tcp->dns_terminal, 0, tcp->acked,
+                                    tcp->local_seq) == DNS_FRAME_TERMINAL_NONE)
+            finish_dns_terminal(args, session);
+        return;
+    }
+
+    if (tcp->dns_terminal == DNS_FRAME_TERMINAL_FIN_DRAIN) {
+        if (dns_frame_stream_has_pending(&tcp->dns_frames) &&
+            flush_dns_frames(args, session) < 0) {
+            log_android(ANDROID_LOG_WARN, "DNS TCP EOF output failed");
+            terminate_dns_session(args, session);
+        } else if (!dns_frame_stream_has_pending(&tcp->dns_frames))
+            finish_dns_fin(args, session);
+        return;
+    }
+
+    if (tcp->dns_terminal == DNS_FRAME_TERMINAL_HUP_PENDING) {
+        if (dns_frame_stream_has_pending(&tcp->dns_frames) &&
+            flush_dns_frames(args, session) < 0) {
+            log_android(ANDROID_LOG_WARN, "DNS TCP HUP output failed");
+            terminate_dns_session(args, session);
+        } else if (resume_dns_hup(session, epoll_fd) < 0) {
+            log_android(ANDROID_LOG_WARN, "DNS TCP HUP resume failed");
+            terminate_dns_session(args, session);
+        } else if (tcp->dns_terminal == DNS_FRAME_TERMINAL_DRAIN) {
+            /* Re-arm failure changed HUP_PENDING into reset-drain. Apply the
+             * ACK transition now; no later ACK is guaranteed. */
+            flush_dns_ack(args, session, epoll_fd);
+        }
+        return;
+    }
+
+    if (tcp->dns_terminal == DNS_FRAME_TERMINAL_DRAIN) {
+        if (flush_dns_frames(args, session) < 0) {
+            log_android(ANDROID_LOG_WARN, "DNS TCP terminal output failed");
+            terminate_dns_session(args, session);
+        } else {
+            tcp->dns_terminal = dns_frame_terminal_next(
+                    tcp->dns_terminal,
+                    dns_frame_stream_has_pending(&tcp->dns_frames),
+                    tcp->acked, tcp->local_seq);
+            if (tcp->dns_terminal == DNS_FRAME_TERMINAL_NONE)
+                finish_dns_terminal(args, session);
+        }
+    } else if (dns_frame_stream_has_pending(&tcp->dns_frames) &&
+               flush_dns_frames(args, session) < 0) {
+        log_android(ANDROID_LOG_WARN, "DNS TCP pending output failed");
+        terminate_dns_session(args, session);
+    }
+}
+
 void clear_tcp_data(struct tcp_session *cur) {
     struct segment *s = cur->forward;
     while (s != NULL) {
@@ -40,11 +359,24 @@ void clear_tcp_data(struct tcp_session *cur) {
         cur->tls_data = NULL;
         cur->tls_len = 0;
     }
+    if (cur->dns_frames.buffer != NULL) {
+        ng_free(cur->dns_frames.buffer, __FILE__, __LINE__);
+        cur->dns_frames.buffer = NULL;
+        cur->dns_frames.capacity = 0;
+    }
+    if (cur->dns_frames.pending != NULL)
+        ng_free(cur->dns_frames.pending, __FILE__, __LINE__);
+    dns_frame_stream_init(&cur->dns_frames, NULL, 0);
+    cur->dns_terminal = DNS_FRAME_TERMINAL_NONE;
 }
 
 int get_tcp_timeout(const struct tcp_session *t, int sessions, int maxsessions) {
     int timeout;
-    if (t->state == TCP_LISTEN || t->state == TCP_SYN_RECV)
+    int terminal_timeout = dns_frame_terminal_timeout(t->dns_terminal,
+                                                       TCP_CLOSE_TIMEOUT);
+    if (terminal_timeout != 0)
+        timeout = terminal_timeout;
+    else if (t->state == TCP_LISTEN || t->state == TCP_SYN_RECV)
         timeout = TCP_INIT_TIMEOUT;
     else if (t->state == TCP_ESTABLISHED)
         timeout = TCP_IDLE_TIMEOUT;
@@ -85,12 +417,18 @@ int check_tcp_session(const struct arguments *args, struct ng_session *s,
                     timeout);
         if (s->tcp.state == TCP_LISTEN)
             s->tcp.state = TCP_CLOSING;
+        else if (ntohs(s->tcp.dest) == 53)
+            terminate_dns_session(args, s);
         else
             write_rst(args, &s->tcp);
     }
 
     // Check closing sessions
     if (s->tcp.state == TCP_CLOSING) {
+        /* DNS buffers are session state, not part of the generic TCP linger
+         * period. Release them as soon as any terminal path reaches closing. */
+        discard_dns_frame_state(&s->tcp);
+
         // eof closes socket
         if (s->socket >= 0) {
             if (close(s->socket))
@@ -124,6 +462,12 @@ int monitor_tcp_session(const struct arguments *args, struct ng_session *s, int 
     int recheck = 0;
     unsigned int events = EPOLLERR;
 
+    /* Terminal DNS sessions close their upstream descriptor and flush from
+     * handle_tcp() when an ACK reopens the TUN-side window. Never re-arm
+     * epoll or create a maintenance poll for this state. */
+    if (s->tcp.dns_terminal != DNS_FRAME_TERMINAL_NONE)
+        return 0;
+
     if (s->tcp.state == TCP_LISTEN) {
         // Check for connected = writable
         if (s->tcp.socks5 == SOCKS5_NONE)
@@ -131,15 +475,19 @@ int monitor_tcp_session(const struct arguments *args, struct ng_session *s, int 
         else
             events = events | EPOLLIN;
     } else if (s->tcp.state == TCP_ESTABLISHED || s->tcp.state == TCP_CLOSE_WAIT) {
-
         // Check for incoming data
-        if (get_send_window(&s->tcp) > 0)
+        uint32_t send_window = get_send_window(&s->tcp);
+        if (s->tcp.state != TCP_CLOSING &&
+            dns_frame_should_read(s->tcp.dns_terminal,
+                                  dns_frame_stream_has_pending(&s->tcp.dns_frames),
+                                  send_window))
             events = events | EPOLLIN;
-        else {
+        else if (dns_frame_requires_recheck(send_window)) {
             recheck = 1;
 
             long long ms = get_ms();
-            if (ms - s->tcp.last_keep_alive > EPOLL_MIN_CHECK) {
+            if (dns_frame_recheck_due(ms, s->tcp.last_keep_alive,
+                                      EPOLL_MIN_CHECK)) {
                 s->tcp.last_keep_alive = ms;
                 log_android(ANDROID_LOG_WARN, "Sending keep alive to update send window");
                 s->tcp.remote_seq--;
@@ -162,7 +510,11 @@ int monitor_tcp_session(const struct arguments *args, struct ng_session *s, int 
     if (events != s->ev.events) {
         s->ev.events = events;
         if (epoll_ctl(epoll_fd, EPOLL_CTL_MOD, s->socket, &s->ev)) {
-            s->tcp.state = TCP_CLOSING;
+            if (ntohs(s->tcp.dest) == 53)
+                terminate_dns_session(args, s);
+            else
+                s->tcp.state = TCP_CLOSING;
+            recheck = 1;
             log_android(ANDROID_LOG_ERROR, "epoll mod tcp error %d: %s", errno, strerror(errno));
         } else
             log_android(ANDROID_LOG_DEBUG, "epoll mod tcp socket %d in %d out %d",
@@ -173,17 +525,11 @@ int monitor_tcp_session(const struct arguments *args, struct ng_session *s, int 
 }
 
 uint32_t get_send_window(const struct tcp_session *cur) {
-    uint32_t behind;
-    if (cur->acked <= cur->local_seq)
-        behind = (cur->local_seq - cur->acked);
-    else
-        behind = (0x10000 + cur->local_seq - cur->acked);
-    behind += (cur->unconfirmed + 1) * 40; // Maximum header size
+    uint32_t total = dns_frame_send_window(cur->acked, cur->local_seq,
+                                           cur->unconfirmed, cur->send_window);
 
-    uint32_t total = (behind < cur->send_window ? cur->send_window - behind : 0);
-
-    log_android(ANDROID_LOG_DEBUG, "Send window behind %u window %u total %u",
-                behind, cur->send_window, total);
+    log_android(ANDROID_LOG_DEBUG, "Send window window %u total %u",
+                cur->send_window, total);
 
     return total;
 }
@@ -265,21 +611,73 @@ void check_tcp_socket(const struct arguments *args,
             s->tcp.local_seq - s->tcp.local_start,
             s->tcp.remote_seq - s->tcp.remote_start);
 
-    // Check socket error
-    if (ev->events & EPOLLERR) {
+    // Check socket error or hangup. EPOLLHUP is delivered even when EPOLLIN
+    // is masked, so it must detach the upstream descriptor or epoll spins.
+    const int socket_error = (ev->events & EPOLLERR) != 0;
+    const int socket_hup = (ev->events & EPOLLHUP) != 0;
+    const int pending_dns = dns_frame_stream_has_pending(&s->tcp.dns_frames);
+    const int hup_pending = dns_frame_hup_pending_state(
+            socket_error, socket_hup, pending_dns);
+    if (dns_frame_socket_terminal_event(
+                socket_error, socket_hup, (ev->events & EPOLLIN) != 0,
+                pending_dns)) {
         s->tcp.time = time(NULL);
 
         int serr = 0;
         socklen_t optlen = sizeof(int);
-        int err = getsockopt(s->socket, SOL_SOCKET, SO_ERROR, &serr, &optlen);
-        if (err < 0)
-            log_android(ANDROID_LOG_ERROR, "%s getsockopt error %d: %s",
-                        session, errno, strerror(errno));
-        else if (serr)
-            log_android(ANDROID_LOG_ERROR, "%s SO_ERROR %d: %s",
-                        session, serr, strerror(serr));
+        int err = 0;
+        if (socket_error) {
+            err = getsockopt(s->socket, SOL_SOCKET, SO_ERROR, &serr, &optlen);
+            if (err < 0)
+                log_android(ANDROID_LOG_ERROR, "%s getsockopt error %d: %s",
+                            session, errno, strerror(errno));
+            else if (serr)
+                log_android(ANDROID_LOG_ERROR, "%s SO_ERROR %d: %s",
+                            session, serr, strerror(serr));
+        }
 
-        write_rst(args, &s->tcp);
+        /* A socket error stops upstream reads. Keep complete rewritten DNS
+         * bytes queued while the downstream window drains; a zero window is
+         * reopened by a later ACK handled on the TUN side. */
+        int terminal_state = DNS_FRAME_TERMINAL_DRAIN;
+        if (!socket_error) {
+            terminal_state = dns_frame_eof_terminal_state(
+                    dns_frame_stream_has_pending(&s->tcp.dns_frames),
+                    s->tcp.dns_frames.buffered,
+                    s->tcp.forward != NULL);
+        }
+        int terminal_started = 0;
+        if ((s->tcp.state == TCP_ESTABLISHED || s->tcp.state == TCP_CLOSE_WAIT) &&
+            ntohs(s->tcp.dest) == 53 && hup_pending == DNS_FRAME_TERMINAL_HUP_PENDING &&
+            begin_dns_hup_pending(s, epoll_fd) == 0) {
+            flush_dns_ack(args, s, epoll_fd);
+            terminal_started = 1;
+        }
+        if (!terminal_started &&
+            (s->tcp.state == TCP_ESTABLISHED || s->tcp.state == TCP_CLOSE_WAIT) &&
+            terminal_state != DNS_FRAME_TERMINAL_NONE &&
+            ntohs(s->tcp.dest) == 53 &&
+            begin_dns_terminal(s, epoll_fd, terminal_state) == 0) {
+            flush_dns_ack(args, s, epoll_fd);
+            terminal_started = 1;
+        }
+        if (!terminal_started) {
+            /* Detach HUP descriptors even when no complete DNS response is
+             * available, otherwise epoll reports the same HUP forever. */
+            if (socket_hup && s->socket >= 0) {
+                if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, s->socket, NULL))
+                    log_android(ANDROID_LOG_WARN,
+                                "%s HUP epoll delete error %d: %s",
+                                session, errno, strerror(errno));
+                if (close(s->socket))
+                    log_android(ANDROID_LOG_WARN, "%s HUP close error %d: %s",
+                                session, errno, strerror(errno));
+                s->socket = -1;
+            }
+            /* Incomplete frames and any failed detach cannot be forwarded
+             * safely. Send an explicit reset and release all DNS state now. */
+            terminate_dns_session(args, s);
+        }
 
         // Connection refused
         if (0)
@@ -558,7 +956,11 @@ void check_tcp_socket(const struct arguments *args,
                 // Send window can be changed in the mean time
 
                 uint32_t send_window = get_send_window(&s->tcp);
-                if ((ev->events & EPOLLIN) && send_window > 0) {
+                if ((ev->events & EPOLLIN) &&
+                    dns_frame_should_read(
+                            s->tcp.dns_terminal,
+                            dns_frame_stream_has_pending(&s->tcp.dns_frames),
+                            send_window)) {
                     s->tcp.time = time(NULL);
 
                     uint32_t buffer_size = (send_window > s->tcp.mss
@@ -570,12 +972,40 @@ void check_tcp_socket(const struct arguments *args,
                         log_android(ANDROID_LOG_ERROR, "%s recv error %d: %s",
                                     session, errno, strerror(errno));
 
-                        if (errno != EINTR && errno != EAGAIN)
-                            write_rst(args, &s->tcp);
+                        if (errno != EINTR && errno != EAGAIN) {
+                            if (ntohs(s->tcp.dest) == 53)
+                                terminate_dns_session(args, s);
+                            else
+                                write_rst(args, &s->tcp);
+                        }
                     } else if (bytes == 0) {
                         log_android(ANDROID_LOG_WARN, "%s recv eof", session);
 
-                        if (s->tcp.forward == NULL) {
+                        int dns_stream = ntohs(s->tcp.dest) == 53;
+                        int preserve_dns_terminal = 0;
+                        int eof_terminal = dns_frame_eof_terminal_state(
+                                dns_stream && dns_frame_stream_has_pending(&s->tcp.dns_frames),
+                                s->tcp.dns_frames.buffered,
+                                s->tcp.forward != NULL);
+                        if (dns_stream && eof_terminal != DNS_FRAME_TERMINAL_NONE) {
+                            if (begin_dns_terminal(s, epoll_fd, eof_terminal) == 0) {
+                                /* Keep complete rewritten responses alive
+                                 * after upstream EOF; ACKs flush the queue and
+                                 * then finish_dns_fin or finish_dns_terminal. */
+                                preserve_dns_terminal = 1;
+                                flush_dns_ack(args, s, epoll_fd);
+                            } else {
+                                log_android(ANDROID_LOG_WARN,
+                                            "%s DNS TCP EOF detach failed; resetting",
+                                            session);
+                                terminate_dns_session(args, s);
+                            }
+                        } else if (dns_stream && s->tcp.dns_frames.buffered != 0) {
+                            log_android(ANDROID_LOG_WARN,
+                                        "%s DNS TCP EOF with incomplete frame; resetting",
+                                        session);
+                            write_rst(args, &s->tcp);
+                        } else if (s->tcp.forward == NULL) {
                             if (write_fin_ack(args, &s->tcp) >= 0) {
                                 log_android(ANDROID_LOG_WARN, "%s FIN sent", session);
                                 s->tcp.local_seq++; // local FIN
@@ -593,38 +1023,54 @@ void check_tcp_socket(const struct arguments *args,
                             write_rst(args, &s->tcp);
                         }
 
-                        if (close(s->socket))
-                            log_android(ANDROID_LOG_ERROR, "%s close error %d: %s",
-                                        session, errno, strerror(errno));
-                        s->socket = -1;
+                        if (s->socket >= 0) {
+                            if (close(s->socket))
+                                log_android(ANDROID_LOG_ERROR, "%s close error %d: %s",
+                                            session, errno, strerror(errno));
+                            s->socket = -1;
+                        }
+                        if (!preserve_dns_terminal)
+                            discard_dns_frame_state(&s->tcp);
 
                     } else {
                         // Socket read data
                         log_android(ANDROID_LOG_DEBUG, "%s recv bytes %d", session, bytes);
                         s->tcp.received += bytes;
 
-                        // Process DNS response
-                        if (ntohs(s->tcp.dest) == 53 && bytes > 2) {
-                            size_t frame_len = ((size_t) buffer[0] << 8) | buffer[1];
-                            // recv() may split or coalesce DNS frames. The
-                            // header is blanked in place for every frame so
-                            // policy still applies, but only an isolated
-                            // complete frame can be shortened, because
-                            // trimming a coalesced or split read would
-                            // discard stream bytes.
-                            struct dns_frame_decision decision =
-                                    dns_frame_decide((size_t) bytes, frame_len);
-                            if (decision.should_parse) {
-                                size_t dlen = decision.dlen;
-                                parse_dns_response(args, s, buffer + 2, &dlen);
-                                dns_frame_apply_rewrite(buffer, &decision, dlen, &bytes);
+                        // Process DNS response. TCP reads are arbitrary stream
+                        // chunks, so retain incomplete frames and inspect every
+                        // complete frame exactly once. Completed output stays
+                        // queued until the downstream send window permits it.
+                        int dns_stream = ntohs(s->tcp.dest) == 53;
+                        if (dns_stream) {
+                            struct dns_frame_parse_context parse_context = {
+                                    .args = args,
+                                    .session = s,
+                            };
+                            size_t stream_bytes = (size_t) bytes;
+                            struct dns_frame_stream_result result;
+                            int feed_error = dns_frame_stream_feed(
+                                    &s->tcp.dns_frames, buffer, &stream_bytes,
+                                    parse_dns_frame, reserve_dns_frame,
+                                    reserve_dns_pending, &parse_context, &result);
+                            if (feed_error < 0) {
+                                log_android(ANDROID_LOG_WARN,
+                                            "%s DNS TCP fail-open queue failed; closing",
+                                            session);
+                                terminate_dns_session(args, s);
+                            } else if (flush_dns_frames(args, s) < 0) {
+                                log_android(ANDROID_LOG_WARN,
+                                            "%s DNS TCP pending output failed",
+                                            session);
+                                terminate_dns_session(args, s);
                             }
-                        }
-
-                        // Forward to tun
-                        if (write_data(args, &s->tcp, buffer, (size_t) bytes) >= 0) {
-                            s->tcp.local_seq += bytes;
-                            s->tcp.unconfirmed++;
+                            release_dns_frame_storage(&s->tcp);
+                        } else {
+                            // Forward non-DNS data to tun.
+                            if (write_data(args, &s->tcp, buffer, (size_t) bytes) >= 0) {
+                                s->tcp.local_seq += bytes;
+                                s->tcp.unconfirmed++;
+                            }
                         }
                     }
                     ng_free(buffer, __FILE__, __LINE__);
@@ -797,6 +1243,8 @@ jboolean handle_tcp(const struct arguments *args,
             s->tcp.checkedHostname = 0;
             s->tcp.tls_data = NULL;
             s->tcp.tls_len = 0;
+            dns_frame_stream_init(&s->tcp.dns_frames, NULL, 0);
+            s->tcp.dns_terminal = DNS_FRAME_TERMINAL_NONE;
             s->next = NULL;
 
             if (datalen) {
@@ -894,16 +1342,27 @@ jboolean handle_tcp(const struct arguments *args,
             // Queue data to forward
             if (datalen) {
                 if (cur->socket < 0) {
-                    log_android(ANDROID_LOG_ERROR, "%s data while local closed", session);
-                    write_rst(args, &cur->tcp);
-                    return 0;
-                }
-                if (cur->tcp.state == TCP_CLOSE_WAIT) {
+                    if (ntohs(cur->tcp.dest) != 53 ||
+                        cur->tcp.dns_terminal == DNS_FRAME_TERMINAL_NONE) {
+                        log_android(ANDROID_LOG_ERROR,
+                                    "%s data while local closed", session);
+                        write_rst(args, &cur->tcp);
+                        return 0;
+                    }
+                    /* A detached DNS upstream cannot accept another query,
+                     * but a valid response may still be queued downstream.
+                     * Keep that response alive and process this packet's ACK;
+                     * do not turn an ACK+payload into an unconditional RST. */
+                    log_android(ANDROID_LOG_WARN,
+                                "%s DNS data while upstream terminal; not forwarding",
+                                session);
+                } else if (cur->tcp.state == TCP_CLOSE_WAIT) {
                     log_android(ANDROID_LOG_ERROR, "%s data while remote closed", session);
                     write_rst(args, &cur->tcp);
                     return 0;
+                } else {
+                    queue_tcp(args, tcphdr, session, &cur->tcp, data, datalen);
                 }
-                queue_tcp(args, tcphdr, session, &cur->tcp, data, datalen);
             }
 
             if (tcphdr->rst /* +ACK */) {
@@ -911,6 +1370,12 @@ jboolean handle_tcp(const struct arguments *args,
                 // http://tools.ietf.org/html/rfc1122#page-87
                 log_android(ANDROID_LOG_WARN, "%s received reset", session);
                 cur->tcp.state = TCP_CLOSING;
+                if (cur->tcp.dns_frames.buffered != 0)
+                    log_android(ANDROID_LOG_WARN,
+                                "%s DNS TCP reset with incomplete frame, dropping",
+                                session);
+                discard_dns_frame_state(&cur->tcp);
+                cur->tcp.dns_terminal = DNS_FRAME_TERMINAL_NONE;
                 return 0;
             } else {
                 if (!tcphdr->ack || ntohl(tcphdr->ack_seq) == cur->tcp.local_seq) {
@@ -967,7 +1432,7 @@ jboolean handle_tcp(const struct arguments *args,
                     uint32_t ack = ntohl(tcphdr->ack_seq);
                     if ((uint32_t) (ack + 1) == cur->tcp.local_seq) {
                         // Keep alive
-                        if (cur->tcp.state == TCP_ESTABLISHED) {
+                        if (cur->tcp.state == TCP_ESTABLISHED && cur->socket >= 0) {
                             int on = 1;
                             if (setsockopt(cur->socket, SOL_SOCKET, SO_KEEPALIVE, &on, sizeof(on)))
                                 log_android(ANDROID_LOG_ERROR,
@@ -992,6 +1457,11 @@ jboolean handle_tcp(const struct arguments *args,
                             cur->tcp.acked = ack;
                         }
 
+                        if (dns_frame_should_flush_ack(
+                                    tcphdr->ack,
+                                    cur->tcp.dns_terminal,
+                                    dns_frame_stream_has_pending(&cur->tcp.dns_frames)))
+                            flush_dns_ack(args, cur, epoll_fd);
                         return 1;
                     } else {
                         log_android(ANDROID_LOG_ERROR, "%s future ACK", session);
@@ -1000,6 +1470,12 @@ jboolean handle_tcp(const struct arguments *args,
                     }
                 }
             }
+
+            if (dns_frame_should_flush_ack(
+                        tcphdr->ack,
+                        cur->tcp.dns_terminal,
+                        dns_frame_stream_has_pending(&cur->tcp.dns_frames)))
+                flush_dns_ack(args, cur, epoll_fd);
 
             if (cur->tcp.state != oldstate ||
                 cur->tcp.local_seq != oldlocal ||
@@ -1171,6 +1647,8 @@ int open_tcp_socket(const struct arguments *args,
 
 int write_syn_ack(const struct arguments *args, struct tcp_session *cur) {
     if (write_tcp(args, cur, NULL, 0, 1, 1, 0, 0) < 0) {
+        if (ntohs(cur->dest) == 53)
+            discard_dns_frame_state(cur);
         cur->state = TCP_CLOSING;
         return -1;
     }
@@ -1179,6 +1657,8 @@ int write_syn_ack(const struct arguments *args, struct tcp_session *cur) {
 
 int write_ack(const struct arguments *args, struct tcp_session *cur) {
     if (write_tcp(args, cur, NULL, 0, 0, 1, 0, 0) < 0) {
+        if (ntohs(cur->dest) == 53)
+            discard_dns_frame_state(cur);
         cur->state = TCP_CLOSING;
         return -1;
     }
@@ -1188,6 +1668,8 @@ int write_ack(const struct arguments *args, struct tcp_session *cur) {
 int write_data(const struct arguments *args, struct tcp_session *cur,
                const uint8_t *buffer, size_t length) {
     if (write_tcp(args, cur, buffer, length, 0, 1, 0, 0) < 0) {
+        if (ntohs(cur->dest) == 53)
+            discard_dns_frame_state(cur);
         cur->state = TCP_CLOSING;
         return -1;
     }
@@ -1196,6 +1678,8 @@ int write_data(const struct arguments *args, struct tcp_session *cur,
 
 int write_fin_ack(const struct arguments *args, struct tcp_session *cur) {
     if (write_tcp(args, cur, NULL, 0, 0, 1, 1, 0) < 0) {
+        if (ntohs(cur->dest) == 53)
+            discard_dns_frame_state(cur);
         cur->state = TCP_CLOSING;
         return -1;
     }
@@ -1204,6 +1688,7 @@ int write_fin_ack(const struct arguments *args, struct tcp_session *cur) {
 
 void write_rst(const struct arguments *args, struct tcp_session *cur) {
     // https://www.snellman.net/blog/archive/2016-02-01-tcp-rst/
+    const int dns_stream = ntohs(cur->dest) == 53;
     int ack = 0;
     if (cur->state == TCP_LISTEN) {
         ack = 1;
@@ -1212,6 +1697,10 @@ void write_rst(const struct arguments *args, struct tcp_session *cur) {
     write_tcp(args, cur, NULL, 0, 0, ack, 0, 1);
     if (cur->state != TCP_CLOSE)
         cur->state = TCP_CLOSING;
+    if (dns_stream) {
+        discard_dns_frame_state(cur);
+        cur->dns_terminal = DNS_FRAME_TERMINAL_NONE;
+    }
 }
 
 ssize_t write_tcp(const struct arguments *args, const struct tcp_session *cur,

--- a/app/src/test/native/dns_frame_test.c
+++ b/app/src/test/native/dns_frame_test.c
@@ -1,13 +1,13 @@
 /*
- * Host unit tests for the DNS-over-TCP framing decision extracted into
+ * Host unit tests for the DNS-over-TCP framing stream extracted into
  * app/src/main/jni/netguard/dns_frame.{h,c}.
  *
  * This is a plain C test program with a tiny assert-based harness (no test
  * framework dependency), so it can build and run with the system compiler
  * on any host -- see .github/workflows/test.yml. It intentionally does not
- * link netguard.h, JNI, or parse_dns_response: dns_frame_decide() and
- * dns_frame_apply_rewrite() are pure, so a DNS-parse outcome is simulated
- * inline (a "post_parse_dlen" value) instead of calling the real parser.
+ * link netguard.h, JNI, or parse_dns_response: the stream state machine is
+ * pure, so a DNS-parse outcome is simulated inline instead of calling the
+ * real parser.
  *
  * Background: this framing logic shipped a real blocking bypass once
  * already, fixed in commit 9c49cc09 ("Fix DNS filtering regressions from
@@ -44,209 +44,905 @@ static size_t read_prefix(const uint8_t *buffer) {
     return ((size_t) buffer[0] << 8) | buffer[1];
 }
 
-/* A test double standing in for parse_dns_response(): optionally shrinks
- * dlen (simulating a policy hit that blanks/truncates the DNS message),
- * or leaves it unchanged. The extracted helpers never call this -- they
- * only ever see its *result*, which is exactly the point of extracting
- * them as pure functions. */
-static size_t stub_parse_unchanged(size_t dlen) {
-    return dlen;
-}
+struct stream_observer {
+    size_t calls;
+    uint8_t ids[16];
+    size_t lengths[16];
+    size_t emitted;
+    size_t output_len;
+    uint8_t output[DNS_FRAME_MAX_BUFFER + 64];
+    int mutate;
+    int shrink;
+    int reserve_fail;
+    int pending_reserve_fail;
+    int emit_fail;
+    int enforce_send_window;
+    uint16_t mss;
+    uint16_t unconfirmed;
+    uint32_t acked;
+    uint32_t local_seq;
+    uint32_t send_window;
+    size_t writes;
+    size_t reserve_calls;
+    size_t pending_reserve_calls;
+    size_t pending_transient_peak;
+    int pending_reserve_fail_after;
+};
 
-static size_t stub_parse_shrink_to(size_t new_len) {
-    return new_len;
-}
-
-/* 1. Isolated complete frame: parser shortens it -> shorten + prefix rewritten. */
-static void test_isolated_frame_shortened(void) {
-    size_t frame_len = 50;
-    ssize_t bytes = (ssize_t) (frame_len + 2);
-    uint8_t buffer[2 + 50];
-    set_prefix(buffer, frame_len);
-    memset(buffer + 2, 0xAA, frame_len);
-
-    struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-    CHECK(d.should_parse, "isolated frame: should_parse");
-    CHECK(d.isolated, "isolated frame: isolated");
-    CHECK(d.dlen == frame_len, "isolated frame: dlen == frame_len");
-
-    size_t post_parse_dlen = stub_parse_shrink_to(20);
-    dns_frame_apply_rewrite(buffer, &d, post_parse_dlen, &bytes);
-
-    CHECK(bytes == 22, "isolated frame shortened: bytes rewritten to 22");
-    CHECK(read_prefix(buffer) == 20, "isolated frame shortened: prefix rewritten to 20");
-}
-
-/* 2. Isolated complete frame: parser does not shorten -> no rewrite. */
-static void test_isolated_frame_unchanged(void) {
-    size_t frame_len = 50;
-    ssize_t bytes = (ssize_t) (frame_len + 2);
-    uint8_t buffer[2 + 50];
-    set_prefix(buffer, frame_len);
-    memset(buffer + 2, 0xBB, frame_len);
-
-    struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-    CHECK(d.should_parse, "isolated frame unchanged: should_parse");
-    CHECK(d.isolated, "isolated frame unchanged: isolated");
-    CHECK(d.dlen == frame_len, "isolated frame unchanged: dlen == frame_len");
-
-    size_t post_parse_dlen = stub_parse_unchanged(d.dlen);
-    dns_frame_apply_rewrite(buffer, &d, post_parse_dlen, &bytes);
-
-    CHECK(bytes == (ssize_t) (frame_len + 2), "isolated frame unchanged: bytes untouched");
-    CHECK(read_prefix(buffer) == frame_len, "isolated frame unchanged: prefix untouched");
-}
-
-/* 3. Coalesced read: frame + extra bytes belonging to (the start of) the
- * next frame. Only the first frame's payload is parsed; the read is never
- * shortened and the prefix is never rewritten, because that would discard
- * the extra bytes still owed to the stream. */
-static void test_coalesced_read(void) {
-    size_t frame_len = 50;
-    size_t extra = 30;
-    ssize_t bytes = (ssize_t) (frame_len + 2 + extra);
-    uint8_t buffer[2 + 50 + 30];
-    set_prefix(buffer, frame_len);
-    memset(buffer + 2, 0xCC, frame_len);
-    memset(buffer + 2 + frame_len, 0xDD, extra);
-
-    uint8_t snapshot[sizeof(buffer)];
-    memcpy(snapshot, buffer, sizeof(buffer));
-
-    struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-    CHECK(d.should_parse, "coalesced read: should_parse (regression 9c49cc09)");
-    CHECK(!d.isolated, "coalesced read: not isolated");
-    CHECK(d.dlen == frame_len, "coalesced read: dlen == first frame's payload length only");
-
-    /* Even if the (simulated) parser wants to shrink the first frame, a
-     * coalesced read must never be shortened -- that would eat into the
-     * next frame's bytes. */
-    size_t post_parse_dlen = stub_parse_shrink_to(10);
-    dns_frame_apply_rewrite(buffer, &d, post_parse_dlen, &bytes);
-
-    CHECK(bytes == (ssize_t) (frame_len + 2 + extra), "coalesced read: bytes forwarded unchanged");
-    CHECK(memcmp(buffer, snapshot, sizeof(buffer)) == 0,
-          "coalesced read: buffer contents forwarded unchanged (prefix + extra bytes)");
-}
-
-/* 4. Split/partial frame: recv() got fewer bytes than the prefix declares.
- * Only the available bytes are parsed; never shortened/rewritten. */
-static void test_split_frame(void) {
-    size_t frame_len = 100;
-    size_t avail = 50;
-    ssize_t bytes = (ssize_t) (2 + avail);
-    uint8_t buffer[2 + 50];
-    set_prefix(buffer, frame_len);
-    memset(buffer + 2, 0xEE, avail);
-
-    uint8_t snapshot[sizeof(buffer)];
-    memcpy(snapshot, buffer, sizeof(buffer));
-
-    struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-    CHECK(d.should_parse, "split frame: should_parse (regression 9c49cc09)");
-    CHECK(!d.isolated, "split frame: not isolated");
-    CHECK(d.dlen == avail, "split frame: dlen capped to bytes actually available");
-
-    size_t post_parse_dlen = stub_parse_unchanged(d.dlen);
-    dns_frame_apply_rewrite(buffer, &d, post_parse_dlen, &bytes);
-
-    CHECK(bytes == (ssize_t) (2 + avail), "split frame: bytes untouched");
-    CHECK(memcmp(buffer, snapshot, sizeof(buffer)) == 0, "split frame: buffer untouched");
-}
-
-/* 5. frame_len == 0: skipped entirely, no parse, no rewrite. */
-static void test_zero_frame_len_skipped(void) {
-    size_t frame_len = 0;
-    ssize_t bytes = 10;
-
-    struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-    CHECK(!d.should_parse, "frame_len == 0: skipped (should_parse == 0)");
-    CHECK(!d.isolated, "frame_len == 0: not isolated");
-    CHECK(d.dlen == 0, "frame_len == 0: dlen == 0");
-}
-
-/* 6. bytes == 3 minimal edge: exactly one payload byte available. */
-static void test_bytes_equal_three_minimal(void) {
-    /* Isolated: a 1-byte DNS message, nothing else in the read. */
-    {
-        size_t frame_len = 1;
-        ssize_t bytes = 3;
-        struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-        CHECK(d.should_parse, "bytes==3 isolated: should_parse");
-        CHECK(d.isolated, "bytes==3 isolated: isolated");
-        CHECK(d.dlen == 1, "bytes==3 isolated: dlen == 1");
+static size_t observe_frame(void *opaque, uint8_t *payload, size_t length) {
+    struct stream_observer *observer = (struct stream_observer *) opaque;
+    CHECK(observer->calls < sizeof(observer->ids), "stream observer capacity");
+    if (observer->calls < sizeof(observer->ids)) {
+        observer->ids[observer->calls] = length == 0 ? 0 : payload[0];
+        observer->lengths[observer->calls] = length;
     }
-    /* Split: prefix declares more than the single available byte. */
-    {
-        size_t frame_len = 5;
-        ssize_t bytes = 3;
-        struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-        CHECK(d.should_parse, "bytes==3 split: should_parse");
-        CHECK(!d.isolated, "bytes==3 split: not isolated");
-        CHECK(d.dlen == 1, "bytes==3 split: dlen capped to the single available byte");
-    }
+    observer->calls++;
+
+    if (observer->mutate && length != 0)
+        payload[0] ^= 0xFF;
+    if (observer->shrink && length > 3)
+        return length - 3;
+    return length;
 }
 
-/* 7. frame_len at the maximum a 2-byte prefix can represent (0xFFFF):
- * boundary check for the >>8 / mask arithmetic in the write-back path, and
- * for a split read against that maximum. */
-static void test_frame_len_u16_boundary(void) {
-    size_t frame_len = 0xFFFF; /* 65535: max value a 2-byte prefix can hold */
+static int emit_frame(void *opaque, const uint8_t *frame, size_t length) {
+    struct stream_observer *observer = (struct stream_observer *) opaque;
+    if (observer->emit_fail)
+        return -1;
+    if (observer->output_len + length > sizeof(observer->output))
+        return -1;
+    memcpy(observer->output + observer->output_len, frame, length);
+    observer->output_len += length;
+    observer->emitted++;
+    return 0;
+}
 
-    /* Isolated at the boundary, with a shrink on rewrite. */
-    {
-        ssize_t bytes = (ssize_t) (frame_len + 2);
-        uint8_t *buffer = malloc((size_t) bytes);
-        CHECK(buffer != NULL, "u16 boundary isolated: allocation");
-        if (buffer != NULL) {
-            set_prefix(buffer, frame_len);
+static int emit_tcp_frame(void *opaque, const uint8_t *frame, size_t length) {
+    struct stream_observer *observer = (struct stream_observer *) opaque;
+    const size_t budget = dns_frame_send_budget(
+            dns_frame_send_window(observer->acked, observer->local_seq,
+                                  observer->unconfirmed, observer->send_window),
+            observer->mss);
+    if (!observer->enforce_send_window || length > budget || length > observer->mss)
+        return observer->enforce_send_window ? -1 : emit_frame(opaque, frame, length);
+    if (observer->output_len + length > sizeof(observer->output))
+        return -1;
+    memcpy(observer->output + observer->output_len, frame, length);
+    observer->output_len += length;
+    observer->writes++;
+    observer->local_seq += (uint32_t) length;
+    observer->unconfirmed++;
+    return 0;
+}
 
-            struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-            CHECK(d.should_parse, "u16 boundary isolated: should_parse");
-            CHECK(d.isolated, "u16 boundary isolated: isolated");
-            CHECK(d.dlen == frame_len, "u16 boundary isolated: dlen == frame_len");
+static int reserve_frame(void *opaque, struct dns_frame_stream *stream,
+                         size_t required) {
+    struct stream_observer *observer = (struct stream_observer *) opaque;
+    observer->reserve_calls++;
+    if (observer->reserve_fail)
+        return -1;
 
-            size_t post_parse_dlen = stub_parse_shrink_to(65435); /* still fits in 16 bits */
-            dns_frame_apply_rewrite(buffer, &d, post_parse_dlen, &bytes);
+    uint8_t *storage = malloc(required);
+    if (storage == NULL)
+        return -1;
+    if (stream->buffer != NULL) {
+        memcpy(storage, stream->buffer, stream->buffered);
+        free(stream->buffer);
+    }
+    stream->buffer = storage;
+    stream->capacity = required;
+    return 0;
+}
 
-            CHECK(bytes == (ssize_t) (65435 + 2), "u16 boundary isolated: bytes rewritten");
-            CHECK(read_prefix(buffer) == 65435, "u16 boundary isolated: prefix rewritten correctly");
-            free(buffer);
+static int reserve_pending(void *opaque, struct dns_frame_stream *stream,
+                           size_t required) {
+    struct stream_observer *observer = (struct stream_observer *) opaque;
+    observer->reserve_calls++;
+    observer->pending_reserve_calls++;
+    if (observer->pending_reserve_fail ||
+        (observer->pending_reserve_fail_after > 0 &&
+         observer->pending_reserve_calls > (size_t) observer->pending_reserve_fail_after))
+        return -1;
+
+    size_t capacity = stream->pending_capacity;
+    const size_t half = DNS_FRAME_MAX_PENDING / 2;
+    if (capacity < 2)
+        capacity = 2;
+    while (capacity < required) {
+        if (capacity >= half) {
+            capacity = DNS_FRAME_MAX_PENDING;
+            break;
+        }
+        if (capacity > half / 2)
+            capacity = half;
+        else
+            capacity *= 2;
+    }
+    if (capacity < required)
+        return -1;
+
+    if (stream->pending_capacity + capacity > observer->pending_transient_peak)
+        observer->pending_transient_peak = stream->pending_capacity + capacity;
+
+    uint8_t *storage = malloc(capacity);
+    if (storage == NULL)
+        return -1;
+    if (stream->pending != NULL) {
+        size_t pending = stream->pending_length - stream->pending_offset;
+        memcpy(storage, stream->pending + stream->pending_offset, pending);
+        free(stream->pending);
+        stream->pending_offset = 0;
+        stream->pending_length = pending;
+    }
+    stream->pending = storage;
+    stream->pending_capacity = capacity;
+    return 0;
+}
+
+static void release_pending(void *opaque, struct dns_frame_stream *stream) {
+    (void) opaque;
+    free(stream->pending);
+}
+
+static void flush_stream(struct dns_frame_stream *stream,
+                         struct stream_observer *observer, size_t budget) {
+    while (dns_frame_stream_has_pending(stream)) {
+        struct dns_frame_stream_result result;
+        CHECK(dns_frame_stream_flush(stream, budget, emit_frame, observer,
+                                     &result) == 0,
+              "stream pending flush");
+        CHECK(result.emitted != 0, "stream pending flush made progress");
+    }
+    dns_frame_stream_release_pending(stream, release_pending, NULL);
+}
+
+static size_t make_frame(uint8_t *buffer, size_t payload_len, uint8_t id) {
+    set_prefix(buffer, payload_len);
+    for (size_t i = 0; i < payload_len; i++)
+        buffer[2 + i] = (uint8_t) (id + i);
+    return payload_len + 2;
+}
+
+static void test_stream_consecutive_split_reads(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "split stream storage allocation");
+    if (storage == NULL)
+        return;
+
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    uint8_t frame1[14];
+    uint8_t frame2[12];
+    size_t frame1_len = make_frame(frame1, 12, 0xA1);
+    size_t frame2_len = make_frame(frame2, 10, 0xB2);
+    uint8_t chunk[32];
+    size_t bytes;
+    struct dns_frame_stream_result result;
+
+    /* Prefix + part of frame 1. */
+    memcpy(chunk, frame1, 6);
+    bytes = 6;
+    CHECK(dns_frame_stream_feed(&stream, chunk, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "split stream first feed");
+    CHECK(observer.calls == 0, "split stream does not parse incomplete frame");
+    CHECK(stream.buffered == 6, "split stream retains first partial frame");
+
+    /* Finish frame 1 and begin frame 2 in the same read. */
+    memcpy(chunk, frame1 + 6, frame1_len - 6);
+    memcpy(chunk + frame1_len - 6, frame2, 6);
+    bytes = frame1_len - 6 + 6;
+    uint8_t snapshot[sizeof(chunk)];
+    memcpy(snapshot, chunk, bytes);
+    CHECK(dns_frame_stream_feed(&stream, chunk, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "split stream second feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 1, "split stream parses first frame once");
+    CHECK(observer.ids[0] == 0xA1, "split stream records first frame");
+    CHECK(observer.emitted == 1 && observer.output_len == 11 &&
+          read_prefix(observer.output) == 9 &&
+          observer.output[2] == (uint8_t) (frame1[2] ^ 0xFF),
+          "split stream emits the rewritten first frame");
+    CHECK(stream.buffered == 6, "split stream retains second partial frame");
+    CHECK(memcmp(chunk, snapshot, bytes) == 0,
+          "split stream forwards completion bytes unchanged");
+
+    /* Finish frame 2. It must not cause frame 1 to be recorded again. */
+    memcpy(chunk, frame2 + 6, frame2_len - 6);
+    bytes = frame2_len - 6;
+    memcpy(snapshot, chunk, bytes);
+    CHECK(dns_frame_stream_feed(&stream, chunk, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "split stream third feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 2, "split stream parses second frame once");
+    CHECK(observer.ids[1] == 0xB2, "split stream records second frame");
+    CHECK(observer.emitted == 2 && observer.output_len == 20 &&
+          read_prefix(observer.output + 11) == 7 &&
+          observer.output[13] == (uint8_t) (frame2[2] ^ 0xFF),
+          "split stream emits the rewritten second frame");
+    CHECK(stream.buffered == 0 && stream.expected == 0,
+          "split stream is empty after consecutive frames");
+    CHECK(memcmp(chunk, snapshot, bytes) == 0,
+          "split stream forwards final bytes unchanged");
+    free(storage);
+}
+
+static void test_stream_coalesced_frames(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "coalesced stream storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t data[40];
+    size_t first = make_frame(data, 8, 0x11);
+    size_t second = make_frame(data + first, 12, 0x22);
+    size_t third = make_frame(data + first + second, 6, 0x33);
+    size_t bytes = first + second + third;
+    uint8_t snapshot[sizeof(data)];
+    memcpy(snapshot, data, bytes);
+
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    struct dns_frame_stream_result result;
+    CHECK(dns_frame_stream_feed(&stream, data, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "coalesced stream feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 3, "coalesced stream parses every frame");
+    CHECK(result.parsed == 3, "coalesced stream result count");
+    CHECK(observer.ids[0] == 0x11 && observer.ids[1] == 0x22 &&
+          observer.ids[2] == 0x33, "coalesced stream records all frame ids");
+    CHECK(observer.output_len == 23 && read_prefix(observer.output) == 5 &&
+          observer.output[2] == (uint8_t) (0x11 ^ 0xFF),
+          "coalesced stream emits first rewritten frame");
+    CHECK(read_prefix(observer.output + 7) == 9 &&
+          observer.output[9] == (uint8_t) (0x22 ^ 0xFF),
+          "coalesced stream emits second rewritten frame");
+    CHECK(read_prefix(observer.output + 18) == 3 &&
+          observer.output[20] == (uint8_t) (0x33 ^ 0xFF),
+          "coalesced stream emits third rewritten frame");
+    CHECK(bytes == first + second + third,
+          "coalesced stream preserves total bytes");
+    CHECK(memcmp(data, snapshot, bytes) == 0,
+          "coalesced stream forwards original bytes despite parser rewrite");
+    CHECK(stream.buffered == 0, "coalesced stream is empty");
+    free(storage);
+}
+
+static void test_stream_isolated_rewrite(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "isolated stream storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t frame[14];
+    size_t frame_len = make_frame(frame, 12, 0x66);
+    uint8_t original_payload[12];
+    memcpy(original_payload, frame + 2, sizeof(original_payload));
+    size_t bytes = frame_len;
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    struct dns_frame_stream_result result;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "isolated stream feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 1 && result.parsed == 1,
+          "isolated stream parses one frame");
+    CHECK(bytes == frame_len,
+          "isolated stream leaves input buffer untouched");
+    CHECK(observer.output_len == frame_len - 3,
+          "isolated stream emits safe shortened length");
+    CHECK(read_prefix(observer.output) == 9,
+          "isolated stream rewrites emitted prefix");
+    CHECK(observer.output[2] == (uint8_t) (original_payload[0] ^ 0xFF),
+          "isolated stream emits parser payload rewrite");
+    CHECK(stream.buffered == 0, "isolated stream is empty after rewrite");
+    free(storage);
+}
+
+static void test_stream_bounded_flush_and_gate(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "bounded flush storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t data[40];
+    size_t first = make_frame(data, 24, 0x90);
+    size_t second = make_frame(data + first, 6, 0xA0);
+    size_t bytes = first + second;
+    uint8_t snapshot[sizeof(data)];
+    memcpy(snapshot, data, bytes);
+
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+    CHECK(dns_frame_stream_feed(&stream, data, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "bounded flush feed");
+    CHECK(result.parsed == 2 && observer.calls == 2 &&
+          dns_frame_stream_has_pending(&stream),
+          "bounded flush queues coalesced frames");
+
+    CHECK(dns_frame_stream_flush(&stream, 5, emit_frame, &observer, &result) == 0 &&
+          result.emitted == 5 && observer.output_len == 5,
+          "bounded flush respects initial window");
+    CHECK(dns_frame_stream_has_pending(&stream) && observer.calls == 2,
+          "pending output gates another upstream read");
+    CHECK(memcmp(observer.output, snapshot, 5) == 0,
+          "bounded flush preserves first bytes");
+
+    CHECK(dns_frame_stream_flush(&stream, 7, emit_frame, &observer, &result) == 0 &&
+          result.emitted == 7 && observer.output_len == 12,
+          "bounded flush resumes partial drain");
+    CHECK(dns_frame_stream_has_pending(&stream) && observer.calls == 2,
+          "partial drain keeps upstream gated");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.output_len == bytes &&
+          memcmp(observer.output, snapshot, bytes) == 0,
+          "bounded flush drains without duplication");
+    CHECK(!dns_frame_stream_has_pending(&stream),
+          "bounded flush clears pending state");
+    free(storage);
+}
+
+static void test_stream_tcp_window_ack_and_mss(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "TCP window storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t frame[22];
+    size_t frame_len = make_frame(frame, 20, 0xA5);
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {
+            .mss = 7,
+            .send_window = 45,
+            .enforce_send_window = 1,
+    };
+    struct dns_frame_stream_result result;
+    size_t bytes = frame_len;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "TCP window feed");
+    CHECK(observer.local_seq == 0 && observer.unconfirmed == 0 &&
+          dns_frame_stream_has_pending(&stream),
+          "TCP window starts with output pending");
+    CHECK(!dns_frame_should_read(1, 1, observer.send_window),
+          "TCP terminal drain keeps upstream reads gated");
+
+    size_t flushes = 0;
+    while (dns_frame_stream_has_pending(&stream)) {
+        size_t window = dns_frame_send_window(observer.acked, observer.local_seq,
+                                              observer.unconfirmed,
+                                              observer.send_window);
+        if (window == 0) {
+            /* This models an ACK handled by handle_tcp(): the peer confirms
+             * all emitted bytes and advertises the same window again. */
+            observer.acked = observer.local_seq;
+            observer.unconfirmed = 0;
+            window = dns_frame_send_window(observer.acked, observer.local_seq,
+                                           observer.unconfirmed,
+                                           observer.send_window);
+        }
+        size_t budget = dns_frame_send_budget(window, observer.mss);
+        CHECK(budget != 0 && budget <= observer.mss,
+              "TCP window computes MSS-bounded flush budget");
+        CHECK(dns_frame_stream_flush(&stream, budget, emit_tcp_frame,
+                                     &observer, &result) == 0,
+              "TCP window flush");
+        CHECK(result.emitted != 0, "TCP window flush makes progress");
+        flushes++;
+        CHECK(flushes < 16, "TCP window flush remains bounded");
+    }
+    CHECK(observer.output_len == frame_len &&
+          memcmp(observer.output, frame, frame_len) == 0,
+          "TCP window drains complete response in order");
+    CHECK(observer.local_seq == frame_len && observer.writes > 1,
+          "TCP window advances local sequence per segment");
+    CHECK(!dns_frame_stream_has_pending(&stream),
+          "TCP window clears pending output after ACK reopening");
+    CHECK(dns_frame_should_read(0, 0, observer.send_window),
+          "TCP window reopens upstream reads after drain");
+    dns_frame_stream_release_pending(&stream, release_pending, NULL);
+    free(storage);
+}
+
+static void test_stream_emitter_error_retry(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "emitter error storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t frame[14];
+    size_t frame_len = make_frame(frame, 12, 0xB0);
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+    size_t bytes = frame_len;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "emitter error feed");
+    observer.emit_fail = 1;
+    CHECK(dns_frame_stream_flush(&stream, frame_len, emit_frame, &observer,
+                                 &result) < 0 && result.emitted == 0,
+          "emitter error leaves output pending");
+    observer.emit_fail = 0;
+    CHECK(dns_frame_stream_flush(&stream, frame_len, emit_frame, &observer,
+                                 &result) == 0 && result.emitted == frame_len,
+          "emitter retry succeeds");
+    CHECK(observer.output_len == frame_len &&
+          memcmp(observer.output, frame, frame_len) == 0,
+          "emitter retry does not duplicate or lose bytes");
+    free(storage);
+}
+
+static void test_stream_pending_compaction(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "pending compaction storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t data[32];
+    size_t first = make_frame(data, 6, 0xC0);
+    size_t second = make_frame(data + first, 6, 0xD0);
+    size_t initial = first + second;
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+    size_t bytes = initial;
+    CHECK(dns_frame_stream_feed(&stream, data, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "pending compaction initial feed");
+    CHECK(stream.pending_capacity == initial &&
+          dns_frame_stream_flush(&stream, 5, emit_frame, &observer, &result) == 0,
+          "pending compaction partial drain");
+    const size_t reserve_calls = observer.reserve_calls;
+    uint8_t third[5];
+    size_t third_len = make_frame(third, 3, 0xE0);
+    uint8_t snapshot[sizeof(data)];
+    memcpy(snapshot, data, initial);
+    CHECK(dns_frame_stream_feed(&stream, third, &third_len, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "pending compaction append after drain");
+    CHECK(stream.pending_capacity == initial && observer.reserve_calls == reserve_calls,
+          "pending compaction reuses capacity after offset advancement");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    memcpy(snapshot + initial, third, third_len);
+    CHECK(observer.output_len == initial + third_len &&
+          memcmp(observer.output, snapshot, observer.output_len) == 0,
+          "pending compaction preserves queued byte order");
+    CHECK(observer.calls == 3, "pending compaction parses appended frame once");
+    free(storage);
+}
+
+static void test_stream_geometric_pending_growth(void) {
+    enum { frame_count = 64 };
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    uint8_t *data = malloc(frame_count * 3);
+    CHECK(storage != NULL && data != NULL, "geometric pending storage allocation");
+    if (storage == NULL || data == NULL) {
+        free(storage);
+        free(data);
+        return;
+    }
+
+    size_t bytes = 0;
+    size_t zero_frames = 0;
+    size_t tiny_frames = 0;
+    for (size_t i = 0; i < frame_count; i++) {
+        if (i % 8 == 0) {
+            bytes += make_frame(data + bytes, 1, (uint8_t) (0x20 + i));
+            tiny_frames++;
+        } else {
+            data[bytes++] = 0;
+            data[bytes++] = 0;
+            zero_frames++;
         }
     }
 
-    /* Split: prefix claims the maximum 16-bit length, but recv() only got
-     * a small buffer's worth (realistic: the TCP read buffer is sized to
-     * the connection's MSS, far smaller than 65535). */
-    {
-        size_t avail = 200;
-        ssize_t bytes = (ssize_t) (2 + avail);
-        uint8_t buffer[2 + 200];
-        set_prefix(buffer, frame_len);
-        memset(buffer + 2, 0x11, avail);
+    uint8_t *snapshot = malloc(bytes);
+    CHECK(snapshot != NULL, "geometric pending snapshot allocation");
+    if (snapshot != NULL)
+        memcpy(snapshot, data, bytes);
 
-        uint8_t snapshot[sizeof(buffer)];
-        memcpy(snapshot, buffer, sizeof(buffer));
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+    size_t input = bytes;
+    CHECK(dns_frame_stream_feed(&stream, data, &input, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "geometric pending feed");
+    CHECK(result.parsed == tiny_frames && result.skipped == zero_frames &&
+          observer.calls == tiny_frames,
+          "geometric pending parses zero and tiny frames in order");
+    CHECK(stream.pending_capacity <= DNS_FRAME_MAX_PENDING &&
+          stream.pending_capacity < bytes * 2,
+          "geometric pending capacity stays bounded near queued bytes");
+    CHECK(observer.reserve_calls <= 8,
+          "geometric pending avoids per-frame reserve calls");
+    CHECK(observer.pending_transient_peak <= DNS_FRAME_MAX_TRANSIENT_STORAGE,
+          "geometric pending replacement stays within transient bound");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.output_len == bytes && snapshot != NULL &&
+          memcmp(observer.output, snapshot, bytes) == 0,
+          "geometric pending preserves coalesced byte order");
 
-        struct dns_frame_decision d = dns_frame_decide((size_t) bytes, frame_len);
-        CHECK(d.should_parse, "u16 boundary split: should_parse");
-        CHECK(!d.isolated, "u16 boundary split: not isolated");
-        CHECK(d.dlen == avail, "u16 boundary split: dlen capped to available bytes");
+    free(snapshot);
+    free(data);
+    free(storage);
+}
 
-        dns_frame_apply_rewrite(buffer, &d, stub_parse_unchanged(d.dlen), &bytes);
-        CHECK(bytes == (ssize_t) (2 + avail), "u16 boundary split: bytes untouched");
-        CHECK(memcmp(buffer, snapshot, sizeof(buffer)) == 0, "u16 boundary split: buffer untouched");
+static void test_stream_lifecycle_decisions(void) {
+    CHECK(dns_frame_should_read(0, 0, 1),
+          "lifecycle allows read with window and no pending output");
+    CHECK(!dns_frame_should_read(1, 0, 1),
+          "lifecycle gates read during terminal drain");
+    CHECK(!dns_frame_should_read(0, 1, 1),
+          "lifecycle gates read while output is pending");
+    CHECK(!dns_frame_should_read(0, 0, 0),
+          "lifecycle gates read with a closed window");
+    CHECK(dns_frame_should_flush_ack(1, 0, 1) &&
+          dns_frame_should_flush_ack(1, DNS_FRAME_TERMINAL_DRAIN, 0) &&
+          !dns_frame_should_flush_ack(0, 0, 1) &&
+          !dns_frame_should_flush_ack(1, 0, 0),
+          "lifecycle flushes pending output for ACK packets with or without payload");
+    CHECK(dns_frame_socket_terminal_event(1, 0, 1, 0) &&
+          dns_frame_socket_terminal_event(0, 1, 0, 0) &&
+          !dns_frame_socket_terminal_event(0, 1, 1, 0),
+          "lifecycle detects errors and masked HUP without readable data");
+    CHECK(dns_frame_hup_pending_state(0, 1, 1) ==
+                  DNS_FRAME_TERMINAL_HUP_PENDING &&
+          dns_frame_hup_pending_state(1, 1, 1) == DNS_FRAME_TERMINAL_NONE &&
+          dns_frame_hup_pending_state(0, 1, 0) == DNS_FRAME_TERMINAL_NONE,
+          "lifecycle retains HUP fd for pending data before rearming");
+    CHECK(!dns_frame_should_resume_hup(DNS_FRAME_TERMINAL_HUP_PENDING, 1, 1) &&
+          !dns_frame_should_resume_hup(DNS_FRAME_TERMINAL_HUP_PENDING, 0, 0) &&
+          dns_frame_should_resume_hup(DNS_FRAME_TERMINAL_HUP_PENDING, 0, 1) &&
+          !dns_frame_should_resume_hup(DNS_FRAME_TERMINAL_NONE, 0, 1),
+          "lifecycle rearms HUP fd only after pending drain and window reopen");
+    CHECK(dns_frame_hup_rearm_failure_state(DNS_FRAME_TERMINAL_HUP_PENDING) ==
+                  DNS_FRAME_TERMINAL_DRAIN &&
+          dns_frame_hup_rearm_failure_state(DNS_FRAME_TERMINAL_NONE) ==
+                  DNS_FRAME_TERMINAL_NONE,
+          "lifecycle preserves final bytes through HUP rearm failure");
+    CHECK(dns_frame_eof_terminal_state(1, 0, 0) == DNS_FRAME_TERMINAL_FIN_DRAIN &&
+          dns_frame_eof_terminal_state(1, 1, 0) == DNS_FRAME_TERMINAL_DRAIN &&
+          dns_frame_eof_terminal_state(1, 0, 1) == DNS_FRAME_TERMINAL_DRAIN &&
+          dns_frame_eof_terminal_state(0, 1, 0) == DNS_FRAME_TERMINAL_NONE &&
+          dns_frame_eof_terminal_state(0, 0, 0) == DNS_FRAME_TERMINAL_FIN_DRAIN,
+          "lifecycle drains complete output before FIN or truncated-frame reset");
+    CHECK(dns_frame_requires_recheck(0) && !dns_frame_requires_recheck(1),
+          "lifecycle rechecks only a closed window");
+    CHECK(dns_frame_flush_chunk_allowed(0) &&
+          dns_frame_flush_chunk_allowed(DNS_FRAME_MAX_FLUSH_CHUNKS - 1) &&
+          !dns_frame_flush_chunk_allowed(DNS_FRAME_MAX_FLUSH_CHUNKS),
+          "lifecycle caps per-flush chunk work");
+    CHECK(dns_frame_terminal_next(DNS_FRAME_TERMINAL_DRAIN, 1, 5, 5) ==
+                  DNS_FRAME_TERMINAL_DRAIN &&
+          dns_frame_terminal_next(DNS_FRAME_TERMINAL_DRAIN, 0, 4, 5) ==
+                  DNS_FRAME_TERMINAL_WAIT_ACK &&
+          dns_frame_terminal_next(DNS_FRAME_TERMINAL_DRAIN, 0, 5, 5) ==
+                  DNS_FRAME_TERMINAL_NONE &&
+          dns_frame_terminal_next(DNS_FRAME_TERMINAL_WAIT_ACK, 0, 4, 5) ==
+                  DNS_FRAME_TERMINAL_WAIT_ACK &&
+          dns_frame_terminal_next(DNS_FRAME_TERMINAL_WAIT_ACK, 0, 5, 5) ==
+          DNS_FRAME_TERMINAL_NONE,
+          "lifecycle waits for final ACK before terminal reset");
+    CHECK(dns_frame_terminal_timeout(DNS_FRAME_TERMINAL_DRAIN, 20) == 20 &&
+          dns_frame_terminal_timeout(DNS_FRAME_TERMINAL_WAIT_ACK, 20) == 20 &&
+          dns_frame_terminal_timeout(DNS_FRAME_TERMINAL_NONE, 20) == 0,
+          "lifecycle uses close timeout while terminal output drains or waits");
+    CHECK(!dns_frame_recheck_due(99, 0, 100) &&
+          !dns_frame_recheck_due(100, 0, 100) &&
+          dns_frame_recheck_due(101, 0, 100) &&
+          !dns_frame_recheck_due(99, 100, 100),
+          "lifecycle uses the 100 ms recheck cadence");
+}
+
+static void test_stream_pending_reserve_failure_is_terminal(void) {
+    uint8_t storage[DNS_FRAME_MAX_BUFFER];
+    uint8_t frame[10];
+    size_t frame_len = make_frame(frame, 8, 0xF0);
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, sizeof(storage));
+    struct stream_observer observer = {.pending_reserve_fail = 1};
+    struct dns_frame_stream_result result;
+    size_t bytes = frame_len;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) < 0,
+          "pending reserve failure reports error");
+    CHECK(stream.disabled && !dns_frame_stream_has_pending(&stream) &&
+          observer.calls == 0,
+          "pending reserve failure does not claim transparent fail-open");
+    dns_frame_stream_reset(&stream);
+}
+
+static void test_stream_late_reserve_failure_is_atomic(void) {
+    uint8_t storage[DNS_FRAME_MAX_BUFFER];
+    uint8_t data[12];
+    size_t first = make_frame(data, 3, 0x61);
+    size_t second = make_frame(data + first, 3, 0x71);
+    const size_t total = first + second;
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, sizeof(storage));
+    struct stream_observer observer = {
+            .pending_reserve_fail_after = 1,
+    };
+    struct dns_frame_stream_result result;
+    size_t bytes = total;
+    CHECK(dns_frame_stream_feed(&stream, data, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) < 0,
+          "late pending reserve failure reports terminal error");
+    CHECK(observer.calls == 1 && result.parsed == 1 && stream.disabled &&
+          !stream.pending_passthrough && stream.pending_length == first,
+          "late pending reserve failure keeps only prior rewritten output");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.output_len == first &&
+          memcmp(observer.output, data, first) == 0,
+          "late pending reserve failure does not append raw suffix");
+    dns_frame_stream_reset(&stream);
+}
+
+static void test_stream_dynamic_reserve(void) {
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, NULL, 0);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    struct dns_frame_stream_result result;
+    uint8_t data[24];
+    size_t first = make_frame(data, 8, 0x12);
+    size_t second = make_frame(data + first, 12, 0x23);
+    size_t bytes = first + second;
+    CHECK(dns_frame_stream_feed(&stream, data, &bytes, observe_frame,
+                                reserve_frame, reserve_pending, &observer,
+                                &result) == 0,
+          "dynamic reserve stream feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 2 && observer.emitted == 1,
+          "dynamic reserve parses and emits each frame");
+    CHECK(observer.reserve_calls >= 4,
+          "dynamic reserve grows frame and pending storage");
+    CHECK(observer.output_len == (8 - 3 + 2) + (12 - 3 + 2),
+          "dynamic reserve emits shortened frames");
+    CHECK(read_prefix(observer.output) == 5 && observer.output[2] == (uint8_t) (0x12 ^ 0xFF),
+          "dynamic reserve emits first mutation");
+    size_t second_offset = 8 - 3 + 2;
+    CHECK(read_prefix(observer.output + second_offset) == 9 &&
+          observer.output[second_offset + 2] == (uint8_t) (0x23 ^ 0xFF),
+          "dynamic reserve emits second mutation");
+    CHECK(stream.buffered == 0 && stream.capacity == second,
+          "dynamic reserve retains only latest declared capacity until release");
+    free(stream.buffer);
+}
+
+static void test_stream_allocation_failure_fail_open(void) {
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, NULL, 0);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    struct dns_frame_stream_result result;
+    uint8_t frame[10];
+    size_t frame_len = make_frame(frame, 8, 0x31);
+
+    /* Keep the first prefix byte, then fail while growing after the second
+     * prefix byte reveals the declared frame size. */
+    size_t bytes = 1;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                reserve_frame, reserve_pending, &observer,
+                                &result) == 0,
+          "allocation failure prefix feed");
+    CHECK(stream.buffered == 1 && observer.output_len == 0,
+          "allocation failure retains prefix before reserve");
+    observer.reserve_fail = 1;
+    bytes = 4;
+    uint8_t second_and_part[4];
+    memcpy(second_and_part, frame + 1, bytes);
+    CHECK(dns_frame_stream_feed(&stream, second_and_part, &bytes,
+                                observe_frame, reserve_frame, reserve_pending,
+                                &observer, &result) == 0,
+          "allocation failure fail-open feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(stream.disabled && observer.calls == 0 && observer.output_len == 5,
+          "allocation failure queues held prefix and current bytes");
+    CHECK(memcmp(observer.output, frame, 5) == 0,
+          "allocation failure preserves held byte order");
+
+    bytes = frame_len - 5;
+    CHECK(dns_frame_stream_feed(&stream, frame + 5, &bytes, observe_frame,
+                                reserve_frame, reserve_pending, &observer,
+                                &result) == 0,
+          "allocation failure subsequent raw feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.output_len == frame_len &&
+          memcmp(observer.output, frame, frame_len) == 0,
+          "allocation failure keeps future forwarding fail-open");
+    free(stream.buffer);
+}
+
+static void test_stream_partial_prefix(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "partial prefix storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t frame[10];
+    size_t frame_len = make_frame(frame, 8, 0x44);
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {.mutate = 1, .shrink = 1};
+    struct dns_frame_stream_result result;
+    size_t bytes = 1;
+    uint8_t prefix = frame[0];
+    CHECK(dns_frame_stream_feed(&stream, &prefix, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "partial prefix first byte");
+    CHECK(observer.calls == 0 && stream.buffered == 1,
+          "partial prefix retains one prefix byte");
+
+    bytes = 1;
+    uint8_t second_prefix = frame[1];
+    CHECK(dns_frame_stream_feed(&stream, &second_prefix, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "partial prefix second byte");
+    CHECK(observer.calls == 0 && stream.buffered == 2 &&
+          stream.expected == frame_len,
+          "partial prefix waits for payload after complete prefix");
+
+    bytes = frame_len - 2;
+    uint8_t payload[8];
+    memcpy(payload, frame + 2, bytes);
+    uint8_t snapshot[sizeof(payload)];
+    memcpy(snapshot, payload, bytes);
+    CHECK(dns_frame_stream_feed(&stream, payload, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "partial prefix payload");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 1 && observer.ids[0] == 0x44,
+          "partial prefix parses complete frame once");
+    CHECK(observer.output_len == 7 && read_prefix(observer.output) == 5,
+          "partial prefix emits rewritten frame after completion");
+    CHECK(memcmp(payload, snapshot, bytes) == 0,
+          "partial prefix forwards payload unchanged");
+    free(storage);
+}
+
+static void test_stream_zero_and_oversized_frames(void) {
+    uint8_t storage[16];
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, sizeof(storage));
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+
+    /* Zero-length frames are consumed but are not DNS messages. */
+    uint8_t valid[8];
+    size_t valid_len = make_frame(valid, 6, 0x55);
+    uint8_t zero_and_valid[sizeof(valid) + 2];
+    zero_and_valid[0] = 0;
+    zero_and_valid[1] = 0;
+    memcpy(zero_and_valid + 2, valid, valid_len);
+    size_t bytes = valid_len + 2;
+    CHECK(dns_frame_stream_feed(&stream, zero_and_valid, &bytes,
+                                observe_frame, NULL, reserve_pending,
+                                &observer, &result) == 0,
+          "zero-length stream feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(result.skipped == 1 && result.parsed == 1 && observer.calls == 1,
+          "zero-length frame skipped and following frame parsed");
+    CHECK(observer.ids[0] == 0x55, "zero-length stream stays aligned");
+
+    /* A maximum-prefix frame is too large for this deliberately small test
+     * storage. It is discarded by declared length, not reinterpreted as a
+     * sequence of prefixes, and the following valid frame still parses. */
+    dns_frame_stream_reset(&stream);
+    observer.calls = 0;
+    observer.emitted = 0;
+    observer.output_len = 0;
+    uint8_t first[2 + 5];
+    set_prefix(first, DNS_FRAME_MAX_PAYLOAD);
+    memset(first + 2, 0x66, 5);
+    bytes = sizeof(first);
+    CHECK(dns_frame_stream_feed(&stream, first, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "oversized stream first feed");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 0 && stream.disabled && observer.output_len == sizeof(first),
+          "oversized stream switches to bounded fail-open forwarding");
+
+    const size_t remaining = DNS_FRAME_MAX_PAYLOAD - 5;
+    uint8_t *tail = malloc(remaining + valid_len);
+    CHECK(tail != NULL, "oversized stream tail allocation");
+    if (tail != NULL) {
+        memset(tail, 0x77, remaining);
+        memcpy(tail + remaining, valid, valid_len);
+        bytes = remaining + valid_len;
+        CHECK(dns_frame_stream_feed(&stream, tail, &bytes, observe_frame,
+                                    NULL, reserve_pending, &observer, &result) == 0,
+              "oversized stream completion feed");
+        flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+        CHECK(observer.calls == 0 && observer.output_len == DNS_FRAME_MAX_BUFFER + valid_len,
+              "oversized stream forwards all subsequent bytes unchanged");
+        CHECK(memcmp(observer.output, first, sizeof(first)) == 0 &&
+              memcmp(observer.output + DNS_FRAME_MAX_BUFFER, valid, valid_len) == 0,
+              "oversized stream preserves following bytes after max frame");
+        free(tail);
     }
 }
 
+static void test_stream_reset_and_teardown(void) {
+    uint8_t *storage = malloc(DNS_FRAME_MAX_BUFFER);
+    CHECK(storage != NULL, "reset stream storage allocation");
+    if (storage == NULL)
+        return;
+
+    uint8_t frame[12];
+    size_t frame_len = make_frame(frame, 10, 0x77);
+    struct dns_frame_stream stream;
+    dns_frame_stream_init(&stream, storage, DNS_FRAME_MAX_BUFFER);
+    struct stream_observer observer = {0};
+    struct dns_frame_stream_result result;
+    size_t bytes = 5;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "reset stream partial feed");
+    CHECK(stream.buffered == 5 && observer.calls == 0,
+          "reset stream has partial state before reset");
+
+    dns_frame_stream_reset(&stream);
+    CHECK(stream.buffered == 0 && stream.expected == 0,
+          "reset stream drops partial state");
+    bytes = frame_len;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "reset stream fresh frame feed");
+    CHECK(dns_frame_stream_has_pending(&stream),
+          "reset stream has output before teardown");
+    dns_frame_stream_reset(&stream);
+    CHECK(!dns_frame_stream_has_pending(&stream),
+          "reset stream drops pending output on teardown");
+    dns_frame_stream_release_pending(&stream, release_pending, NULL);
+    observer.calls = 0;
+    observer.output_len = 0;
+    observer.emitted = 0;
+    bytes = frame_len;
+    CHECK(dns_frame_stream_feed(&stream, frame, &bytes, observe_frame,
+                                NULL, reserve_pending, &observer, &result) == 0,
+          "reset stream feed after pending teardown");
+    flush_stream(&stream, &observer, DNS_FRAME_MAX_BUFFER);
+    CHECK(observer.calls == 1 && observer.ids[0] == 0x77,
+          "reset stream parses fresh frame once");
+
+    /* The owner, as clear_tcp_data() does in production, releases storage
+     * after resetting the state. */
+    dns_frame_stream_reset(&stream);
+    free(storage);
+}
+
 int main(void) {
-    test_isolated_frame_shortened();
-    test_isolated_frame_unchanged();
-    test_coalesced_read();
-    test_split_frame();
-    test_zero_frame_len_skipped();
-    test_bytes_equal_three_minimal();
-    test_frame_len_u16_boundary();
+    test_stream_consecutive_split_reads();
+    test_stream_coalesced_frames();
+    test_stream_isolated_rewrite();
+    test_stream_bounded_flush_and_gate();
+    test_stream_tcp_window_ack_and_mss();
+    test_stream_emitter_error_retry();
+    test_stream_pending_compaction();
+    test_stream_geometric_pending_growth();
+    test_stream_lifecycle_decisions();
+    test_stream_pending_reserve_failure_is_terminal();
+    test_stream_late_reserve_failure_is_atomic();
+    test_stream_dynamic_reserve();
+    test_stream_allocation_failure_fail_open();
+    test_stream_partial_prefix();
+    test_stream_zero_and_oversized_frames();
+    test_stream_reset_and_teardown();
 
     if (failures == 0) {
         printf("dns_frame_test: all tests passed\n");


### PR DESCRIPTION
## Summary
- reassemble DNS-over-TCP as a byte stream across split and coalesced socket reads
- apply blocking rewrites to every complete frame before any part reaches the app
- bound reassembly and pending output while respecting the TCP window, MSS, and sequence accounting
- preserve queued output across ACK, HUP, EOF, and error transitions without periodic polling

## Why
`recv()` boundaries are not DNS frame boundaries. The previous path could miss later coalesced answers or parse partial answers, causing tracker detection and blocking gaps.

## Validation
- host C suite with `-Wall -Wextra -Werror -pedantic`
- ASan/UBSan host run
- `:app:externalNativeBuildGithubDebug` for all configured ABIs
- Rust workspace and `tc-dns` C-ABI tests
- `git diff --check`

## Risk
- No device-level DNS-over-TCP capture was run. Allocation failure forwards unchanged when the exact stream can be queued; if pending storage itself is unavailable, the TCP session closes instead of forwarding a partial/corrupt stream.
