### PR TITLE
Migrate Crowdin synchronization to GitHub Actions

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,64 @@
+name: Synchronize Crowdin translations
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - app/src/main/res/values/strings.xml
+      - fastlane/metadata/android/en-US/full_description.txt
+      - fastlane/metadata/android/en-US/short_description.txt
+  schedule:
+    - cron: '17 3 * * *'
+  workflow_dispatch:
+    inputs:
+      upload_sources:
+        description: Upload the master source files before downloading translations
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: crowdin-l10n-crowdin-translations
+  cancel-in-progress: false
+
+jobs:
+  synchronize:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'push' && github.sha || 'master' }}
+
+      - name: Synchronize with Crowdin
+        uses: crowdin/github-action@v3
+        with:
+          crowdin_branch_name: master
+          # Source pushes upload first and then download; scheduled/manual
+          # runs are download-only by default so stale checkout sources never
+          # overwrite Crowdin.
+          upload_sources: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.upload_sources) }}
+          upload_translations: false
+          download_sources: false
+          download_translations: true
+          push_sources: false
+          push_translations: true
+          localization_branch_name: l10n_crowdin_translations
+          commit_message: Update translations from Crowdin
+          create_pull_request: true
+          pull_request_title: New Crowdin translations (GitHub Action)
+          pull_request_body: |
+            Automated translation update from Crowdin.
+
+            The PR targets `master` and uses the dedicated
+            `l10n_crowdin_translations` branch so its output can be compared
+            with the native Crowdin integration.
+          pull_request_base_branch_name: master
+          skip_ref_checkout: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -18,7 +18,7 @@ on:
         type: boolean
 
 concurrency:
-  group: crowdin-l10n-crowdin-translations
+  group: crowdin-l10n-master
   cancel-in-progress: false
 
 jobs:
@@ -46,16 +46,15 @@ jobs:
           download_translations: true
           push_sources: false
           push_translations: true
-          localization_branch_name: l10n_crowdin_translations
+          localization_branch_name: l10n_master
           commit_message: Update translations from Crowdin
           create_pull_request: true
-          pull_request_title: New Crowdin translations (GitHub Action)
+          pull_request_title: New Crowdin translations
           pull_request_body: |
             Automated translation update from Crowdin.
 
-            The PR targets `master` and uses the dedicated
-            `l10n_crowdin_translations` branch so its output can be compared
-            with the native Crowdin integration.
+            The PR targets `master` and continues using the existing
+            `l10n_master` localization branch from the native integration.
           pull_request_base_branch_name: master
           skip_ref_checkout: true
         env:

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,7 @@
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
+
 files:
   - source: /app/src/main/res/values/strings.xml
     translation: /app/src/main/res/values-%android_code%/strings.xml


### PR DESCRIPTION
## Summary
- migrate Crowdin synchronization from the native GitHub integration to crowdin/github-action@v3
- preserve the existing Android and Fastlane translation mappings
- retain the existing l10n_master localization branch
- use scoped Actions permissions and repository secrets for Crowdin credentials

## Validation
- Ruby YAML and workflow assertions
- git diff --check

## Rollout
Merge the outstanding native translation PR first, disable the native Crowdin integration, then merge this PR and manually dispatch one download-only synchronization.