### PR TITLE
Advertise iOS version in About dialog

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -1443,6 +1443,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Button btnRate = view.findViewById(R.id.btnRate);
         TextView tvEula = view.findViewById(R.id.tvEula);
         TextView tvPrivacy = view.findViewById(R.id.tvPrivacy);
+        TextView tvIos = view.findViewById(R.id.tvIos);
 
         // Show version
         tvVersionName.setText(Util.getSelfVersionName(this));
@@ -1451,6 +1452,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         // Handle license
         tvEula.setMovementMethod(LinkMovementMethod.getInstance());
         tvPrivacy.setMovementMethod(LinkMovementMethod.getInstance());
+        tvIos.setMovementMethod(LinkMovementMethod.getInstance());
 
         // Handle rate
         btnRate.setVisibility(

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -109,6 +109,15 @@
                 android:text="@string/app_privacy"
                 android:textAppearance="@style/TextSmall"
                 android:textSize="12sp" />
+
+            <TextView
+                android:id="@+id/tvIos"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/app_ios"
+                android:textAppearance="@style/TextSmall"
+                android:textSize="12sp" />
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="app_xposed">Xposed causes too many crashes, which might result in TrackerControl being removed from the Google Play Store, therefore TrackerControl isn\'t supported while Xposed is installed</string>
     <string name="app_eula">The usage of this app is at your own risk. No app can offer 100% protection against tracking.</string>
     <string name="app_privacy"><a href="https://github.com/TrackerControl/tracker-control-android#privacy-notice">Privacy Policy</a> <a href="https://github.com/TrackerControl/tracker-control-android#cookie-policy">Cookie Policy</a></string>
+    <string name="app_ios"><a href="https://ios.trackercontrol.org">TrackerControl is also available for iOS</a></string>
 
     <string name="channel_foreground">Running services</string>
     <string name="channel_notify">General notifications</string>


### PR DESCRIPTION
## Summary
- Adds a link to `ios.trackercontrol.org` in the About dialog, since TrackerControl for iOS is the same product under a different platform.
- Kept it to the About surface only (not a promo banner/dialog), matching the existing `app_privacy` link style (`<a href>` string + `LinkMovementMethod`).

## Changes
- `app/src/main/res/values/strings.xml`: new `app_ios` string linking to `https://ios.trackercontrol.org`.
- `app/src/main/res/layout/about.xml`: new `tvIos` TextView under the existing privacy/cookie links.
- `app/src/main/java/eu/faircode/netguard/ActivityMain.java`: wires `LinkMovementMethod` on the new TextView in `menu_about()`.

## Test plan
- [ ] No Android SDK available in this sandbox, so this wasn't compiled or run on-device — verified by inspection against the existing `tvPrivacy` pattern (same string format, same `setMovementMethod` call).
- [ ] Manually open the About dialog (long-press the toolbar icon, or via the overflow menu once `menu_about` is visible) and confirm the iOS link opens `ios.trackercontrol.org`.


---
_Generated by [Claude Code](https://claude.ai/code/session_016t2FBWbPWaCGMieB94rmdo)_