### PR TITLE
Address review nits from #803, #804, #805 and #806

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2941,123 +2941,122 @@ public class ServiceSinkhole extends VpnService {
         if (tracker == null) {
             // Check if IP known
             String dname = null;
-            if (dname == null) { // TODO: Note that this does not implement any SNI code
-                // Snapshot before the DB read: if dnsResolved() invalidates this
-                // IP's cache entry while we're mid-read below, our result may be
-                // stale (it could miss a row that raced us, or reflect a row
-                // that no longer applies). Comparing after the read lets us
-                // drop the put and let the next packet re-read instead of
-                // pinning a possibly-wrong verdict.
-                long generationBefore = trackerCache.generation();
-                // Retrieve dname from DB
-                DatabaseHelper dh = DatabaseHelper.getInstance(ServiceSinkhole.this);
-                long now = new Date().getTime();
-                // Expiry of the DNS record the chosen dname/tracker came from;
-                // -1 until we lock onto a tracker row, so a host-only result can
-                // fall back to the first candidate row's expiry instead.
-                long chosenTime = -1;
-                long chosenTtl = -1;
-                long firstTime = now;
-                long firstTtl = 7 * 24 * 3600 * 1000L;
-                boolean sawFirstRow = false;
-                boolean sawTrackerEvidence = false;
-                boolean sawNonTrackerEvidence = false;
-                try (Cursor lookup = dh.getQAName(uid, daddr)) {
-                    // Loop through all fresh DNS candidates for this IP and only fail closed
-                    // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
-                    if (lookup != null) {
-                        while (lookup.moveToNext()) {
-                            // Get DNS expiry details for this candidate row
-                            int colTime = lookup.getColumnIndex("time");
-                            int colTTL = lookup.getColumnIndex("ttl");
-                            long rowTime = lookup.isNull(colTime) ? now : lookup.getLong(colTime);
-                            long rowTtl = lookup.isNull(colTTL) ? firstTtl : lookup.getLong(colTTL);
-                            if (!sawFirstRow) {
-                                firstTime = rowTime;
-                                firstTtl = rowTtl;
-                                sawFirstRow = true;
-                            }
+            // TODO: Note that this does not implement any SNI code
+            // Snapshot before the DB read: if dnsResolved() invalidates this
+            // IP's cache entry while we're mid-read below, our result may be
+            // stale (it could miss a row that raced us, or reflect a row
+            // that no longer applies). Comparing after the read lets us
+            // drop the put and let the next packet re-read instead of
+            // pinning a possibly-wrong verdict.
+            long generationBefore = trackerCache.generation();
+            // Retrieve dname from DB
+            DatabaseHelper dh = DatabaseHelper.getInstance(ServiceSinkhole.this);
+            long now = new Date().getTime();
+            // Expiry of the DNS record the chosen dname/tracker came from;
+            // -1 until we lock onto a tracker row, so a host-only result can
+            // fall back to the first candidate row's expiry instead.
+            long chosenTime = -1;
+            long chosenTtl = -1;
+            long firstTime = now;
+            long firstTtl = 7 * 24 * 3600 * 1000L;
+            boolean sawFirstRow = false;
+            boolean sawTrackerEvidence = false;
+            boolean sawNonTrackerEvidence = false;
+            try (Cursor lookup = dh.getQAName(uid, daddr)) {
+                // Loop through all fresh DNS candidates for this IP and only fail closed
+                // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
+                if (lookup != null) {
+                    while (lookup.moveToNext()) {
+                        // Get DNS expiry details for this candidate row
+                        int colTime = lookup.getColumnIndex("time");
+                        int colTTL = lookup.getColumnIndex("ttl");
+                        long rowTime = lookup.isNull(colTime) ? now : lookup.getLong(colTime);
+                        long rowTtl = lookup.isNull(colTTL) ? firstTtl : lookup.getLong(colTTL);
+                        if (!sawFirstRow) {
+                            firstTime = rowTime;
+                            firstTtl = rowTtl;
+                            sawFirstRow = true;
+                        }
 
-                            // Check tracker
-                            String aname = lookup.getString(lookup.getColumnIndexOrThrow("aname"));
-                            String qname = lookup.getString(lookup.getColumnIndexOrThrow("qname"));
-                            String candidateDname = qname;
-                            Tracker candidateTracker = TrackerList.findTracker(qname);
+                        // Check tracker
+                        String aname = lookup.getString(lookup.getColumnIndexOrThrow("aname"));
+                        String qname = lookup.getString(lookup.getColumnIndexOrThrow("qname"));
+                        String candidateDname = qname;
+                        Tracker candidateTracker = TrackerList.findTracker(qname);
 
-                            if (dname == null && qname != null)
-                                dname = qname;
+                        if (dname == null && qname != null)
+                            dname = qname;
 
-                            // If no tracker found, try DNS uncloaking
-                            if (candidateTracker == null
-                                    && aname != null) {
-                                candidateTracker = TrackerList.findTracker(aname);
-
-                                if (candidateTracker != null) {
-                                    candidateDname = aname;
-                                    Log.d(TAG, "Uncloaked: " + qname + " -> " + aname);
-                                }
-                            }
+                        // If no tracker found, try DNS uncloaking
+                        if (candidateTracker == null
+                                && aname != null) {
+                            candidateTracker = TrackerList.findTracker(aname);
 
                             if (candidateTracker != null) {
-                                sawTrackerEvidence = true;
-                                if (tracker == null) {
-                                    tracker = candidateTracker;
-                                    dname = candidateDname;
-                                    // Expire the cache entry with the DNS record
-                                    // this tracker was derived from, not whatever
-                                    // row happened to be read last.
-                                    chosenTime = rowTime;
-                                    chosenTtl = rowTtl;
-                                }
-                            } else if (qname != null || aname != null)
-                                sawNonTrackerEvidence = true;
+                                candidateDname = aname;
+                                Log.d(TAG, "Uncloaked: " + qname + " -> " + aname);
+                            }
                         }
+
+                        if (candidateTracker != null) {
+                            sawTrackerEvidence = true;
+                            if (tracker == null) {
+                                tracker = candidateTracker;
+                                dname = candidateDname;
+                                // Expire the cache entry with the DNS record
+                                // this tracker was derived from, not whatever
+                                // row happened to be read last.
+                                chosenTime = rowTime;
+                                chosenTtl = rowTtl;
+                            }
+                        } else if (qname != null || aname != null)
+                            sawNonTrackerEvidence = true;
                     }
                 }
-
-                if (sawTrackerEvidence && sawNonTrackerEvidence && !blockAmbiguousTrackers) {
-                    Log.d(TAG, "Allowing mixed tracker evidence for " + daddr);
-                    tracker = NO_TRACKER;
-                }
-
-                // No success in finding dname or tracker?
-                if (dname == null)
-                    dname = NO_DNAME;
-                if (tracker == null)
-                    tracker = NO_TRACKER;
-
-                // Choose the cache expiry:
-                long expiry;
-                if (dname == NO_DNAME) {
-                    // No DNS mapping was captured for this IP at all — the query
-                    // may have gone over DoT, arrived before the service
-                    // started, or been lost to a split TCP response. This is an
-                    // unconfident miss: re-check soon rather than caching it for
-                    // the full DNS TTL (up to 7 days), which would keep any
-                    // tracker traffic to this IP invisible and unblocked until
-                    // then.
-                    expiry = now + NEGATIVE_TRACKER_CACHE_TTL_MS;
-                } else {
-                    // DNS evidence exists (tracker or confident non-tracker);
-                    // expire with the record the decision was derived from, not
-                    // whatever row happened to be read last.
-                    expiry = (chosenTime >= 0)
-                            ? chosenTime + chosenTtl
-                            : firstTime + firstTtl;
-                }
-
-                // Save dname and tracker, but only if no concurrent
-                // dnsResolved() invalidated this IP's cache while we were
-                // reading the DB above — otherwise this put could pin a
-                // stale verdict that a racing insert already made obsolete.
-                // Skipping is cheap and correct: the next packet to this IP
-                // simply re-reads the DB.
-                TrackerCache.Entry cacheEntry = new TrackerCache.Entry(dname, tracker, expiry);
-                trackerCache.putIfGeneration(daddr, cacheEntry, generationBefore);
-                // Keep the exact snapshot used for the decision for logging;
-                // the shared cache may be invalidated or replaced meanwhile.
-                cached = cacheEntry;
             }
+
+            if (sawTrackerEvidence && sawNonTrackerEvidence && !blockAmbiguousTrackers) {
+                Log.d(TAG, "Allowing mixed tracker evidence for " + daddr);
+                tracker = NO_TRACKER;
+            }
+
+            // No success in finding dname or tracker?
+            if (dname == null)
+                dname = NO_DNAME;
+            if (tracker == null)
+                tracker = NO_TRACKER;
+
+            // Choose the cache expiry:
+            long expiry;
+            if (dname == NO_DNAME) {
+                // No DNS mapping was captured for this IP at all — the query
+                // may have gone over DoT, arrived before the service
+                // started, or been lost to a split TCP response. This is an
+                // unconfident miss: re-check soon rather than caching it for
+                // the full DNS TTL (up to 7 days), which would keep any
+                // tracker traffic to this IP invisible and unblocked until
+                // then.
+                expiry = now + NEGATIVE_TRACKER_CACHE_TTL_MS;
+            } else {
+                // DNS evidence exists (tracker or confident non-tracker);
+                // expire with the record the decision was derived from, not
+                // whatever row happened to be read last.
+                expiry = (chosenTime >= 0)
+                        ? chosenTime + chosenTtl
+                        : firstTime + firstTtl;
+            }
+
+            // Save dname and tracker, but only if no concurrent
+            // dnsResolved() invalidated this IP's cache while we were
+            // reading the DB above — otherwise this put could pin a
+            // stale verdict that a racing insert already made obsolete.
+            // Skipping is cheap and correct: the next packet to this IP
+            // simply re-reads the DB.
+            TrackerCache.Entry cacheEntry = new TrackerCache.Entry(dname, tracker, expiry);
+            trackerCache.putIfGeneration(daddr, cacheEntry, generationBefore);
+            // Keep the exact snapshot used for the decision for logging;
+            // the shared cache may be invalidated or replaced meanwhile.
+            cached = cacheEntry;
 
             // Do not block based on IP-only tracker evidence.
             // Shared IPs are too ambiguous without hostname evidence.

--- a/app/src/main/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicy.java
@@ -63,14 +63,15 @@ final class WireGuardStartupRecoveryPolicy {
         return true;
     }
 
-    /** Successful startup clears a pending callback and restores the budget. */
-    synchronized void onSuccess() {
-        pending = false;
-        dispatched = false;
-        retryPolicy.reset();
-    }
-
-    /** Cancels queued work; callers choose whether this is a new episode. */
+    /**
+     * Cancels queued work; callers choose whether this is a new episode.
+     *
+     * <p>A successful startup is just {@code cancel(true)}: it has no state to
+     * clear beyond the pending callback and the spent budget. ServiceSinkhole
+     * calls it through cancelWireGuardStartupRecovery, which also drops the
+     * queued Handler callback, so a separate onSuccess would either duplicate
+     * this or silently skip that removal.</p>
+     */
     synchronized void cancel(boolean resetBudget) {
         pending = false;
         dispatched = false;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -69,8 +69,11 @@ public class TrackerList {
             "cloudfront.net",
             "fastly.net",
             "cloudflare.com"));
+    // Bootstrap snapshot: never published by a load, so its mode is a
+    // placeholder rather than the user's. getBlockingMode falls back to the
+    // preference while this is still current.
     private static volatile TrackerSnapshot trackerSnapshot = new TrackerSnapshot(
-            new ConcurrentHashMap<>(), false, false, BlockingMode.getDefaultMode());
+            new ConcurrentHashMap<>(), false, false, BlockingMode.getDefaultMode(), false);
     public static String TRACKER_HOSTLIST = "TRACKER_HOSTLIST";
     private static final Tracker hostlistTracker = new Tracker(TRACKER_HOSTLIST, UNCATEGORISED);
     private static volatile TrackerList instance;
@@ -95,13 +98,19 @@ public class TrackerList {
         private final boolean domainBasedBlocking;
         private final boolean minimalBlockingMode;
         private final String blockingMode;
+        // False only for the bootstrap snapshot, i.e. before any load has
+        // succeeded. Distinguishes "loaded, and this is the mode it was built
+        // for" from "nothing has ever loaded".
+        private final boolean loaded;
 
         private TrackerSnapshot(Map<String, Tracker> hostnameToTracker,
-                boolean domainBasedBlocking, boolean minimalBlockingMode, String blockingMode) {
+                boolean domainBasedBlocking, boolean minimalBlockingMode, String blockingMode,
+                boolean loaded) {
             this.hostnameToTracker = hostnameToTracker;
             this.domainBasedBlocking = domainBasedBlocking;
             this.minimalBlockingMode = minimalBlockingMode;
             this.blockingMode = blockingMode;
+            this.loaded = loaded;
         }
     }
 
@@ -137,11 +146,17 @@ public class TrackerList {
      * Return the blocking mode published with the active tracker snapshot.
      * Initialising through getInstance ensures the map and mode are never read
      * from two different lifecycle states by packet-path callers.
+     *
+     * <p>If no load has ever succeeded there is no published mode to be
+     * consistent with, so fall back to the preference. Reporting the bootstrap
+     * placeholder instead would silently downgrade a Strict-mode user to the
+     * default for as long as asset loading keeps failing.</p>
      */
     public static String getBlockingMode(Context c) {
         if (instance == null)
             getInstance(c);
-        return trackerSnapshot.blockingMode;
+        TrackerSnapshot snapshot = trackerSnapshot;
+        return snapshot.loaded ? snapshot.blockingMode : BlockingMode.getMode(c);
     }
 
     static boolean isIgnoredDomain(String domain) {
@@ -253,7 +268,7 @@ public class TrackerList {
             }
 
             trackerSnapshot = new TrackerSnapshot(
-                    loadedTrackers, domainBasedBlocking, minimalBlockingMode, blockingMode);
+                    loadedTrackers, domainBasedBlocking, minimalBlockingMode, blockingMode, true);
             invalidateTrackerCountCache();
             return true;
         }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
@@ -178,7 +178,10 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
         if (!cadenceOk) return
         try {
             prod()
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
+            // The prod reaches sendKeepalive() across JNI. Errors raised on
+            // that boundary are not the caller's to die on: swallow them the
+            // same way a thrown exception is, so the polling loop survives.
             Log.w(TAG, "prod threw", e)
         }
         if (initialProdTs == null) initialProdTs = now
@@ -372,7 +375,11 @@ internal class WgConnectivityMonitor(
         return try {
             try {
                 statsProvider()
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // statsProvider crosses JNI into the Rust tunnel. Let an
+                // Error from there be treated as a failed sample rather than
+                // killing the monitor thread, which would leave the tunnel
+                // unwatched until the next same-config startOrUpdate.
                 warn("stats read threw", e)
                 null
             }
@@ -407,7 +414,9 @@ internal class WgConnectivityMonitor(
 
             try {
                 callback()
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // prod reaches sendKeepalive() across JNI; the other callbacks
+                // run app code. Neither may end the polling loop.
                 warn("$label threw", e)
             }
         }
@@ -434,7 +443,8 @@ internal class WgConnectivityMonitor(
 
             try {
                 onBroken()
-            } catch (e: Exception) {
+            } catch (e: Throwable) {
+                // onBroken restarts the tunnel across JNI.
                 warn("onBroken threw", e)
             }
         }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -398,7 +398,7 @@ object WgEgress {
             prod = {
                 if (isCurrent(expected)) try {
                     expected.tunnel.sendKeepalive()
-                } catch (e: Exception) {
+                } catch (e: Throwable) {
                     Log.w(TAG, "prod keepalive threw", e)
                 }
             },
@@ -641,7 +641,10 @@ object WgEgress {
                 it.latestHandshakeMillis > 0 && now() - it.latestHandshakeMillis < HANDSHAKE_DEAD_AFTER_MS
             )
         }
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
+        // Tunnel.stats() crosses JNI. A missing sample is ambiguous by
+        // design and the monitor already bounds how long it tolerates one,
+        // so an Error here must not escape into the polling loop.
         null
     }
 

--- a/app/src/test/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/WireGuardStartupRecoveryPolicyTest.java
@@ -26,7 +26,9 @@ public class WireGuardStartupRecoveryPolicyTest {
 
         assertEquals(500L, policy.onFailure(0L, true));
         assertTrue(policy.claim());
-        policy.onSuccess();
+        // What startNative's success path does, via
+        // cancelWireGuardStartupRecovery(true).
+        policy.cancel(true);
         assertEquals(500L, policy.onFailure(1L, true));
     }
 

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
@@ -144,6 +144,31 @@ public class TrackerListReloadTest {
         assertEquals(BlockingMode.MODE_STANDARD, TrackerList.getBlockingMode(context));
     }
 
+    /**
+     * With no snapshot ever published there is no loaded mode to stay
+     * consistent with, so the preference must win. Reporting the bootstrap
+     * placeholder would silently drop a Strict-mode user to the default.
+     */
+    @Test
+    public void blockingModeFallsBackToThePrefWhenNoLoadEverSucceeded() throws Exception {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BLOCKING_MODE, BlockingMode.MODE_STRICT).commit();
+
+        Constructor<AssetManager> assetConstructor = AssetManager.class.getDeclaredConstructor();
+        assetConstructor.setAccessible(true);
+        AssetManager brokenAssets = assetConstructor.newInstance();
+        Context brokenContext = new ContextWrapper(context) {
+            @Override
+            public AssetManager getAssets() {
+                return brokenAssets;
+            }
+        };
+
+        assertFalse(TrackerList.reloadTrackerData(brokenContext));
+
+        assertEquals(BlockingMode.MODE_STRICT, TrackerList.getBlockingMode(context));
+    }
+
     @Test
     public void modeSelectionPublishesOnlyTheSelectedLists() {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
@@ -198,11 +223,11 @@ public class TrackerListReloadTest {
         Class<?> snapshotClass = Class.forName(
                 "net.kollnig.missioncontrol.data.TrackerList$TrackerSnapshot");
         Constructor<?> constructor = snapshotClass.getDeclaredConstructor(
-                Map.class, boolean.class, boolean.class, String.class);
+                Map.class, boolean.class, boolean.class, String.class, boolean.class);
         constructor.setAccessible(true);
         Object emptySnapshot = constructor.newInstance(
                 new ConcurrentHashMap<String, Tracker>(), false, false,
-                BlockingMode.getDefaultMode());
+                BlockingMode.getDefaultMode(), false);
         Field snapshot = TrackerList.class.getDeclaredField("trackerSnapshot");
         snapshot.setAccessible(true);
         snapshot.set(null, emptySnapshot);


### PR DESCRIPTION
## Summary
- restore `catch (Throwable)` at the boundaries that cross JNI into the Rust tunnel
- fall back to the blocking-mode preference while no tracker snapshot has ever loaded
- drop the vacuous `if (dname == null)` guard in `blockKnownTracker`
- drop the never-called `WireGuardStartupRecoveryPolicy.onSuccess()`

## Why

**#806 — narrowed JNI boundary.** `Tunnel.stats()`, `sendKeepalive()` and the callbacks that restart the tunnel all cross into Rust. Narrowing their handlers from `Throwable` to `Exception` let an `Error` raised on that boundary escape `runLoop` and kill the monitor thread; recovery then depended on a later same-config `startOrUpdate` happening to reach `startMonitorIfDead()`. The purely app-level handlers (config parsing, endpoint resolution, the test readiness hook) stay on `Exception`.

**#805 — silent mode downgrade on a first-load failure.** The bootstrap snapshot carries `getDefaultMode()` as a placeholder. If the very first `loadTrackers` failed, `getBlockingMode()` reported that placeholder to the packet path, so a Strict-mode user was silently downgraded to the default for as long as loading kept failing. A snapshot now records whether a real load published it, and `getBlockingMode()` falls back to the preference until one has. Retention of a *previous* good snapshot is unchanged — that case already worked.

**#804 — vacuous conditional.** `if (dname == null)` guarded the DB read back when a separate `ipToHost` cache could satisfy it. With one unified cache entry, `dname` is unconditionally null at that point. Removing it is a dedent; `git diff -w` shows only the removed `if` and its brace.

**#803 — dead method.** `onSuccess()` was never called in production. The success path in `startNative` uses `cancelWireGuardStartupRecovery(true)`, which is `cancel(true)` *plus* the Handler callback removal that `onSuccess` would have skipped, so wiring it in would have been a bug and keeping it invited one.

## Validation
- `git diff --check`; brace balance of `ServiceSinkhole.java` unchanged across the dedent, and `git diff -w` confirms the only non-whitespace change there is the removed conditional
- new `blockingModeFallsBackToThePrefWhenNoLoadEverSucceeded` covers the #805 case
- `TrackerListReloadTest.resetTrackerList` updated for the added `TrackerSnapshot` field
- `WireGuardStartupRecoveryPolicyTest.successfulStartupResetsBackoff` now exercises `cancel(true)`, i.e. what the production success path actually calls
- **Not compiled or run locally** — no Android SDK in the environment this was prepared in. CI on this stack is the first real build.

## Dependency
- Stacked on #806. Base is `codex/fix-wg-monitor-stats`, which this also merged up to current `master` so the diff here is only the nits.

## Risk
- Only the #805 change alters behaviour, and only on the narrow path where no tracker list has ever loaded.
- Widening the catches back to `Throwable` means an `Error` from the Rust boundary is again logged and swallowed rather than propagating. That is the pre-#806 behaviour and is deliberate: the polling loop surviving a bad sample is worth more than the crash.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cEuJotK74wA6tRzGRVnV1)_