### PR TITLE
Define the tc-dns C ABI in the wgbridge cdylib crate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,10 +61,9 @@ jobs:
 
       - name: Run Rust unit tests
         run: |
-          cargo test --manifest-path wgbridge-rs/Cargo.toml --locked --offline
-          # The capi feature gates the C ABI the NetGuard engine calls; its
-          # FFI-boundary tests only compile with the feature enabled.
-          cargo test --manifest-path wgbridge-rs/Cargo.toml -p tc-dns --features capi --locked --offline
+          # Covers the whole workspace, including the FFI-boundary tests for
+          # the C ABI the NetGuard engine calls (wgbridge-rs/tests/).
+          cargo test --manifest-path wgbridge-rs/Cargo.toml --workspace --locked --offline
 
       - name: Run DNS-over-TCP framing host tests
         run: |

--- a/agents/docs/build-and-test.md
+++ b/agents/docs/build-and-test.md
@@ -45,7 +45,6 @@ configuration, especially WireGuard profiles and the Mullvad login — see
 
 ```bash
 cd wgbridge-rs && cargo test --workspace
-cd wgbridge-rs && cargo test -p tc-dns --features capi
 ```
 
 ## Native code builds automatically with the app

--- a/app/gradle/wgbridge.gradle
+++ b/app/gradle/wgbridge.gradle
@@ -214,15 +214,18 @@ tasks.register('wgbridgeBuild') {
             }
         }
 
-        // tc-dns is an rlib dependency of the wgbridge cdylib; its
-        // #[no_mangle] pub extern "C" symbols (tcdns_process_response,
-        // tcdns_abi_version — see app/src/main/jni/netguard/tcdns.h) only
-        // reach libwgbridge.so because rustc currently chooses to keep them.
-        // libnetguard.so links against libwgbridge.so for these symbols (the
-        // IMPORTED_NO_SONAME wgbridge target in app/CMakeLists.txt), so a
-        // future LTO / --gc-sections / rustc change that drops the re-export
-        // would silently build but fail at runtime with an
-        // UnsatisfiedLinkError. Catch that here instead.
+        // wgbridge-rs/src/tcdns_capi.rs defines the #[no_mangle] pub extern
+        // "C" symbols (tcdns_process_response, tcdns_abi_version — see
+        // app/src/main/jni/netguard/tcdns.h) in the cdylib crate itself, so
+        // rustc exports them by construction. libnetguard.so links against
+        // libwgbridge.so for them (the IMPORTED_NO_SONAME wgbridge target in
+        // app/CMakeLists.txt) and calls them without a null check, so a future
+        // LTO / --gc-sections change that dropped one would silently build but
+        // fail at runtime with an UnsatisfiedLinkError. Catch that here.
+        //
+        // tc_policy_* deliberately stay out of this list: policy.c resolves
+        // them with dlsym and degrades to a conservative all-tunnel policy when
+        // they are absent, so a missing symbol there is survivable by design.
         def requiredTcdnsSymbols = ['tcdns_process_response', 'tcdns_abi_version']
         def llvmNm = "${findNdkDirectory().absolutePath}/toolchains/llvm/prebuilt/${hostTag}/bin/llvm-nm"
         wgbridgeAbis.each { abi ->
@@ -241,14 +244,14 @@ tasks.register('wgbridgeBuild') {
                 if (!exportedSymbols.contains(symbol)) {
                     throw new GradleException("""
                         libwgbridge.so ($abi) is missing the expected dynamic
-                        symbol `$symbol` from the tc-dns crate. libnetguard.so
-                        has a hard runtime dependency on this symbol (see
+                        symbol `$symbol`. libnetguard.so has a hard runtime
+                        dependency on this symbol (see
                         app/src/main/jni/netguard/tcdns.h); without it the app
                         will crash with UnsatisfiedLinkError on device.
                         This likely means a linker/LTO/rustc change stopped
-                        re-exporting tc-dns's #[no_mangle] symbols through the
-                        wgbridge cdylib — check wgbridge-rs/Cargo.toml and
-                        wgbridge-rs/tc-dns for crate-type / visibility changes.
+                        exporting the #[no_mangle] symbols defined in
+                        wgbridge-rs/src/tcdns_capi.rs — check that file and
+                        the crate-type in wgbridge-rs/Cargo.toml.
                     """.stripIndent())
                 }
             }

--- a/wgbridge-rs/Cargo.toml
+++ b/wgbridge-rs/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 crate-type = ["cdylib", "lib"]
 
 [dependencies]
-tc-dns = { path = "tc-dns", features = ["capi"] }
+tc-dns = { path = "tc-dns" }
 gotatun = { version = "=0.9.0", default-features = false, features = ["ring", "device"] }
 tokio = { version = "1.43", features = ["rt-multi-thread", "net", "sync", "time", "macros"] }
 base64 = "0.23"

--- a/wgbridge-rs/README.md
+++ b/wgbridge-rs/README.md
@@ -4,7 +4,9 @@ This directory is a Cargo workspace with two members:
 
 - `wgbridge`, the Android WireGuard bridge described below;
 - `tc-dns`, the dependency-free DNS message parser and response-policy core
-  shared by the WireGuard and NetGuard C paths.
+  shared by the WireGuard and NetGuard C paths. It is pure safe Rust; the C ABI
+  the NetGuard engine calls lives in `wgbridge` (`src/tcdns_capi.rs`) so the
+  cdylib itself defines those exported symbols.
 
 A small Rust crate that lets TrackerControl run [gotatun] — Mullvad's
 WireGuard® implementation, a fork of Cloudflare's BoringTun — inside its own
@@ -93,7 +95,6 @@ key derivation) run on the host:
 
 ```bash
 cargo test --workspace
-cargo test -p tc-dns --features capi
 ```
 
 ## F-Droid build metadata
