### PR TITLE
Use safer --force-with-lease refspec when pushing update-lists branch

### DIFF
--- a/.github/workflows/update-lists.yml
+++ b/.github/workflows/update-lists.yml
@@ -68,10 +68,13 @@ jobs:
           BRANCH="automation/update-lists"
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          REMOTE_SHA="$(git ls-remote --heads origin "$BRANCH" | cut -f1)"
           git checkout -B "$BRANCH"
           git add app/src/main/assets
           git commit -m "Update bundled tracker/host lists"
-          git push --force-with-lease origin "$BRANCH"
+          git push \
+            --force-with-lease="refs/heads/$BRANCH:$REMOTE_SHA" \
+            origin "$BRANCH"
 
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
             echo "PR already open for $BRANCH — updated in place."


### PR DESCRIPTION
### Motivation
- Ensure the workflow's force-push does not overwrite concurrent updates by using an explicit remote SHA and a `--force-with-lease` refspec.

### Description
- Compute `REMOTE_SHA` with `git ls-remote --heads origin "$BRANCH" | cut -f1` and replace `git push --force-with-lease origin "$BRANCH"` with `git push --force-with-lease="refs/heads/$BRANCH:$REMOTE_SHA" origin "$BRANCH"` to make the update branch push safer.

### Testing
- No automated tests were run for this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92ae140560832b93b1156b8a41d0ce)