### PR TITLE
Allow reviewed repository translations to sync to Crowdin

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -17,7 +17,7 @@ on:
         default: false
         type: boolean
       upload_translations:
-        description: One-time migration import of existing repository translations
+        description: Import reviewed repository translations into Crowdin before downloading
         required: false
         default: false
         type: boolean

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      upload_translations:
+        description: One-time migration import of existing repository translations
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: crowdin-l10n-master
@@ -41,7 +46,7 @@ jobs:
           # runs are download-only by default so stale checkout sources never
           # overwrite Crowdin.
           upload_sources: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.upload_sources) }}
-          upload_translations: false
+          upload_translations: ${{ github.event_name == 'workflow_dispatch' && inputs.upload_translations }}
           download_sources: false
           download_translations: true
           push_sources: false


### PR DESCRIPTION
## Summary
- add an opt-in manual input for uploading reviewed repository translations to Crowdin
- keep scheduled and source-triggered synchronization behavior unchanged
- default repository-to-Crowdin translation uploads to off

## Why
The first Action export removed 742 entries whose keys still exist in the source, including 22 recent protection and WireGuard-routing translations across most locales. Those translations were added directly to the repository and had never been imported into Crowdin.

This keeps synchronization controlled but bidirectional: Crowdin exports automatically, while reviewed repository or AI translations can be imported explicitly before downloading.

## Validation
- Ruby YAML and workflow assertions
- git diff --check