@@ -134,6 +135,21 @@ missing.
 
 These are exported from the `cdylib` and survive `strip = true`; CI asserts they
 are present in every ABI of the F-Droid APK.
+
+`src/tcdns_capi.rs` exports the DNS half of the surface, declared in
+`jni/netguard/tcdns.h`. Unlike `tc_policy_*`, `libnetguard.so` links these
+(the `IMPORTED_NO_SONAME` `wgbridge` target in `app/CMakeLists.txt`) and calls
+them with no fallback, so `wgbridgeBuild` fails the build if `llvm-nm` cannot
+find them.
+
+| Symbol | Purpose |
+|---|---|
+| `tcdns_abi_version()` | Guards the callback table against a mismatched library; currently `1`. |
+| `tcdns_process_response(data, len, callbacks, ctx)` | Records A/AAAA answers and applies the blanking policy to one bare DNS message in place. Returns the new length, or `SIZE_MAX` when unchanged. |
+
+The module keeps the `deny(unwrap_used, expect_used, panic, indexing_slicing)`
+lints that `tc-dns` applies crate-wide: the release profile builds with
+`panic = "abort"`, so a panic across the FFI boundary aborts the app.
 
 ## Java/Kotlin API surface
 

--- a/wgbridge-rs/src/lib.rs
+++ b/wgbridge-rs/src/lib.rs
@@ -21,6 +21,10 @@ pub mod config;
 pub mod dns;
 pub mod keys;
 pub mod policy;
+// The C ABI the NetGuard engine links against. It lives in this crate, not
+// in tc-dns, so the cdylib itself defines the exported symbols rather than
+// inheriting them from an rlib dependency (see app/gradle/wgbridge.gradle).
+pub mod tcdns_capi;
 pub mod transport;
 pub mod tunnel;
 

--- a/wgbridge-rs/src/tcdns_capi.rs
+++ b/wgbridge-rs/src/tcdns_capi.rs
@@ -2,9 +2,22 @@
 //! path. The caller owns the message buffer; callback strings are owned by
 //! this library and remain valid only for the duration of their callback.
 
+// Carried over from tc-dns, which denies these crate-wide: this module holds
+// the FFI boundary, and the C contract requires it never to panic (the Android
+// release profile builds with `panic = "abort"`).
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::panic,
+        clippy::indexing_slicing
+    )
+)]
+
 use std::ffi::{c_char, c_void, CString};
 
-use crate::{process_response, DnsPolicy, Outcome};
+use tcdns::{process_response, DnsPolicy, Outcome};
 
 pub const TCDNS_ABI_VERSION: u32 = 1;
 pub const TCDNS_UNCHANGED: usize = usize::MAX;

--- a/wgbridge-rs/tc-dns/Cargo.toml
+++ b/wgbridge-rs/tc-dns/Cargo.toml
@@ -7,8 +7,3 @@ publish = false
 
 [lib]
 name = "tcdns"
