### PR TITLE
Warn immediately when allowed DoT is observed

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -492,6 +492,24 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             }
         });
 
+        TextView tvPrivateDnsBypass = findViewById(R.id.tvPrivateDnsBypass);
+        tvPrivateDnsBypass.setVisibility(View.GONE);
+        tvPrivateDnsBypass.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent settings;
+                if (ServiceSinkhole.getPrivateDnsWarningState(ActivityMain.this)
+                        == ServiceSinkhole.PRIVATE_DNS_WARNING_ALLOWED_DOT)
+                    settings = new Intent(ActivityMain.this, ActivitySettings.class);
+                else {
+                    settings = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
+                    if (settings.resolveActivity(getPackageManager()) == null)
+                        settings = new Intent(Settings.ACTION_WIFI_SETTINGS);
+                }
+                startActivity(settings);
+            }
+        });
+
         // Application list
         RecyclerView rvApplication = findViewById(R.id.rvApplication);
         rvApplication.setHasFixedSize(false);
@@ -601,6 +619,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             tvPrivateDns.setVisibility(
                     vpnEnabled && Util.isPrivateDnsBlocked(this) ? View.VISIBLE : View.GONE);
         }
+        updatePrivateDnsBypassBanner();
 
         super.onResume();
     }
@@ -630,6 +649,28 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         updateHorizontalPadding(findViewById(R.id.tvNotifications), horizontalPadding);
         updateHorizontalPadding(findViewById(R.id.tvLocalNetwork), horizontalPadding);
         updateHorizontalPadding(findViewById(R.id.tvPrivateDns), horizontalPadding);
+        updateHorizontalPadding(findViewById(R.id.tvPrivateDnsBypass), horizontalPadding);
+        updatePrivateDnsBypassBanner();
+    }
+
+    private void updatePrivateDnsBypassBanner() {
+        TextView tvPrivateDnsBypass = findViewById(R.id.tvPrivateDnsBypass);
+        if (tvPrivateDnsBypass == null)
+            return;
+
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+        boolean vpnEnabled = prefs.getBoolean("enabled", false);
+        int state = vpnEnabled ? ServiceSinkhole.getPrivateDnsWarningState(this)
+                : ServiceSinkhole.PRIVATE_DNS_WARNING_NONE;
+        if (state == ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME) {
+            String specifier = Util.getPrivateDnsSpecifier(this);
+            String resolver = TextUtils.isEmpty(specifier)
+                    ? getString(R.string.msg_private_dns_unknown_resolver) : specifier;
+            tvPrivateDnsBypass.setText(getString(R.string.msg_private_dns_bypass_notify, resolver));
+        } else if (state == ServiceSinkhole.PRIVATE_DNS_WARNING_ALLOWED_DOT)
+            tvPrivateDnsBypass.setText(R.string.msg_private_dns_bypass_allowed_notify);
+        tvPrivateDnsBypass.setVisibility(
+                state != ServiceSinkhole.PRIVATE_DNS_WARNING_NONE ? View.VISIBLE : View.GONE);
     }
 
     private void updateHorizontalPadding(View view, int horizontalPadding) {
@@ -884,6 +925,11 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             MaterialSwitch swEnabled = getSupportActionBar().getCustomView().findViewById(R.id.swEnabled);
             if (swEnabled.isChecked() != enabled)
                 swEnabled.setChecked(enabled);
+
+            updatePrivateDnsBypassBanner();
+
+        } else if ("block_dot".equals(name) || "log".equals(name)) {
+            updatePrivateDnsBypassBanner();
 
         } else if ("show_user".equals(name) ||
                 "show_system".equals(name) ||

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -639,6 +639,28 @@ public class DatabaseHelper extends SQLiteOpenHelper {
         }
     }
 
