### PR TITLE
Block DNS-over-TCP responses split across socket reads

### DIFF
--- a/app/gradle/wgbridge.gradle
+++ b/app/gradle/wgbridge.gradle
@@ -215,9 +215,11 @@ tasks.register('wgbridgeBuild') {
         }
 
         // wgbridge-rs/src/tcdns_capi.rs defines the #[no_mangle] pub extern
-        // "C" symbols (tcdns_process_response, tcdns_abi_version — see
-        // app/src/main/jni/netguard/tcdns.h) in the cdylib crate itself, so
-        // rustc exports them by construction. libnetguard.so links against
+        // "C" symbols (tcdns_process_response, tcdns_process_partial_response,
+        // tcdns_abi_version — see app/src/main/jni/netguard/tcdns.h) in the
+        // cdylib crate itself, so rustc exports them by construction. Every
+        // symbol tcdns.h declares belongs in the list below: a new export that
+        // is not listed is unguarded. libnetguard.so links against
         // libwgbridge.so for them (the IMPORTED_NO_SONAME wgbridge target in
         // app/CMakeLists.txt) and calls them without a null check, so a future
         // LTO / --gc-sections change that dropped one would silently build but
@@ -226,7 +228,9 @@ tasks.register('wgbridgeBuild') {
         // tc_policy_* deliberately stay out of this list: policy.c resolves
         // them with dlsym and degrades to a conservative all-tunnel policy when
         // they are absent, so a missing symbol there is survivable by design.
-        def requiredTcdnsSymbols = ['tcdns_process_response', 'tcdns_abi_version']
+        def requiredTcdnsSymbols = ['tcdns_process_response',
+                                    'tcdns_process_partial_response',
+                                    'tcdns_abi_version']
         def llvmNm = "${findNdkDirectory().absolutePath}/toolchains/llvm/prebuilt/${hostTag}/bin/llvm-nm"
         wgbridgeAbis.each { abi ->
             def lib = file("$wgbridgeOutDir/$abi/libwgbridge.so")

--- a/app/src/main/jni/netguard/dns.c
+++ b/app/src/main/jni/netguard/dns.c
@@ -105,3 +105,13 @@ void parse_dns_response(const struct arguments *args, const struct ng_session *s
     if (new_len != TCDNS_UNCHANGED)
         *datalen = new_len;
 }
+
+void parse_dns_partial_response(const struct arguments *args, const struct ng_session *s,
+                                uint8_t *data, size_t *datalen, int *blanked) {
+    struct tcdns_ctx ctx = { .args = args, .s = s };
+    tcdns_callbacks cb = TCDNS_CALLBACKS_INIT;
+    *blanked = 0;
+    size_t result = tcdns_process_partial_response(data, *datalen, &cb, &ctx);
+    if (result != TCDNS_UNCHANGED)
+        *blanked = 1;
+}

--- a/app/src/main/jni/netguard/dns_frame.c
+++ b/app/src/main/jni/netguard/dns_frame.c
@@ -38,8 +38,12 @@ size_t dns_frame_process_stream(uint8_t *buffer, size_t bytes,
         size_t remaining = end - cursor;
         size_t skip = (state->frame_remaining < remaining
                        ? (size_t) state->frame_remaining : remaining);
+        if (state->blank_remaining != 0 && skip > 0)
+            memset(buffer + cursor, 0, skip);
         state->frame_remaining -= (uint32_t) skip;
         cursor += skip;
+        if (state->frame_remaining == 0)
+            state->blank_remaining = 0;
         if (cursor >= end)
             return end;
     }
@@ -56,13 +60,16 @@ size_t dns_frame_process_stream(uint8_t *buffer, size_t bytes,
 
         size_t avail = end - cursor;
         if (frame_len > avail) {
+            int blank_rest = 0;
             if (avail > 0)
-                (void) parse(ctx, buffer + cursor, avail);
+                (void) parse(ctx, buffer + cursor, avail, 1, &blank_rest);
             state->frame_remaining = (uint32_t) (frame_len - avail);
+            state->blank_remaining = (uint8_t) (blank_rest != 0);
             return end;
         }
         if (frame_len > 0) {
-            (void) parse(ctx, buffer + cursor, frame_len); // shrink ignored
+            int blank_rest = 0;
+            (void) parse(ctx, buffer + cursor, frame_len, 1, &blank_rest); // shrink ignored
             cursor += frame_len;
         }
     }
@@ -92,15 +99,18 @@ size_t dns_frame_process_stream(uint8_t *buffer, size_t bytes,
         if (frame_len > avail) {
             // Frame runs past this read: parse what is visible (blanking only,
             // any shrink is ignored) and remember the overflow.
+            int blank_rest = 0;
             if (avail > 0)
-                (void) parse(ctx, buffer + cursor, avail);
+                (void) parse(ctx, buffer + cursor, avail, 1, &blank_rest);
             state->frame_remaining = (uint32_t) (frame_len - avail);
+            state->blank_remaining = (uint8_t) (blank_rest != 0);
             return end;
         }
 
         // Complete frame, prefix and payload both inside this buffer: nothing
         // here has been forwarded yet, so it may be shortened.
-        size_t new_dlen = parse(ctx, buffer + cursor, frame_len);
+        int blank_rest = 0;
+        size_t new_dlen = parse(ctx, buffer + cursor, frame_len, 0, &blank_rest);
         if (new_dlen > frame_len)
             new_dlen = frame_len; // defensive: a parser must never grow a frame
 

--- a/app/src/main/jni/netguard/dns_frame.h
+++ b/app/src/main/jni/netguard/dns_frame.h
@@ -44,7 +44,19 @@
  * enforcement for such split frames therefore remains best-effort: once the
  * answer section is cut short, per-answer detection stops at the truncation
  * point and SVCB-triggered blanking is unavailable, leaving the domain of the
- * question as the only signal the block decision can use.
+ * question as the only signal the block decision can use. That signal needs the
+ * header and the whole question inside the visible bytes, so a read split
+ * within the first few bytes of a response blocks nothing at all and the frame
+ * passes through intact.
+ *
+ * A blanked split frame keeps its original 2-byte length prefix, so what
+ * reaches the client is a DNS message with all three counts cleared followed by
+ * zero bytes out to the declared length. Clients that walk the counts (the
+ * common case) stop after the question and ignore the tail; a client that
+ * insists the message fill its frame exactly may instead call it malformed. The
+ * domain is blocked either way, so the cost of that is a noisier failure and
+ * never a leaked address. Only the fully-contained-frame path can avoid the
+ * padding, by shrinking the frame outright.
  *
  * Length rewrites (a blocking hit that shortens a DNS message) are applied
  * only to a frame whose 2-byte prefix *and* whole payload lie inside the

--- a/app/src/main/jni/netguard/dns_frame.h
+++ b/app/src/main/jni/netguard/dns_frame.h
@@ -38,9 +38,13 @@
  * buffer and carries enough state to stay aligned into the next call without
  * buffering stream bytes. A frame is offered to the DNS parser only in the
  * recv() where its prefix is completed. If its payload continues into later
- * reads, only the bytes visible in that first call are parsed; continuation
- * bytes are skipped because they no longer include the DNS header. Policy
- * enforcement for such split frames therefore remains best-effort.
+ * reads, only the bytes visible in that first call are parsed; the parser is
+ * told that the frame is partial, and a blocking result causes the visible
+ * answer tail and all later continuation bytes to be zeroed in place. Policy
+ * enforcement for such split frames therefore remains best-effort: once the
+ * answer section is cut short, per-answer detection stops at the truncation
+ * point and SVCB-triggered blanking is unavailable, leaving the domain of the
+ * question as the only signal the block decision can use.
  *
  * Length rewrites (a blocking hit that shortens a DNS message) are applied
  * only to a frame whose 2-byte prefix *and* whole payload lie inside the
@@ -48,9 +52,10 @@
  * shrinking such a frame is sequence-safe, and the frames behind it are
  * memmove()d down. A frame whose prefix or payload carries over from an earlier
  * recv() can never be shortened because bytes committed earlier cannot be
- * taken back. When the prefix alone was split, its payload may still be parsed
- * and mutated in place; when the payload was split, later continuation bytes
- * are forwarded untouched.
+ * taken back. When the prefix alone was split, its payload is parsed as
+ * partial and may be mutated in place; when the payload was split, the
+ * blanking decision is carried to later continuation bytes, which are zeroed
+ * as they pass through.
  */
 
 #include <stddef.h>
@@ -69,6 +74,7 @@ struct dns_stream_state {
     uint32_t frame_remaining; /* payload bytes of the current frame whose prefix
                                  was seen in an earlier recv() and whose earlier
                                  bytes were already forwarded */
+    uint8_t blank_remaining;  /* zero continuation bytes while this is set */
     uint8_t prefix_hi;        /* stashed first byte of a length prefix split
                                  across recv()s */
     uint8_t have_prefix_hi;   /* nonzero when prefix_hi is valid */
@@ -76,11 +82,15 @@ struct dns_stream_state {
 
 /*
  * Called for each DNS payload (or the visible part of one) found in the
- * buffer; stands in for parse_dns_response(). Returns the possibly-shrunk
- * payload length; a return > dlen must be treated by the caller as
- * "unchanged" (defensive clamp).
+ * buffer; stands in for parse_dns_response(). partial != 0 means the frame is
+ * not wholly inside this buffer, so the callback must not shrink it. On a
+ * partial call, *blank_rest is set nonzero when the callback blanked the
+ * visible part and the caller must blank the frame's later continuation bytes.
+ * Returns the possibly-shrunk payload length for a complete frame; a return
+ * > dlen must be treated by the caller as "unchanged" (defensive clamp).
  */
-typedef size_t (*dns_frame_parse_fn)(void *ctx, uint8_t *data, size_t dlen);
+typedef size_t (*dns_frame_parse_fn)(void *ctx, uint8_t *data, size_t dlen,
+                                     int partial, int *blank_rest);
 
 /*
  * Processes one recv() buffer of a DNS-over-TCP stream in place.

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -412,6 +412,10 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
 void parse_dns_response(const struct arguments *args, const struct ng_session *session,
                         uint8_t *data, size_t *datalen);
 
+void parse_dns_partial_response(const struct arguments *args,
+                                const struct ng_session *session,
+                                uint8_t *data, size_t *datalen, int *blanked);
+
 uint32_t get_send_window(const struct tcp_session *cur);
 
 uint32_t get_receive_buffer(const struct ng_session *cur);

--- a/app/src/main/jni/netguard/tcdns.h
+++ b/app/src/main/jni/netguard/tcdns.h
@@ -54,6 +54,15 @@ _Static_assert(offsetof(tcdns_callbacks, log) == (sizeof(void *) == 8 ? 40 : 20)
 size_t tcdns_process_response(uint8_t *data, size_t len,
                                const tcdns_callbacks *cb, void *ctx);
 
+/*
+ * Processes the visible prefix of a DNS-over-TCP message in place. The
+ * caller must not shrink the buffer on a non-TCDNS_UNCHANGED return. A return
+ * value other than TCDNS_UNCHANGED means "blanked in place; keep blanking the
+ * rest of this frame"; the caller must keep forwarding the original length.
+ */
+size_t tcdns_process_partial_response(uint8_t *data, size_t len,
+                                       const tcdns_callbacks *cb, void *ctx);
+
 uint32_t tcdns_abi_version(void);
 
 #endif /* TCDNS_H */

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -246,10 +246,19 @@ struct dns_stream_parse_ctx {
     const struct ng_session *s;
 };
 
-// Adapter matching dns_frame_parse_fn: parse_dns_response() may blank the
-// payload in place and may shrink it (blocking rewrite).
-static size_t tcp_dns_parse_frame(void *ctx, uint8_t *data, size_t dlen) {
+// Adapter matching dns_frame_parse_fn: complete frames use
+// parse_dns_response() and may shrink; partial frames use the in-place path
+// and report whether their later continuation bytes must be blanked.
+static size_t tcp_dns_parse_frame(void *ctx, uint8_t *data, size_t dlen,
+                                  int partial, int *blank_rest) {
     struct dns_stream_parse_ctx *pctx = (struct dns_stream_parse_ctx *) ctx;
+    if (partial != 0) {
+        int blanked = 0;
+        parse_dns_partial_response(pctx->args, pctx->s, data, &dlen, &blanked);
+        *blank_rest = blanked;
+        return dlen;
+    }
+
     size_t len = dlen;
     parse_dns_response(pctx->args, pctx->s, data, &len);
     return len;
@@ -625,9 +634,9 @@ void check_tcp_socket(const struct arguments *args,
                             // the split-frame cursor across reads. Frames lying
                             // wholly inside this buffer may be shortened (none
                             // of it has been forwarded yet). Split frames stay
-                            // aligned, but payload continuation bytes are
-                            // forwarded without parsing until buffered
-                            // reassembly exists.
+                            // aligned and are blanked in place when blocked;
+                            // their continuation bytes are blanked as they
+                            // pass through, without changing byte counts.
                             struct dns_stream_parse_ctx pctx = {.args = args, .s = s};
                             bytes = (ssize_t) dns_frame_process_stream(
                                     buffer, (size_t) bytes, &s->tcp.dns_stream,
@@ -810,9 +819,7 @@ jboolean handle_tcp(const struct arguments *args,
             s->tcp.checkedHostname = 0;
             s->tcp.tls_data = NULL;
             s->tcp.tls_len = 0;
-            s->tcp.dns_stream.frame_remaining = 0;
-            s->tcp.dns_stream.prefix_hi = 0;
-            s->tcp.dns_stream.have_prefix_hi = 0;
+            memset(&s->tcp.dns_stream, 0, sizeof(s->tcp.dns_stream));
             s->next = NULL;
 
             if (datalen) {

--- a/app/src/test/native/dns_frame_test.c
+++ b/app/src/test/native/dns_frame_test.c
@@ -7,8 +7,9 @@
  * on any host -- see .github/workflows/test.yml. It intentionally does not
  * link netguard.h, JNI, or parse_dns_response: dns_frame_process_stream()
  * takes the DNS parser as a callback, so a parse outcome is simulated with
- * stub callbacks (one recording every (offset, dlen) invocation, optionally
- * shrinking a chosen frame) instead of calling the real parser.
+ * stub callbacks (one recording every (offset, dlen, partial) invocation,
+ * optionally shrinking a chosen complete frame or blanking a partial one)
+ * instead of calling the real parser.
  *
  * Background: this framing logic shipped a real blocking bypass once
  * already, fixed in commit 9c49cc09 ("Fix DNS filtering regressions from
@@ -16,11 +17,12 @@
  * entirely unless a recv() held exactly one complete frame, so coalesced or
  * split reads went unfiltered. The cursor now parses every complete frame in
  * a read and the initially visible bytes of a split frame, while later payload
- * continuation bytes remain unparsed. These tests pin down which frames get
- * parsed, which may be shortened (only those lying wholly inside the current
- * read, since nothing in it has been forwarded yet), and -- the subtler
- * failure mode -- that the carry-over state and the returned byte count agree,
- * so the stream cannot silently desynchronise one recv() later.
+ * continuation bytes are blanked when the partial parser reports a block.
+ * These tests pin down which frames get parsed, which may be shortened (only
+ * those lying wholly inside the current read, since nothing in it has been
+ * forwarded yet), and -- the subtler failure mode -- that the carry-over
+ * state and the returned byte count agree, so the stream cannot silently
+ * desynchronise one recv() later.
  */
 
 #include <stdint.h>
@@ -61,6 +63,7 @@ struct parse_recorder {
     size_t calls;
     size_t off[MAX_CALLS];
     size_t len[MAX_CALLS];
+    int partial[MAX_CALLS];
     size_t shrink_call; /* 1-based invocation to shrink; 0 = never shrink */
     size_t shrink_to;
     size_t shrink_many_count;
@@ -68,6 +71,9 @@ struct parse_recorder {
     int shrink_on_marker;
     uint8_t shrink_marker;
     size_t shrink_marker_to;
+    int blank_partial_on_marker;
+    uint8_t blank_marker;
+    size_t blank_from;
 };
 
 static void recorder_init(struct parse_recorder *r, const uint8_t *base) {
@@ -75,13 +81,22 @@ static void recorder_init(struct parse_recorder *r, const uint8_t *base) {
     r->base = base;
 }
 
-static size_t stub_parse(void *ctx, uint8_t *data, size_t dlen) {
+static size_t stub_parse(void *ctx, uint8_t *data, size_t dlen, int partial,
+                         int *blank_rest) {
     struct parse_recorder *r = (struct parse_recorder *) ctx;
+    *blank_rest = 0;
     if (r->calls < MAX_CALLS) {
         r->off[r->calls] = (size_t) (data - r->base);
         r->len[r->calls] = dlen;
+        r->partial[r->calls] = partial;
     }
     r->calls++;
+    if (r->blank_partial_on_marker && partial != 0 && dlen > 0 &&
+        data[0] == r->blank_marker) {
+        if (r->blank_from < dlen)
+            memset(data + r->blank_from, 0, dlen - r->blank_from);
+        *blank_rest = 1;
+    }
     if (r->shrink_call != 0 && r->calls == r->shrink_call)
         return r->shrink_to;
     if (r->shrink_many_count > 0 && r->calls <= r->shrink_many_count)
@@ -92,16 +107,18 @@ static size_t stub_parse(void *ctx, uint8_t *data, size_t dlen) {
 /* Records like stub_parse(), but shrinks every payload whose first byte is
  * the configured marker. This models a rule-based parser outcome without
  * depending on callback invocation order. */
-static size_t stub_parse_by_marker(void *ctx, uint8_t *data, size_t dlen) {
+static size_t stub_parse_by_marker(void *ctx, uint8_t *data, size_t dlen,
+                                   int partial, int *blank_rest) {
     struct parse_recorder *r = (struct parse_recorder *) ctx;
-    (void) stub_parse(ctx, data, dlen);
+    (void) stub_parse(ctx, data, dlen, partial, blank_rest);
     if (r->shrink_on_marker && dlen > 0 && data[0] == r->shrink_marker)
         return r->shrink_marker_to;
     return dlen;
 }
 
 static int state_is_clean(const struct dns_stream_state *state) {
-    return state->frame_remaining == 0 && state->have_prefix_hi == 0;
+    return state->frame_remaining == 0 && state->blank_remaining == 0 &&
+           state->have_prefix_hi == 0;
 }
 
 static size_t append_frame(uint8_t *buffer, size_t offset, size_t frame_len,
@@ -144,7 +161,7 @@ static void run_coalesced_shrink_case(const char *label,
     original[bytes++] = 0xE5; /* trailing byte after the last complete frame */
     memcpy(copy, original, bytes);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, copy);
     r.shrink_many_count = 4;
@@ -188,7 +205,7 @@ static void test_coalesced_multiple_frames(void) {
         bytes = append_frame(original, bytes, frame_lens[i], fills[i]);
     memcpy(copy, original, bytes);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, copy);
     size_t out = dns_frame_process_stream(copy, bytes, &state, stub_parse, &r);
@@ -233,7 +250,7 @@ static void test_single_frame_shortened(void) {
     set_prefix(buffer, frame_len);
     memset(buffer + 2, 0xAA, frame_len);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
     r.shrink_call = 1;
@@ -261,7 +278,7 @@ static void test_single_frame_unchanged(void) {
     uint8_t snapshot[sizeof(buffer)];
     memcpy(snapshot, buffer, sizeof(buffer));
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
 
@@ -274,7 +291,7 @@ static void test_single_frame_unchanged(void) {
     CHECK(state_is_clean(&state), "single frame unchanged: no carry-over state");
 
     /* Defensive clamp: a bogus grow is ignored. */
-    struct dns_stream_state state2 = {0, 0, 0};
+    struct dns_stream_state state2 = {0};
     struct parse_recorder r2;
     recorder_init(&r2, buffer);
     r2.shrink_call = 1;
@@ -304,7 +321,7 @@ static void test_coalesced_read(void) {
         uint8_t copy[sizeof(buffer)];
         memcpy(copy, buffer, sizeof(buffer));
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, copy);
 
@@ -325,7 +342,7 @@ static void test_coalesced_read(void) {
         uint8_t copy[sizeof(buffer)];
         memcpy(copy, buffer, sizeof(buffer));
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, copy);
         r.shrink_call = 1;
@@ -356,7 +373,7 @@ static void test_shrink_to_zero_alignment(void) {
     uint8_t buffer[sizeof(original)];
     memcpy(buffer, original, bytes);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
     r.shrink_call = 1;
@@ -383,7 +400,7 @@ static void test_shrink_to_zero_alignment(void) {
  * middle continuation is only skipped, and the final continuation exposes
  * subsequent complete frames at the correct offset. */
 static void test_payload_spanning_three_reads(void) {
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
 
     {
         uint8_t buffer[2 + 2];
@@ -448,11 +465,97 @@ static void test_payload_spanning_three_reads(void) {
     }
 }
 
+/* A blocked partial frame is blanked in the first read and its continuation
+ * bytes are blanked without changing the forwarded count. Exercise both a
+ * two-read frame and a three-read frame whose final read also contains the
+ * next frame, proving blank_remaining clears at the exact boundary. */
+static void test_blocked_split_frames(void) {
+    {
+        struct dns_stream_state state = {0};
+        uint8_t first[2 + 3];
+        set_prefix(first, 7);
+        memset(first + 2, 0xA1, 3);
+
+        struct parse_recorder r;
+        recorder_init(&r, first);
+        r.blank_partial_on_marker = 1;
+        r.blank_marker = 0xA1;
+        r.blank_from = 1;
+        size_t out = dns_frame_process_stream(first, sizeof(first), &state,
+                                               stub_parse, &r);
+
+        CHECK(out == sizeof(first), "blocked two-read: first count unchanged");
+        CHECK(r.calls == 1 && r.partial[0] != 0,
+              "blocked two-read: partial frame parsed as partial");
+        CHECK(first[2] == 0xA1 && first[3] == 0 && first[4] == 0,
+              "blocked two-read: visible answer tail blanked");
+        CHECK(state.frame_remaining == 4 && state.blank_remaining != 0,
+              "blocked two-read: blank continuation remembered");
+
+        uint8_t second[4];
+        memset(second, 0xA1, sizeof(second));
+        size_t out2 = dns_frame_process_stream(second, sizeof(second), &state,
+                                                stub_parse, &r);
+        CHECK(out2 == sizeof(second), "blocked two-read: continuation count unchanged");
+        CHECK(second[0] == 0 && second[1] == 0 && second[2] == 0 && second[3] == 0,
+              "blocked two-read: continuation blanked");
+        CHECK(state.frame_remaining == 0 && state.blank_remaining == 0,
+              "blocked two-read: blank continuation cleared at frame end");
+    }
+
+    {
+        struct dns_stream_state state = {0};
+        uint8_t first[2 + 2];
+        set_prefix(first, 8);
+        memset(first + 2, 0xB1, 2);
+
+        struct parse_recorder r;
+        recorder_init(&r, first);
+        r.blank_partial_on_marker = 1;
+        r.blank_marker = 0xB1;
+        r.blank_from = 1;
+        size_t out = dns_frame_process_stream(first, sizeof(first), &state,
+                                               stub_parse, &r);
+        CHECK(out == sizeof(first), "blocked three-read: first count unchanged");
+        CHECK(state.frame_remaining == 6 && state.blank_remaining != 0,
+              "blocked three-read: first overflow remembered");
+        CHECK(first[2] == 0xB1 && first[3] == 0,
+              "blocked three-read: visible answer tail blanked");
+
+        uint8_t second[3];
+        memset(second, 0xB1, sizeof(second));
+        size_t out2 = dns_frame_process_stream(second, sizeof(second), &state,
+                                                stub_parse, &r);
+        CHECK(out2 == sizeof(second), "blocked three-read: middle count unchanged");
+        CHECK(second[0] == 0 && second[1] == 0 && second[2] == 0,
+              "blocked three-read: middle continuation blanked");
+        CHECK(state.frame_remaining == 3 && state.blank_remaining != 0,
+              "blocked three-read: middle overflow remembered");
+
+        uint8_t third[3 + 2 + 1];
+        memset(third, 0xB1, 3);
+        set_prefix(third + 3, 1);
+        third[5] = 0xC2;
+        struct parse_recorder r3;
+        recorder_init(&r3, third);
+        size_t out3 = dns_frame_process_stream(third, sizeof(third), &state,
+                                                stub_parse, &r3);
+        CHECK(out3 == sizeof(third), "blocked three-read: final count unchanged");
+        CHECK(third[0] == 0 && third[1] == 0 && third[2] == 0,
+              "blocked three-read: final continuation blanked");
+        CHECK(r3.calls == 1 && r3.off[0] == 5 && r3.len[0] == 1 &&
+                  r3.partial[0] == 0,
+              "blocked three-read: next frame parsed after exact drain");
+        CHECK(state_is_clean(&state),
+              "blocked three-read: blank continuation cleared at frame end");
+    }
+}
+
 /* A high prefix byte is forwarded first. The next read completes the prefix
  * and exposes a partial, parse-only payload; later reads drain that payload
  * before parsing a new frame. */
 static void test_split_prefix_payload_handoff(void) {
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
 
     {
         uint8_t buffer[1] = {0x00};
@@ -532,7 +635,7 @@ static void test_zero_frames_between_real_frames(void) {
     offset += 2;
     (void) append_frame(buffer, offset, 1, 0x33);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
     size_t out = dns_frame_process_stream(buffer, sizeof(buffer), &state,
@@ -560,7 +663,7 @@ static void test_split_frame(void) {
     uint8_t snapshot[sizeof(buffer)];
     memcpy(snapshot, buffer, sizeof(buffer));
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
     r.shrink_call = 1; /* a shrink on a partial frame must be ignored */
@@ -602,7 +705,7 @@ static void test_zero_frame_len(void) {
     set_prefix(buffer + 2, 8);
     memset(buffer + 4, 0x33, 8);
 
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
     struct parse_recorder r;
     recorder_init(&r, buffer);
     r.shrink_call = 1;
@@ -627,7 +730,7 @@ static void test_minimal_reads(void) {
         set_prefix(buffer, 1);
         buffer[2] = 0x44;
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
         r.shrink_call = 1;
@@ -647,7 +750,7 @@ static void test_minimal_reads(void) {
         set_prefix(buffer, 5);
         buffer[2] = 0x55;
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
 
@@ -664,7 +767,7 @@ static void test_minimal_reads(void) {
     {
         uint8_t buffer[1] = {0x01};
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
 
@@ -685,7 +788,7 @@ static void test_minimal_reads(void) {
         uint8_t snapshot[sizeof(buffer)];
         memcpy(snapshot, buffer, sizeof(buffer));
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
         size_t out = dns_frame_process_stream(buffer, sizeof(buffer), &state,
@@ -705,7 +808,7 @@ static void test_minimal_reads(void) {
         uint8_t snapshot[sizeof(buffer)];
         memcpy(snapshot, buffer, sizeof(buffer));
 
-        struct dns_stream_state state = {5, 0, 0};
+        struct dns_stream_state state = {5, 0, 0, 0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
         size_t out = dns_frame_process_stream(buffer, sizeof(buffer), &state,
@@ -734,7 +837,7 @@ static void test_frame_len_u16_boundary(void) {
             set_prefix(buffer, frame_len);
             memset(buffer + 2, 0x66, frame_len);
 
-            struct dns_stream_state state = {0, 0, 0};
+            struct dns_stream_state state = {0};
             struct parse_recorder r;
             recorder_init(&r, buffer);
             r.shrink_call = 1;
@@ -760,7 +863,7 @@ static void test_frame_len_u16_boundary(void) {
         uint8_t snapshot[sizeof(buffer)];
         memcpy(snapshot, buffer, sizeof(buffer));
 
-        struct dns_stream_state state = {0, 0, 0};
+        struct dns_stream_state state = {0};
         struct parse_recorder r;
         recorder_init(&r, buffer);
 
@@ -782,7 +885,7 @@ static void test_frame_len_u16_boundary(void) {
  * a wrong forwarded count in a *later* call -- which no single-buffer test
  * can catch. */
 static void test_multi_call_no_desync(void) {
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
 
     /* Read 1: frame A (40 bytes, complete, shrunk to 10) followed by the
      * prefix of frame B (60 bytes) with only 20 of its payload present. */
@@ -904,7 +1007,7 @@ static void run_chunk_partition(const uint8_t *stream, size_t stream_bytes,
     size_t actual_bytes = 0;
     size_t returned_bytes = 0;
     size_t chunk_start = 0;
-    struct dns_stream_state state = {0, 0, 0};
+    struct dns_stream_state state = {0};
 
     for (size_t i = 0; i < chunk_count; i++) {
         size_t chunk_end = chunk_ends[i];
@@ -920,6 +1023,9 @@ static void run_chunk_partition(const uint8_t *stream, size_t stream_bytes,
         r.shrink_on_marker = 1;
         r.shrink_marker = 0xA5;
         r.shrink_marker_to = 3;
+        r.blank_partial_on_marker = 1;
+        r.blank_marker = 0xA5;
+        r.blank_from = 1;
 
         size_t out = dns_frame_process_stream(buffer, chunk_bytes, &state,
                                                stub_parse_by_marker, &r);
@@ -961,6 +1067,22 @@ static void run_chunk_partition(const uint8_t *stream, size_t stream_bytes,
     uint8_t expected[CHUNKING_STREAM_BYTES];
     size_t expected_bytes = build_expected_frames(stream, frame_lens, new_lens,
                                                   3, expected);
+    int partial_blocked = 0;
+    for (size_t i = 0; i < chunk_count; i++) {
+        size_t chunk_start_for_frame = i == 0 ? 0 : chunk_ends[i - 1];
+        size_t chunk_end_for_frame = chunk_ends[i];
+        if (designated_start + 1 == chunk_start_for_frame &&
+            chunk_end_for_frame > designated_start + 2) {
+            partial_blocked = 1;
+        }
+        if (designated_start >= chunk_start_for_frame &&
+            designated_start + 2 < chunk_end_for_frame &&
+            designated_end > chunk_end_for_frame) {
+            partial_blocked = 1;
+        }
+    }
+    if (partial_blocked)
+        memset(expected + designated_start + 3, 0, designated_end - designated_start - 3);
     CHECK(returned_bytes == expected_bytes,
           "chunking property: returned counts sum to expected length");
     CHECK(actual_bytes == expected_bytes,
@@ -977,8 +1099,9 @@ static void run_chunk_partition(const uint8_t *stream, size_t stream_bytes,
 }
 
 /* Every two-way and three-way partition exercises prefix splits, payload
- * splits, coalesced frames, in-place rewrites, and output collection from the
- * returned count. Only a wholly contained designated frame may shrink. */
+ * splits, coalesced frames, in-place rewrites, partial-frame blanking, and
+ * output collection from the returned count. Only a wholly contained
+ * designated frame may shrink; a split blocked frame keeps its length. */
 static void test_exhaustive_chunking(void) {
     uint8_t stream[CHUNKING_STREAM_BYTES];
     size_t stream_bytes = build_chunking_reference(stream);
@@ -1005,6 +1128,7 @@ int main(void) {
     test_shrink_to_zero_alignment();
     test_split_frame();
     test_payload_spanning_three_reads();
+    test_blocked_split_frames();
     test_split_prefix_payload_handoff();
     test_zero_frame_len();
     test_zero_frames_between_real_frames();

--- a/wgbridge-rs/README.md
+++ b/wgbridge-rs/README.md
@@ -146,6 +146,7 @@ find them.
 |---|---|
 | `tcdns_abi_version()` | Guards the callback table against a mismatched library; currently `1`. |
 | `tcdns_process_response(data, len, callbacks, ctx)` | Records A/AAAA answers and applies the blanking policy to one bare DNS message in place. Returns the new length, or `SIZE_MAX` when unchanged. |
+| `tcdns_process_partial_response(data, len, callbacks, ctx)` | Same, for the visible prefix of a DNS-over-TCP frame whose remainder has not been read. Never shortens the message — earlier bytes are already on the wire — so the caller keeps forwarding the original length and uses the return only as a blanked/unchanged flag. |
 
 The module keeps the `deny(unwrap_used, expect_used, panic, indexing_slicing)`
 lints that `tc-dns` applies crate-wide: the release profile builds with

--- a/wgbridge-rs/tc-dns/src/capi.rs
+++ b/wgbridge-rs/tc-dns/src/capi.rs
@@ -4,7 +4,7 @@
 
 use std::ffi::{c_char, c_void, CString};
 
-use crate::{process_response, DnsPolicy, Outcome};
+use crate::{process_partial_response, process_response, DnsPolicy, Outcome};
 
 pub const TCDNS_ABI_VERSION: u32 = 1;
 pub const TCDNS_UNCHANGED: usize = usize::MAX;
@@ -132,6 +132,55 @@ pub unsafe extern "C" fn tcdns_process_response(
     };
     let policy = CapiPolicy { callbacks, ctx };
     match process_response(message, &policy) {
+        Outcome::Unchanged => TCDNS_UNCHANGED,
+        Outcome::Blanked {
+            new_len,
+            qname,
+            qtype,
+            rcode,
+        } => {
+            if let (Some(on_blanked), Some(qname)) =
+                (callbacks.on_blanked, CString::new(qname).ok())
+            {
+                // SAFETY: callback validity is checked above and the CString
+                // pointer remains valid for this callback.
+                on_blanked(ctx, qname.as_ptr(), qtype, rcode);
+            }
+            new_len
+        }
+    }
+}
+
+/// Processes the visible prefix of one bare DNS message in place. See
+/// `tcdns.h` for the complete pointer and callback lifetime contract.
+///
+/// # Safety
+///
+/// `data` must be writable for `len` bytes when `len` is nonzero, `callbacks`
+/// must point to a valid callback table for the duration of the call, and all
+/// callbacks must obey the non-reentrancy and no-panic contract.
+#[no_mangle]
+pub unsafe extern "C" fn tcdns_process_partial_response(
+    data: *mut u8,
+    len: usize,
+    callbacks: *const TcdnsCallbacks,
+    ctx: *mut c_void,
+) -> usize {
+    let Some(callbacks) = callbacks.as_ref() else {
+        return TCDNS_UNCHANGED;
+    };
+    if !callbacks.is_valid() || (len != 0 && data.is_null()) {
+        return TCDNS_UNCHANGED;
+    }
+    let message = if len == 0 {
+        &mut []
+    } else {
+        // SAFETY: the C contract requires `data` to be writable for `len`
+        // bytes, and null was rejected above.
+        std::slice::from_raw_parts_mut(data, len)
+    };
+    let policy = CapiPolicy { callbacks, ctx };
+    match process_partial_response(message, &policy) {
         Outcome::Unchanged => TCDNS_UNCHANGED,
         Outcome::Blanked {
             new_len,

--- a/wgbridge-rs/tc-dns/src/lib.rs
+++ b/wgbridge-rs/tc-dns/src/lib.rs
@@ -53,6 +53,65 @@ pub fn process_response(msg: &mut [u8], policy: &dyn DnsPolicy) -> Outcome {
     apply_parsed(msg, parsed, policy)
 }
 
+/// Applies blocking policy to the visible prefix of a DNS-over-TCP response
+/// whose remainder may not have been read yet, mutating it in place without
+/// ever shortening it: earlier bytes of the frame are already on the wire, so
+/// its length can no longer change.
+///
+/// When the answer section happens to be complete the decision is exactly the
+/// one `process_response` would make, SVCB included. When it is truncated the
+/// decision falls back to the question section alone: answers validated before
+/// the truncation point are still recorded, but SVCB/HTTPS records cannot be
+/// detected, so SVCB-triggered blanking is unavailable for such frames.
+///
+/// On a blanking hit the bytes after the question are zeroed, so a client that
+/// ignores the cleared `ancount` cannot recover the original answers. The
+/// returned `new_len` reports where the message proper ends; the caller must
+/// keep forwarding the original length.
+pub fn process_partial_response(msg: &mut [u8], policy: &dyn DnsPolicy) -> Outcome {
+    let parsed = message::parse_answers_incrementally(msg, |answer| {
+        policy.record_answer(&answer.qname, &answer.aname, &answer.resource, answer.ttl);
+    });
+
+    // A fully parsed message is decided exactly as the complete path decides
+    // it; only a truncated one loses the answer-derived signals.
+    let (qname, qtype, question_end, contains_svcb) = match parsed {
+        Some(parsed) => (
+            parsed.qname,
+            parsed.qtype,
+            parsed.question_end,
+            parsed.contains_svcb,
+        ),
+        None => {
+            let Some(layout) = message::read_question_layout(msg) else {
+                return Outcome::Unchanged;
+            };
+            (layout.qname, layout.qtype, layout.question_end, false)
+        }
+    };
+
+    // An empty root qname is valid DNS syntax but is not a policy subject.
+    // In particular, do not call a Java-backed policy with an empty string.
+    if qname.is_empty() {
+        return Outcome::Unchanged;
+    }
+    if !contains_svcb && !policy.is_domain_blocked(&qname) {
+        return Outcome::Unchanged;
+    }
+
+    let rcode = policy.blocked_rcode() & 0x0f;
+    message::blank_dns_message(msg, rcode);
+    if let Some(tail) = msg.get_mut(question_end..) {
+        tail.fill(0);
+    }
+    Outcome::Blanked {
+        new_len: question_end,
+        qname,
+        qtype,
+        rcode,
+    }
+}
+
 fn apply_parsed(msg: &mut [u8], parsed: message::DnsMessage, policy: &dyn DnsPolicy) -> Outcome {
     // An empty root qname is valid DNS syntax but is not a policy subject.
     // In particular, do not call a Java-backed policy with an empty string.

--- a/wgbridge-rs/tc-dns/src/lib.rs
+++ b/wgbridge-rs/tc-dns/src/lib.rs
@@ -64,6 +64,20 @@ pub fn process_response(msg: &mut [u8], policy: &dyn DnsPolicy) -> Outcome {
 /// the truncation point are still recorded, but SVCB/HTTPS records cannot be
 /// detected, so SVCB-triggered blanking is unavailable for such frames.
 ///
+/// That fallback deliberately relaxes one rule of the complete path. Nothing
+/// here can tell a *truncated* answer section from a *malformed* one — both
+/// surface as `None` — so a malformed response `process_response` would leave
+/// alone is blanked here whenever its question names a blocked domain. The
+/// blocklist gate is unchanged, so this can only ever act on a domain the
+/// complete path would also have blocked; it is never a wider policy, only a
+/// less forgiving one about malformed input.
+///
+/// The block is not airtight in the other direction either: the header and the
+/// whole question must lie inside the visible prefix, or `read_question_layout`
+/// yields nothing and the frame is forwarded untouched. A read split inside the
+/// first ~12 + qname bytes of a response therefore blocks nothing. Closing that
+/// would need the reassembly buffer this path exists to avoid.
+///
 /// On a blanking hit the bytes after the question are zeroed, so a client that
 /// ignores the cleared `ancount` cannot recover the original answers. The
 /// returned `new_len` reports where the message proper ends; the caller must

--- a/wgbridge-rs/tc-dns/src/message.rs
+++ b/wgbridge-rs/tc-dns/src/message.rs
@@ -109,6 +109,12 @@ pub(crate) fn parse_message(msg: &[u8]) -> Option<DnsMessage> {
 /// Parses the question section and then answers one at a time. A malformed
 /// later answer returns `None`, so callers can retain records already emitted
 /// from earlier answers while refusing to blank a partially validated message.
+///
+/// `process_partial_response` is the one caller that does not honour that
+/// refusal: on a DNS-over-TCP frame the visible prefix is expected to end
+/// mid-answer, so `None` there carries no signal about whether the bytes are
+/// malformed or merely unread, and it falls back to the question section. See
+/// its documentation for why that is safe.
 pub(crate) fn parse_answers_incrementally(
     msg: &[u8],
     mut on_answer: impl FnMut(&DnsAnswer),

--- a/wgbridge-rs/tc-dns/src/message.rs
+++ b/wgbridge-rs/tc-dns/src/message.rs
@@ -27,12 +27,12 @@ pub(crate) struct DnsMessage {
 }
 
 #[derive(Debug)]
-struct QuestionLayout {
-    qname: String,
-    qtype: u16,
-    question_end: usize,
-    ancount: usize,
-    answer_offset: usize,
+pub(crate) struct QuestionLayout {
+    pub(crate) qname: String,
+    pub(crate) qtype: u16,
+    pub(crate) question_end: usize,
+    pub(crate) ancount: usize,
+    pub(crate) answer_offset: usize,
 }
 
 fn read_u16(msg: &[u8], offset: usize) -> Option<u16> {
@@ -50,7 +50,7 @@ fn read_u32(msg: &[u8], offset: usize) -> Option<u32> {
     ]))
 }
 
-fn read_question_layout(msg: &[u8]) -> Option<QuestionLayout> {
+pub(crate) fn read_question_layout(msg: &[u8]) -> Option<QuestionLayout> {
     if msg.len() < DNS_HEADER_LEN {
         return None;
     }

--- a/wgbridge-rs/tc-dns/tests/capi.rs
+++ b/wgbridge-rs/tc-dns/tests/capi.rs
@@ -4,8 +4,8 @@ use std::ffi::{c_char, c_void, CStr};
 use std::mem::{offset_of, size_of};
 
 use tcdns::capi::{
-    tcdns_abi_version, tcdns_process_response, BlockedRcode, IsDomainBlocked, OnBlanked,
-    RecordAnswer, TcdnsCallbacks, TCDNS_ABI_VERSION, TCDNS_UNCHANGED,
+    tcdns_abi_version, tcdns_process_partial_response, tcdns_process_response, BlockedRcode,
+    IsDomainBlocked, OnBlanked, RecordAnswer, TcdnsCallbacks, TCDNS_ABI_VERSION, TCDNS_UNCHANGED,
 };
 
 const TYPE_A: u16 = 1;
@@ -235,4 +235,39 @@ fn callbacks_receive_terminated_strings_and_new_length() {
         .iter()
         .all(|(name, _, _)| !name.as_bytes().contains(&0)));
     assert_eq!(capture.blanked, vec![("��a".to_owned(), TYPE_A, 0x0f)]);
+}
+
+#[test]
+fn partial_response_preserves_buffer_length_and_reports_blanking() {
+    let raw_name = question_name("tracker.example");
+    let question_end = 12 + question(&raw_name).len();
+    let first_answer = answer(&[0xc0, 12], TYPE_A, &[203, 0, 113, 7]);
+    let mut message = response(
+        &raw_name,
+        &[first_answer.clone(), answer(&[0xc0, 12], TYPE_HTTPS, &[])],
+    );
+    message.truncate(question_end + first_answer.len() + 5);
+    let original_len = message.len();
+    let mut capture = Capture {
+        blocked: true,
+        ..Capture::default()
+    };
+    let callbacks = callbacks();
+    let result = unsafe {
+        tcdns_process_partial_response(
+            message.as_mut_ptr(),
+            message.len(),
+            &callbacks,
+            (&mut capture as *mut Capture).cast(),
+        )
+    };
+
+    assert_eq!(result, question_end);
+    assert_eq!(message.len(), original_len);
+    assert!(message[question_end..].iter().all(|byte| *byte == 0));
+    assert_eq!(capture.records.len(), 1);
+    assert_eq!(
+        capture.blanked,
+        vec![("tracker.example".to_owned(), TYPE_A, 0x0f)]
+    );
 }

--- a/wgbridge-rs/tc-dns/tests/message.rs
+++ b/wgbridge-rs/tc-dns/tests/message.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::ffi::CString;
 
-use tcdns::{process_response, record_answers, DnsPolicy, Outcome};
+use tcdns::{process_partial_response, process_response, record_answers, DnsPolicy, Outcome};
 
 const TYPE_A: u16 = 1;
 const TYPE_AAAA: u16 = 28;
@@ -365,6 +365,131 @@ fn malformed_answer_after_valid_a_records_a_but_does_not_blank() {
     assert_eq!(policy.records.borrow().len(), 1);
 }
 
+#[test]
+fn partial_blocked_response_blanks_visible_tail_without_shrinking() {
+    let qname_encoded = name("blocked.example");
+    let question_bytes = question(&qname_encoded, TYPE_A);
+    let question_end = 12 + question_bytes.len();
+    let mut message = response(
+        std::slice::from_ref(&question_bytes),
+        &[a_answer(&[0xc0, 12])],
+    );
+    message.truncate(question_end + 5);
+    let original_len = message.len();
+
+    let policy = TestPolicy {
+        blocked: true,
+        blocked_rcode: 0x1f,
+        ..TestPolicy::default()
+    };
+    let outcome = process_partial_response(&mut message, &policy);
+
+    assert!(matches!(
+        outcome,
+        Outcome::Blanked {
+            new_len,
+            qname,
+            qtype: TYPE_A,
+            rcode: 0x0f,
+        } if new_len == question_end && qname == "blocked.example"
+    ));
+    assert_eq!(message.len(), original_len);
+    assert!(message[question_end..].iter().all(|byte| *byte == 0));
+    assert_eq!(&message[6..12], &[0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
+fn partial_unblocked_response_is_untouched() {
+    let qname_encoded = name("allowed.example");
+    let question_bytes = question(&qname_encoded, TYPE_A);
+    let question_end = 12 + question_bytes.len();
+    let mut message = response(
+        std::slice::from_ref(&question_bytes),
+        &[a_answer(&[0xc0, 12])],
+    );
+    message.truncate(question_end + 5);
+    let original = message.clone();
+    let policy = TestPolicy::default();
+
+    assert_eq!(
+        process_partial_response(&mut message, &policy),
+        Outcome::Unchanged
+    );
+    assert_eq!(message, original);
+    assert!(policy.records.borrow().is_empty());
+}
+
+#[test]
+fn partial_response_records_answers_before_truncation() {
+    let qname_encoded = name("tracker.example");
+    let question_bytes = question(&qname_encoded, TYPE_A);
+    let question_end = 12 + question_bytes.len();
+    let first = a_answer(&[0xc0, 12]);
+    let second = a_answer(&[0xc0, 12]);
+    let mut message = response(
+        std::slice::from_ref(&question_bytes),
+        &[first.clone(), second],
+    );
+    message.truncate(question_end + first.len() + 5);
+
+    let policy = TestPolicy {
+        blocked: true,
+        ..TestPolicy::default()
+    };
+    let outcome = process_partial_response(&mut message, &policy);
+
+    assert!(matches!(
+        outcome,
+        Outcome::Blanked { new_len, .. } if new_len == question_end
+    ));
+    let records = policy.records.borrow();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].0, "tracker.example");
+    assert_eq!(records[0].2, "203.0.113.7");
+    drop(records);
+    assert!(message[question_end..].iter().all(|byte| *byte == 0));
+}
+
+#[test]
+fn partial_response_with_truncated_question_is_unchanged() {
+    let qname_encoded = name("truncated.example");
+    let question_bytes = question(&qname_encoded, TYPE_A);
+    let full = response(
+        std::slice::from_ref(&question_bytes),
+        &[a_answer(&[0xc0, 12])],
+    );
+    let mut message = full[..15].to_vec();
+    let original = message.clone();
+    let policy = TestPolicy {
+        blocked: true,
+        ..TestPolicy::default()
+    };
+
+    assert_eq!(
+        process_partial_response(&mut message, &policy),
+        Outcome::Unchanged
+    );
+    assert_eq!(message, original);
+    assert_eq!(policy.policy_calls.get(), 0);
+}
+
+#[test]
+fn partial_response_with_empty_qname_is_unchanged() {
+    let mut message = response(&[question(&[0], TYPE_A)], &[a_answer(&[0xc0, 12])]);
+    let original = message.clone();
+    let policy = TestPolicy {
+        blocked: true,
+        ..TestPolicy::default()
+    };
+
+    assert_eq!(
+        process_partial_response(&mut message, &policy),
+        Outcome::Unchanged
+    );
+    assert_eq!(message, original);
+    assert_eq!(policy.policy_calls.get(), 0);
+}
+
 /// A pointer's own 2 bytes must not be charged against the 255-octet
 /// uncompressed-name cap: that cap is RFC 1035's limit on the *expanded*
 /// name, and a legal near-maximum name reached through a compression
@@ -723,4 +848,59 @@ fn process_response_fuzz_smoke_returns_for_fifty_thousand_inputs() {
         }
         let _ = process_response(&mut message, &NoopPolicy);
     }
+}
+
+/// A frame whose length prefix was split across reads is handled by the
+/// partial path even when its whole payload is present. The decision there
+/// must not be weaker than the complete path's, so an SVCB/HTTPS answer still
+/// blanks a domain the policy does not block.
+#[test]
+fn partial_response_blanks_svcb_when_answers_are_complete() {
+    let qname = name("cdn.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let question_end = 12 + question_bytes.len();
+    let mut message = response(
+        std::slice::from_ref(&question_bytes),
+        &[answer(&[0xc0, 12], TYPE_HTTPS, 300, &[0, 1, 0])],
+    );
+    let policy = TestPolicy::default(); // not blocked
+    let outcome = process_partial_response(&mut message, &policy);
+
+    assert!(
+        matches!(outcome, Outcome::Blanked { new_len, .. } if new_len == question_end),
+        "SVCB answer must blank even when the domain is not blocked"
+    );
+    assert!(message[question_end..].iter().all(|byte| *byte == 0));
+    // Same verdict as the complete path would reach.
+    let mut twin = response(
+        std::slice::from_ref(&question_bytes),
+        &[answer(&[0xc0, 12], TYPE_HTTPS, 300, &[0, 1, 0])],
+    );
+    assert!(matches!(
+        process_response(&mut twin, &TestPolicy::default()),
+        Outcome::Blanked { .. }
+    ));
+}
+
+/// The truncated fallback loses only the answer-derived signals: an SVCB
+/// answer cut short by the read boundary can no longer be detected, so an
+/// unblocked domain passes through untouched.
+#[test]
+fn partial_response_cannot_detect_svcb_past_the_truncation_point() {
+    let qname = name("cdn.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let question_end = 12 + question_bytes.len();
+    let full = response(
+        std::slice::from_ref(&question_bytes),
+        &[answer(&[0xc0, 12], TYPE_HTTPS, 300, &[0, 1, 0])],
+    );
+    let mut message = full[..question_end + 6].to_vec();
+    let original = message.clone();
+    let policy = TestPolicy::default(); // not blocked
+
+    assert_eq!(
+        process_partial_response(&mut message, &policy),
+        Outcome::Unchanged
+    );
+    assert_eq!(message, original);
 }


### PR DESCRIPTION
## Summary

Closes #809 — the policy half of the direct DNS-over-TCP path, following #816's framing half.

A response is read into a buffer capped at `min(send_window, mss)`, so any frame past roughly 1400 bytes arrives in pieces. `dns_frame_process_stream()` handed the parser only the visible prefix, and `parse_answers_incrementally()` returns `None` as soon as one answer is truncated — so `process_response()` reported `Unchanged`, the message was never blanked, and its addresses were never recorded. **A blocked tracker domain on that path was neither blocked nor logged.** Resolvers fall back to TCP precisely because the UDP answer was truncated, so oversized responses are the common size class there.

The fix decides such a frame from the **question section alone** and blanks it **in place**, without changing any byte count. Bytes already forwarded to the tun cannot be taken back, so nothing shrinks and no reassembly buffer is introduced — none of #807's per-session data buffers, window/MSS accounting, or new terminal-state handling is needed.

Two details that are not obvious from the diff:

- **The partial path is not weaker than the complete one when it doesn't have to be.** If the answer section happens to be fully present — a frame whose 2-byte *prefix* was split, say — it reaches exactly the verdict `process_response()` would, SVCB included. Only a genuinely truncated answer section falls back to the question, and answers validated before the truncation point are still recorded.
- **The frame tail is zeroed on a blanking hit**, and the decision is carried into later reads so continuation bytes are zeroed as they pass through. Without that, a client that ignores the cleared `ancount` could read the original addresses straight out of the frame, making the block trivially bypassable.

## Changes

- `wgbridge-rs/tc-dns/src/lib.rs` — new `process_partial_response()`; `message.rs` widens `read_question_layout`/`QuestionLayout` visibility, no logic change.
- `wgbridge-rs/tc-dns/src/capi.rs`, `app/src/main/jni/netguard/tcdns.h` — `tcdns_process_partial_response()`, same contract as the existing export. `TCDNS_ABI_VERSION` is unchanged; this only adds a symbol.
- `app/src/main/jni/netguard/dns.c`, `netguard.h` — `parse_dns_partial_response()` adapter reporting whether the frame was blanked.
- `app/src/main/jni/netguard/dns_frame.{h,c}` — the parse callback gains `partial` and an out-param `blank_rest`; `struct dns_stream_state` gains `blank_remaining`, cleared exactly when the frame drains. The fully-contained-frame path (the only one that may shrink) is untouched.
- `app/src/main/jni/netguard/tcp.c` — adapter dispatch, and session-registration state zeroing replaced with a single `memset` so a future field cannot be missed.

## The invariant

`dns_frame_process_stream()`'s return feeds `s->tcp.local_seq += bytes`, so it must equal exactly the bytes handed to `write_data()`. Blanking changes byte *values* only: never the return value, never `frame_remaining`, never a length prefix. The tests assert the forwarded count is unchanged on every partial-blanking path.

## Validation

- Rust: `cargo test -p tc-dns --features capi` — 29 + 4 pass (2 new). `cargo clippy --all-targets` clean, `cargo fmt --check` clean, both on the pinned 1.95.0 toolchain.
- Native: host suite builds `-Wall -Wextra -Werror` and passes, and again under `-fsanitize=address,undefined -fno-sanitize-recover=all` — same invocation as `.github/workflows/test.yml`. (ASan needs `detect_leaks=0` in this container; LeakSanitizer cannot run under ptrace here.)
- New tests: blocked frames split across 2 and 3 reads blanked with continuation bytes zeroed and counts unchanged; `blank_remaining` clearing at the exact frame boundary with the next frame parsed at the right offset; the exhaustive 2- and 3-chunk property test extended to cover blanking; SVCB parity between the partial and complete paths, plus the truncated case where that detection is genuinely lost.
- The native Android build (`tcp.c`, `netguard.h`) is covered by CI; no Android SDK was available in the development environment.
- **No device-level DNS-over-TCP capture was run** — the same residual as #807 and #816, and the reason #809 names it as the closing condition. Worth doing before this is taken out of draft.

## Risk

The failure mode to review for is a desynchronised cursor: if `blank_remaining` cleared at the wrong time, or a partial frame were allowed to shrink, every later frame on that connection would be parsed at the wrong offset. That is what the multi-call and property tests are there to catch, and they were extended rather than worked around.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Epj8xtxCJgH6eGbeqYLuNA)_