-crate-type = ["lib", "staticlib"]
-
-[features]
-default = []
-capi = []

--- a/wgbridge-rs/tc-dns/src/lib.rs
+++ b/wgbridge-rs/tc-dns/src/lib.rs
@@ -71,6 +71,3 @@ fn apply_parsed(msg: &mut [u8], parsed: message::DnsMessage, policy: &dyn DnsPol
         rcode,
     }
 }
-
-#[cfg(feature = "capi")]
-pub mod capi;

--- a/wgbridge-rs/tests/tcdns_capi.rs
+++ b/wgbridge-rs/tests/tcdns_capi.rs
@@ -1,9 +1,8 @@
-#![cfg(feature = "capi")]
 
 use std::ffi::{c_char, c_void, CStr};
 use std::mem::{offset_of, size_of};
 
-use tcdns::capi::{
+use wgbridge::tcdns_capi::{
     tcdns_abi_version, tcdns_process_response, BlockedRcode, IsDomainBlocked, OnBlanked,
     RecordAnswer, TcdnsCallbacks, TCDNS_ABI_VERSION, TCDNS_UNCHANGED,
 };


### PR DESCRIPTION
## Problem

`tcdns_process_response` and `tcdns_abi_version` were `#[no_mangle]` items in `tc-dns`, an rlib dependency that `wgbridge` never calls — `src/dns.rs` uses only the safe API (`apply_policy`, `process_response`, `record_answers`). They reached `libwgbridge.so` purely because rustc propagates `#[no_mangle]` from rlibs into a cdylib. That holds today, but it is not a promise, and `app/gradle/wgbridge.gradle` carried an `llvm-nm` check specifically to catch the day it stops.

That guarantee matters more for these two than for the neighbouring `tc_policy_*` symbols:

- `policy.c:56` resolves `tc_policy_*` with `dlopen`/`dlsym` and, when they are missing, sets `policy_ok = 0` and pins a conservative all-tunnel policy — survivable by design.
- `libnetguard.so` links `tcdns_*` through CMake (`target_link_libraries(netguard … wgbridge)`) and calls them directly at `dns.c:104` and `netguard.c:82` with no null check — absence is an `UnsatisfiedLinkError` at load.

So the family with no safety net was the one relying on the weaker guarantee.

## Change

Move `tc-dns/src/capi.rs` to `wgbridge-rs/src/tcdns_capi.rs`, so the cdylib crate defines the symbols itself, alongside `tc_policy_*`. Consequences:

- `tc-dns` becomes pure safe Rust; its `capi` feature and `staticlib` crate-type are dropped (nothing built the staticlib).
- The FFI-boundary tests move to `wgbridge-rs/tests/tcdns_capi.rs`, where the default `cargo test --workspace` covers them, so CI no longer needs a second feature-gated invocation.
- The module carries over the `deny(unwrap_used, expect_used, panic, indexing_slicing)` lints `tc-dns` applies crate-wide — the release profile builds with `panic = "abort"`, so a panic across the FFI boundary aborts the app.
- The Gradle symbol check is kept as belt-and-braces, with its comment updated to record why `tc_policy_*` deliberately stays out of the list.

No behaviour change: `tcdns.h`, the ABI version, and the call sites are untouched.

## Verification

- `llvm-nm --defined-only --dynamic` on the built cdylib reports exactly the same seven exports before and after (`tc_policy_*` ×5, `tcdns_abi_version`, `tcdns_process_response`).
- `cargo test --manifest-path wgbridge-rs/Cargo.toml --workspace --locked --offline` — 68 tests pass, including the 3 relocated FFI tests. `Cargo.lock` is unchanged.
- Host builds only; the C, Java and CMake sides are untouched, and the Gradle edits are comments.

## Note for the reviewer

Also measured, and rejected: giving `tc-dns` its own cdylib would remove the dependency on the re-export entirely, but a standalone `libtcdns.so` is ~315 KB against ~329 KB for all of `libwgbridge.so` including gotatun and tokio — essentially a second copy of the Rust std floor, ~1.2 MB across the four ABIs. `wgbridge-rs/README.md` already argues against that, and the numbers back it.

---
_Generated by [Claude Code](https://claude.ai/code/session_012KTJg2U859qc5X7bEXSsNX)_