+    /**
+     * Check whether the traffic log contains a recent allowed DoT flow.
+     *
+     * <p>The caller gates this on the full traffic-log preference: the log is
+     * intentionally empty when that preference is off, and the application log
+     * is only a tracker-contact subset that cannot answer this question.</p>
+     */
+    public boolean hasRecentAllowedDot(long sinceMs) {
+        flushLogBatch();
+        lock.readLock().lock();
+        try {
+            SQLiteDatabase db = this.getReadableDatabase();
+            try (Cursor cursor = db.rawQuery(
+                    "SELECT 1 FROM log WHERE dport = ? AND allowed = 1 AND time >= ? LIMIT 1",
+                    new String[] { "853", Long.toString(sinceMs) })) {
+                return cursor.moveToFirst();
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     public Cursor searchLog(String find) {
         lock.readLock().lock();
         try {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1239,8 +1239,15 @@ public class ServiceSinkhole extends VpnService {
                 Log.d(TAG, "Found uncertain entry: " + dname);
 
             // Traffic log
-            if (log)
+            if (log) {
                 dh.insertLog(packet, dname, connection, interactive);
+                // The encrypted-DNS warning is evidence-driven. Re-evaluate as
+                // soon as the first allowed DoT flow is recorded rather than
+                // waiting for a later VPN restart or network change.
+                if (packet.allowed && packet.dport == 853 &&
+                        !prefs.getBoolean("block_dot", true))
+                    updatePrivateDnsBypassWarning();
+            }
 
             // Application log
             if (log_app && isTracker && shouldTrackApp(packet.uid) && packet.uid >= 0 &&

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -364,6 +364,13 @@ public class ServiceSinkhole extends VpnService {
     private static final int NOTIFY_WG_ERROR = 12;
     private static final int NOTIFY_LOCAL_NETWORK = 13;
     private static final int NOTIFY_PRIVATE_DNS = 14;
+    private static final int NOTIFY_PRIVATE_DNS_BYPASS = 15;
+
+    static final int PRIVATE_DNS_WARNING_NONE = 0;
+    static final int PRIVATE_DNS_WARNING_HOSTNAME = 1;
+    static final int PRIVATE_DNS_WARNING_ALLOWED_DOT = 2;
+    private static final long PRIVATE_DNS_WARNING_WINDOW_MS = 60 * 60 * 1000L;
+    private int privateDnsWarningState = PRIVATE_DNS_WARNING_NONE;
 
     public static final String EXTRA_COMMAND = "Command";
     private static final String EXTRA_REASON = "Reason";
@@ -927,8 +934,8 @@ public class ServiceSinkhole extends VpnService {
                 // the case it cannot see, a start that failed without ever
                 // producing a tunnel, where stop() finds nothing to notify about.
                 clearWireGuardErrorNotification();
-                // The other two are config warnings nothing else retracts, and
-                // both describe a tunnel that is no longer running — but leave
+                // The other three are config warnings nothing else retracts, and
+                // all describe a tunnel that is no longer running — but leave
                 // them on a temporary stop (a call, say): the VPN is coming
                 // straight back, and re-posting a cancelled notification alerts
                 // again, so the user would be buzzed on every call.
@@ -940,6 +947,9 @@ public class ServiceSinkhole extends VpnService {
 
                 // Stop DoH proxy
                 net.kollnig.missioncontrol.dns.DnsProxyServer.getInstance(ServiceSinkhole.this).stop();
+            }
+            if (!temporary) {
+                resetPrivateDnsBypassWarning();
             }
             if (state == State.enforcing && !temporary) {
                 Log.d(TAG, "Stop foreground state=" + state.toString());
@@ -1772,6 +1782,34 @@ public class ServiceSinkhole extends VpnService {
         }
     }
 
+    static int getPrivateDnsWarningState(Context context) {
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        boolean blockDot = prefs.getBoolean("block_dot", true);
+        if (blockDot)
+            return PRIVATE_DNS_WARNING_NONE;
+
+        // Case A takes precedence and avoids querying the log. Case B is only
+        // meaningful when the full traffic log is enabled: insertLog runs only
+        // on that path. log_app defaults to true but records recognized tracker
+        // contacts in access, not all flows, so it cannot support this warning.
+        if (Util.isPrivateDnsDetectionDefeated(context))
+            return PRIVATE_DNS_WARNING_HOSTNAME;
+        if (!prefs.getBoolean("log", false))
+            return PRIVATE_DNS_WARNING_NONE;
+
+        return DatabaseHelper.getInstance(context).hasRecentAllowedDot(
+                System.currentTimeMillis() - PRIVATE_DNS_WARNING_WINDOW_MS)
+                ? PRIVATE_DNS_WARNING_ALLOWED_DOT : PRIVATE_DNS_WARNING_NONE;
+    }
+
+    static boolean shouldShowPrivateDnsWarning(int previousState, int currentState) {
+        return currentState != PRIVATE_DNS_WARNING_NONE && previousState != currentState;
+    }
+
+    static boolean shouldClearPrivateDnsWarning(int currentState) {
+        return currentState == PRIVATE_DNS_WARNING_NONE;
+    }
+
     private void updateUnderlyingNetworks() {
         // Set underlying network so Android can correctly assess connectivity,
         // metering, and network scoring for the VPN.
@@ -1954,6 +1992,8 @@ public class ServiceSinkhole extends VpnService {
             showPrivateDnsNotification(Util.getPrivateDnsSpecifier(this));
         } else
             clearPrivateDnsNotification();
+
+        updatePrivateDnsBypassWarning();
 
         // Dynamically exclude carrier ePDG IPs so Wi-Fi calling works globally.
         // ePDG domains follow 3GPP standard: epdg.epc.mnc{MNC}.mcc{MCC}.pub.3gppnetwork.org
@@ -3697,6 +3737,8 @@ public class ServiceSinkhole extends VpnService {
                     last_private_dns = private_dns;
                     reloadAfterNetworkChange(reason);
                 }
+                if (vpn != null)
+                    updatePrivateDnsBypassWarning();
             }
 
             @Override
@@ -4389,6 +4431,77 @@ public class ServiceSinkhole extends VpnService {
 
     private void clearPrivateDnsNotification() {
         NotificationManagerCompat.from(this).cancel(NOTIFY_PRIVATE_DNS);
+    }
+
+    private synchronized void updatePrivateDnsBypassWarning() {
+        if (Util.isPrivateDnsBlocked(this)) {
+            clearPrivateDnsBypassNotification();
+            privateDnsWarningState = PRIVATE_DNS_WARNING_NONE;
+            return;
+        }
+
+        // The loud warning may have been posted by an earlier evaluation before
+        // the user changed block_dot; keep the two notification IDs exclusive.
+        clearPrivateDnsNotification();
+        int state = getPrivateDnsWarningState(this);
+        if (shouldClearPrivateDnsWarning(state)) {
+            clearPrivateDnsBypassNotification();
+            privateDnsWarningState = PRIVATE_DNS_WARNING_NONE;
+        } else {
+            if (shouldShowPrivateDnsWarning(privateDnsWarningState, state))
+                showPrivateDnsBypassNotification(state);
+            privateDnsWarningState = state;
+        }
+    }
+
+    private synchronized void resetPrivateDnsBypassWarning() {
+        clearPrivateDnsBypassNotification();
+        privateDnsWarningState = PRIVATE_DNS_WARNING_NONE;
+    }
+
+    private void showPrivateDnsBypassNotification(int state) {
+        Intent settings;
+        if (state == PRIVATE_DNS_WARNING_ALLOWED_DOT)
+            settings = new Intent(this, ActivitySettings.class);
+        else {
+            settings = new Intent(Settings.ACTION_WIRELESS_SETTINGS);
+            if (settings.resolveActivity(getPackageManager()) == null)
+                settings = new Intent(Settings.ACTION_WIFI_SETTINGS);
+        }
+        PendingIntent pi = PendingIntentCompat.getActivity(this, NOTIFY_PRIVATE_DNS_BYPASS, settings,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String detail;
+        if (state == PRIVATE_DNS_WARNING_HOSTNAME) {
+            String specifier = Util.getPrivateDnsSpecifier(this);
+            String resolver = TextUtils.isEmpty(specifier)
+                    ? getString(R.string.msg_private_dns_unknown_resolver) : specifier;
+            detail = getString(R.string.msg_private_dns_bypass_notify, resolver);
+        } else
+            detail = getString(R.string.msg_private_dns_bypass_allowed_notify);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "notify");
+        builder.setSmallIcon(R.drawable.ic_error_white_24dp)
+                .setContentTitle(getString(R.string.msg_private_dns_bypass_title))
+                .setContentText(detail)
+                .setContentIntent(pi)
+                .setColor(getResources().getColor(R.color.colorTrackerControl))
+                .setOngoing(false)
+                .setAutoCancel(true)
+                .setOnlyAlertOnce(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+
+        NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
+        notification.bigText(detail);
+
+        Util.notify(this, NOTIFY_PRIVATE_DNS_BYPASS, notification.build());
+    }
+
+    private void clearPrivateDnsBypassNotification() {
+        NotificationManagerCompat.from(this).cancel(NOTIFY_PRIVATE_DNS_BYPASS);
     }
 
     private void showUpdateNotification(String name, String url) {

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -586,6 +586,16 @@ public class Util {
                 && isPrivateDnsHostnameMode(context);
     }
 
+    /**
+     * Whether a pinned Private DNS resolver can bypass tracker detection because
+     * DoT blocking is disabled.
+     */
+    public static boolean isPrivateDnsDetectionDefeated(Context context) {
+        return !PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean("block_dot", true)
+                && isPrivateDnsHostnameMode(context);
+    }
+
     public interface DoubtListener {
         void onSure();
     }

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -84,6 +84,21 @@
         android:textColor="?attr/colorOff"
         android:visibility="gone" />
 
+    <TextView
+        android:id="@+id/tvPrivateDnsBypass"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawableStart="@drawable/ic_warning_amber"
+        android:drawablePadding="8dp"
+        android:drawableTint="?attr/colorError"
+        android:padding="8dp"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingEnd="@dimen/activity_horizontal_margin"
+        android:text="@string/msg_private_dns_bypass_allowed_notify"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="?attr/colorOff"
+        android:visibility="gone" />
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -737,6 +737,10 @@ Sincerely,\n\n]]></string>
     <string name="msg_private_dns_unknown_resolver">a custom resolver</string>
     <string name="msg_private_dns_row">Nothing will load: Android\'s \"Private DNS\" is set to a specific resolver, and TrackerControl blocks encrypted DNS so it can detect trackers. Tap to set Private DNS to \"Automatic\" or \"Off\" — TrackerControl offers its own Secure DNS in Settings.</string>
 
+    <string name="msg_private_dns_bypass_title">Private DNS bypasses tracker detection</string>
+    <string name="msg_private_dns_bypass_notify">Tracker detection is off: DNS is encrypted to %1$s, so app connections can\'t be analysed</string>
+    <string name="msg_private_dns_bypass_allowed_notify">Some apps are using encrypted DNS; their tracker contacts are invisible to TrackerControl.</string>
+
     <string name="setting_monitor_system">Monitor system apps</string>
     <string name="summary_monitor_system">Route system apps (Play Services, carrier services, etc.) through the VPN so their trackers are detected and blocked, and show them in the app list.\n\nOff by default: excluding system apps is friendlier to battery, because their background traffic no longer wakes the VPN. Turning this on conflicts with \"Block connections without VPN\" in the Android VPN settings, which must be DISABLED.</string>
 

--- a/app/src/test/java/eu/faircode/netguard/PrivateDnsWarningTest.java
+++ b/app/src/test/java/eu/faircode/netguard/PrivateDnsWarningTest.java
@@ -1,0 +1,127 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.provider.Settings;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+/** Focused tests for the silent Private DNS bypass warnings. */
+@RunWith(RobolectricTestRunner.class)
+public class PrivateDnsWarningTest {
+    private Context context;
+    private SharedPreferences prefs;
+    private DatabaseHelper database;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        prefs = PreferenceManager.getDefaultSharedPreferences(context);
+        prefs.edit().clear().commit();
+        setPrivateDns("off", null);
+
+        database = DatabaseHelper.getInstance(context);
+        database.clearLog(-1);
+    }
+
+    private void setPrivateDns(String mode, String specifier) {
+        Settings.Global.putString(context.getContentResolver(), "private_dns_mode", mode);
+        Settings.Global.putString(context.getContentResolver(), "private_dns_specifier", specifier);
+    }
+
+    @Test
+    public void hostnameAndBlockDotCombinations() {
+        String[] modes = { "off", "opportunistic", "hostname" };
+        for (String mode : modes)
+            for (boolean blockDot : new boolean[] { false, true }) {
+                setPrivateDns(mode, "hostname".equals(mode) ? "dns.google" : null);
+                prefs.edit().putBoolean("block_dot", blockDot).commit();
+
+                boolean hostnameWithoutBlocking = "hostname".equals(mode) && !blockDot;
+                assertEquals(hostnameWithoutBlocking,
+                        Util.isPrivateDnsDetectionDefeated(context));
+                assertEquals(hostnameWithoutBlocking
+                                ? ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME
+                                : ServiceSinkhole.PRIVATE_DNS_WARNING_NONE,
+                        ServiceSinkhole.getPrivateDnsWarningState(context));
+            }
+    }
+
+    @Test
+    public void hostnameWarningTakesPrecedenceOverAllowedDotFlow() {
+        long now = System.currentTimeMillis();
+        database.insertLog(packet(now, 853, true), null, 0, false);
+
+        setPrivateDns("hostname", "dns.google");
+        prefs.edit().putBoolean("block_dot", false).putBoolean("log", true).commit();
+
+        assertEquals(ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME,
+                ServiceSinkhole.getPrivateDnsWarningState(context));
+    }
+
+    @Test
+    public void allowedDotWarningRequiresTrafficLog() {
+        long now = System.currentTimeMillis();
+        database.insertLog(packet(now, 853, true), null, 0, false);
+        setPrivateDns("opportunistic", null);
+        prefs.edit().putBoolean("block_dot", false).commit();
+
+        assertEquals(ServiceSinkhole.PRIVATE_DNS_WARNING_NONE,
+                ServiceSinkhole.getPrivateDnsWarningState(context));
+
+        prefs.edit().putBoolean("log", true).commit();
+        assertEquals(ServiceSinkhole.PRIVATE_DNS_WARNING_ALLOWED_DOT,
+                ServiceSinkhole.getPrivateDnsWarningState(context));
+    }
+
+    @Test
+    public void allowedDotQueryRequiresRecentAllowedFlow() {
+        long now = System.currentTimeMillis();
+        database.insertLog(packet(now - 2 * 60 * 60 * 1000L, 853, true), null, 0, false);
+        database.insertLog(packet(now, 853, false), null, 0, false);
+        database.insertLog(packet(now, 443, true), null, 0, false);
+
+        assertFalse(database.hasRecentAllowedDot(now - 60 * 60 * 1000L));
+
+        database.insertLog(packet(now, 853, true), null, 0, false);
+        assertTrue(database.hasRecentAllowedDot(now - 60 * 60 * 1000L));
+    }
+
+    @Test
+    public void warningShowsAndClearsOnlyOnStateTransitions() {
+        assertTrue(ServiceSinkhole.shouldShowPrivateDnsWarning(
+                ServiceSinkhole.PRIVATE_DNS_WARNING_NONE,
+                ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME));
+        assertFalse(ServiceSinkhole.shouldShowPrivateDnsWarning(
+                ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME,
+                ServiceSinkhole.PRIVATE_DNS_WARNING_HOSTNAME));
+        assertTrue(ServiceSinkhole.shouldClearPrivateDnsWarning(
+                ServiceSinkhole.PRIVATE_DNS_WARNING_NONE));
+        assertFalse(ServiceSinkhole.shouldClearPrivateDnsWarning(
+                ServiceSinkhole.PRIVATE_DNS_WARNING_ALLOWED_DOT));
+    }
+
+    private static Packet packet(long time, int dport, boolean allowed) {
+        Packet packet = new Packet();
+        packet.time = time;
+        packet.version = 4;
+        packet.protocol = 6;
+        packet.saddr = "10.0.0.2";
+        packet.sport = 12345;
+        packet.daddr = "1.1.1.1";
+        packet.dport = dport;
+        packet.allowed = allowed;
+        packet.flags = "";
+        return packet;
+    }
+}


### PR DESCRIPTION
### Motivation

Encrypted DNS can silently bypass TrackerControl's DNS-based detection when DoT is used while DoT blocking is disabled. Users should be warned as soon as evidence of that bypass appears, without adding periodic work.

### Description

- Add evidence-ordered Private DNS bypass warning states for hostname mode and observed allowed DoT.
- Show the warning in the main-screen banner and a transition-based notification.
- Gate observed-DoT detection on the full traffic log and recent allowed port-853 evidence.
- Re-evaluate the warning immediately when an allowed DoT flow is logged, rather than waiting for VPN establishment or a network change.
- Add Robolectric coverage for mode combinations, precedence, log gating, recency, and transitions.

### Testing

- `git diff --check` (passed)
- `./gradlew :app:testGithubDebugUnitTest --tests 'eu.faircode.netguard.PrivateDnsWarningTest' -q` (environment limitation: Android SDK is not configured)
- `./gradlew :app:compileGithubDebugJavaWithJavac -q` (environment limitation: Android SDK is not configured)
