### PR TITLE
Dedupe the UID-keyed stores and stop sweeping them on every install

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -78,6 +78,7 @@ import net.kollnig.missioncontrol.LocalNetworkAccess;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.data.BlockingMode;
 import net.kollnig.missioncontrol.data.InternetBlocklist;
+import net.kollnig.missioncontrol.data.PackageUids;
 import net.kollnig.missioncontrol.data.PausedApps;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
@@ -1376,7 +1377,11 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                                 Collections.addAll(packageNames, packages);
                             }
                         } catch (NumberFormatException e) {
-                            Log.w(TAG, "Invalid UID in blocklist: " + uidStr);
+                            // Not a UID, so already stored under a package name:
+                            // an imported entry whose app is not installed yet.
+                            // The export is package-keyed anyway, so pass it
+                            // through rather than dropping the setting.
+                            packageNames.add(uidStr);
                         }
                     }
 
@@ -1397,23 +1402,15 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                             if (packages != null) {
                                 for (String pkg : packages) {
                                     packageNames.add(pkg);
-
-                                    // Also export the per-app settings for this UID
-                                    // The key format for per-app settings is APPS_BLOCKLIST_APPS_KEY + "_" + uid
-                                    String perAppKey = TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + uidStr;
-                                    Set<String> perAppSettings = prefs.getStringSet(perAppKey, null);
-                                    if (perAppSettings != null) {
-                                        serializer.startTag(null, "setting");
-                                        // Use a package-based key: APPS_BLOCKLIST_PACKAGES_KEY + "_" + packageName
-                                        serializer.attribute(null, "key", "APPS_BLOCKLIST_PACKAGES_KEY" + "_" + pkg);
-                                        serializer.attribute(null, "type", "set");
-                                        serializer.attribute(null, "value", TextUtils.join("\n", perAppSettings));
-                                        serializer.endTag(null, "setting");
-                                    }
+                                    exportTrackerSubset(prefs, serializer, uidStr, pkg);
                                 }
                             }
                         } catch (NumberFormatException e) {
-                            Log.w(TAG, "Invalid UID in blocklist: " + uidStr);
+                            // Not a UID, so already stored under a package name:
+                            // an imported entry whose app is not installed yet.
+                            // Carry it and its subset through unchanged.
+                            packageNames.add(uidStr);
+                            exportTrackerSubset(prefs, serializer, uidStr, uidStr);
                         }
                     }
 
@@ -1439,6 +1436,31 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             } else
                 Log.e(TAG, "Unknown key=" + key);
         }
+    }
+
+    /**
+     * Write one app's tracker subset under its package-name key.
+     *
+     * @param prefs     Blocklist preferences
+     * @param serializer Serializer to write to
+     * @param storedKey The key the subset is stored under: a UID, or a package
+     *                  name for an entry that could not be resolved
+     * @param pkg       The package name to export it under
+     */
+    static void exportTrackerSubset(SharedPreferences prefs, XmlSerializer serializer,
+                                    String storedKey, String pkg) throws IOException {
+        // The key format for per-app settings is APPS_BLOCKLIST_APPS_KEY + "_" + uid
+        Set<String> perAppSettings = prefs.getStringSet(
+                TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + storedKey, null);
+        if (perAppSettings == null)
+            return;
+
+        serializer.startTag(null, "setting");
+        // Use a package-based key: APPS_BLOCKLIST_PACKAGES_KEY + "_" + packageName
+        serializer.attribute(null, "key", "APPS_BLOCKLIST_PACKAGES_KEY" + "_" + pkg);
+        serializer.attribute(null, "type", "set");
+        serializer.attribute(null, "value", TextUtils.join("\n", perAppSettings));
+        serializer.endTag(null, "setting");
     }
 
     private void forwardExport(XmlSerializer serializer) throws IOException {
@@ -1540,19 +1562,17 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         if (TextUtils.isEmpty(value))
             return uids;
 
-        PackageManager pm = context.getPackageManager();
         for (String pkg : value.split("\n")) {
             if (TextUtils.isEmpty(pkg))
                 continue;
-            try {
-                int uid = pm.getApplicationInfo(pkg, 0).uid;
+
+            Integer uid = PackageUids.resolve(context, pkg);
+            if (uid == null) {
+                // Retain the package name so a later install can resolve it.
+                uids.add(pkg);
+                Log.w(TAG, "Retaining unresolved package during import: " + pkg);
+            } else {
                 uids.add(Integer.toString(uid));
-            } catch (PackageManager.NameNotFoundException e) {
-                uids.add(pkg);
-                Log.w(TAG, "Package not found during import: " + pkg);
-            } catch (SecurityException e) {
-                uids.add(pkg);
-                Log.w(TAG, "Cannot resolve package during import: " + pkg);
             }
         }
         return uids;
@@ -1666,22 +1686,14 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                                 for (String s : value.split("\n"))
                                     set.add(s);
 
-                            String originalKey = TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + pkg;
-                            try {
-                                PackageManager pm = context.getPackageManager();
-                                int uid = pm.getApplicationInfo(pkg, 0).uid;
-
+                            Integer uid = PackageUids.resolve(context, pkg);
+                            if (uid == null) {
+                                // Retain the package-name key so a later install can resolve it.
+                                current.put(TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + pkg, set);
+                                Log.w(TAG, "Retaining unresolved package during import of settings: " + pkg);
+                            } else {
                                 // Store under original UID-based key
                                 current.put(TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + uid, set);
-
-                            } catch (PackageManager.NameNotFoundException e) {
-                                // Retain the package-name key so a later install can resolve it.
-                                current.put(originalKey, set);
-                                Log.w(TAG, "Package not found during import of settings: " + pkg);
-                            } catch (SecurityException e) {
-                                // Retain the package-name key when its UID cannot be inspected.
-                                current.put(originalKey, set);
-                                Log.w(TAG, "Cannot resolve package during import of settings: " + pkg);
                             }
                             return;
                         }

--- a/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
@@ -28,17 +28,14 @@ import android.util.Log;
 import androidx.core.app.NotificationManagerCompat;
 
 import net.kollnig.missioncontrol.data.InternetBlocklist;
+import net.kollnig.missioncontrol.data.PackageUids;
 import net.kollnig.missioncontrol.data.PausedApps;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 
 public class ReceiverPackageRemoved extends BroadcastReceiver {
     private static final String TAG = "TrackerControl.Receiver";
 
-    interface PackageUidLookup {
-        String[] getPackagesForUid(int uid);
-    }
-
-    static boolean shouldClearUid(PackageUidLookup lookup, int uid) {
+    static boolean shouldClearUid(PackageUids.Lookup lookup, int uid) {
         // UID-keyed state may still be in use by another package of a shared UID.
         // Clear it only once the UID has no package left, otherwise a reinstall
         // silently comes back with the old app's settings.
@@ -53,7 +50,7 @@ public class ReceiverPackageRemoved extends BroadcastReceiver {
         }
     }
 
-    static void clearUidState(Context context, int uid, PackageUidLookup lookup) {
+    static void clearUidState(Context context, int uid, PackageUids.Lookup lookup) {
         if (!shouldClearUid(lookup, uid))
             return;
 
@@ -66,8 +63,10 @@ public class ReceiverPackageRemoved extends BroadcastReceiver {
             internetBlocklist.unblock(context, uid);
 
         TrackerBlocklist trackerBlocklist = TrackerBlocklist.getInstance(context);
-        trackerBlocklist.clear(uid);
-        trackerBlocklist.saveSettings(context);
+        // saveSettings rewrites every key in the preferences file, so only pay
+        // for it when the uid actually had tracker state.
+        if (trackerBlocklist.clear(uid))
+            trackerBlocklist.saveSettings(context);
 
         NotificationManagerCompat.from(context).cancel(uid); // installed notification
         NotificationManagerCompat.from(context).cancel(uid + 10000); // access notification
@@ -84,12 +83,7 @@ public class ReceiverPackageRemoved extends BroadcastReceiver {
             String packageName = intent.getData() == null ? null : intent.getData().getSchemeSpecificPart();
             PausedApps.onPackageRemoved(context, packageName, uid);
             if (uid > 0) {
-                clearUidState(context, uid, new PackageUidLookup() {
-                    @Override
-                    public String[] getPackagesForUid(int uid) {
-                        return context.getPackageManager().getPackagesForUid(uid);
-                    }
-                });
+                clearUidState(context, uid, PackageUids.lookup(context));
             }
         }
     }

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -42,6 +42,7 @@ import net.kollnig.missioncontrol.Common;
 import net.kollnig.missioncontrol.R;
 import net.kollnig.missioncontrol.data.Pair;
 import net.kollnig.missioncontrol.data.BlockingMode;
+import net.kollnig.missioncontrol.data.InternetBlocklist;
 import net.kollnig.missioncontrol.data.RemoteRoutingLogic;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerList;
@@ -395,7 +396,16 @@ public class Rule {
 
             DatabaseHelper dh = DatabaseHelper.getInstance(context);
             TrackerBlocklist trackerBlocklist = TrackerBlocklist.getInstance(context);
-            boolean trackerDefaultsChanged = false;
+
+            // Let an imported entry claim its app before ensureDefaults runs.
+            // A numeric default created first wins the collision, which would
+            // strand the imported subset under its package-name key. This is
+            // also the only path covering an install made while the VPN was
+            // stopped, when packageChangedReceiver is not registered.
+            InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
+            if (internetBlocklist.resolvePendingPackages(context))
+                internetBlocklist.saveSettings(context);
+            boolean trackerDefaultsChanged = trackerBlocklist.resolvePendingPackages(context);
             for (PackageInfo info : listPI)
                 try {
                     // Skip self

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3428,13 +3428,26 @@ public class ServiceSinkhole extends VpnService {
             Rule.clearCache(context);
 
             InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
-            boolean internetChanged = internetBlocklist.resolvePendingPackages(context);
             TrackerBlocklist b = TrackerBlocklist.getInstance(context);
-            boolean trackerChanged = b.resolvePendingPackages(context);
+            boolean internetChanged = false;
+            boolean trackerChanged = false;
 
+            // A replaced package was already installed, so it resolved at load
+            // time and its uid does not change on update. Only a genuinely new
+            // install can claim a pending entry.
             if (!intent.getBooleanExtra(Intent.EXTRA_REPLACING, false)) {
                 SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
                 int uid = intent.getIntExtra(Intent.EXTRA_UID, -1);
+
+                // Resolve only the package this broadcast is about. Sweeping
+                // every pending entry would cost a PackageManager call each,
+                // on every install, for entries that may never resolve — this
+                // runs on the service's main thread with the screen off.
+                String packageName = (intent.getData() == null
+                        ? null : intent.getData().getSchemeSpecificPart());
+                internetChanged = internetBlocklist.resolvePendingPackage(context, packageName);
+                trackerChanged = b.resolvePendingPackage(context, packageName);
+
                 if (uid > -1) {
                     // Set tracker defaults based on blocking mode
                     trackerChanged |= b.ensureDefaults(uid, BlockingMode.isStrictMode(context));

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
@@ -20,26 +20,19 @@ import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 /**
  * Stores those apps whose access to internet is blocked.
  * <p>
- * Analogous implementation to TrackerBlocklist.
+ * Membership is the whole per-app state, so the {@link UidKeyedStore} payload
+ * is a placeholder and only the key set matters.
  */
-public class InternetBlocklist {
+public class InternetBlocklist extends UidKeyedStore<Boolean> {
     public static final String SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY = "INTERNET_BLOCKLIST_APPS_KEY";
     private static InternetBlocklist instance;
-    private final HashSet<Integer> blockmap = new HashSet<>();
-    private final Set<String> rawBlockmap = new HashSet<>();
-
-    interface PackageUidResolver {
-        Integer resolve(String packageName);
-    }
 
     private InternetBlocklist(Context c) {
         // Initialize Concurrent Set using values from shared preferences if possible.
@@ -54,10 +47,19 @@ public class InternetBlocklist {
      * @param c context used to access InternetBlocklist from
      * @return The current instance of the InternetBlocklist, if none, a new instance is created.
      */
+    // Called from both native packet threads and UI threads.
     public static synchronized InternetBlocklist getInstance(Context c) {
         if (instance == null)
             instance = new InternetBlocklist(c);
         return instance;
+    }
+
+    @Override
+    protected Resolution absorb(int uid, String rawKey, Boolean raw) {
+        // Membership is the whole state, so a collision with an existing UID
+        // has nothing to lose: the raw entry can always be dropped.
+        blockmap.put(uid, Boolean.TRUE);
+        return Resolution.ABSORBED;
     }
 
     /**
@@ -68,83 +70,21 @@ public class InternetBlocklist {
     public synchronized void loadSettings(Context c) {
         SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
         Set<String> set = prefs.getStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, null);
+        PackageUids.Resolver resolver = PackageUids.resolver(c);
 
-        PackageUidResolver resolver = new PackageUidResolver() {
-            @Override
-            public Integer resolve(String packageName) {
-                try {
-                    return c.getPackageManager().getApplicationInfo(packageName, 0).uid;
-                } catch (PackageManager.NameNotFoundException ignored) {
-                    return null;
-                } catch (SecurityException ignored) {
-                    return null;
-                }
-            }
-        };
+        clear();
+        if (set == null)
+            return;
 
-        blockmap.clear();
-        rawBlockmap.clear();
-        if (set != null) {
-            // Numeric entries are canonical. Keep unresolved package names so
-            // they can be resolved when the app is installed later.
-            for (String id : set) {
-                Integer uid = resolveStoredUid(id, resolver);
-                if (uid == null)
-                    rawBlockmap.add(id);
-                else
-                    blockmap.add(uid);
-            }
+        // Numeric entries are canonical. Keep unresolved package names so
+        // they can be resolved when the app is installed later.
+        for (String id : set) {
+            Integer uid = resolveStoredUid(id, resolver);
+            if (uid == null)
+                rawBlockmap.put(id, Boolean.TRUE);
+            else
+                blockmap.put(uid, Boolean.TRUE);
         }
-    }
-
-    private static Integer resolveStoredUid(String storedUid, PackageUidResolver resolver) {
-        if (storedUid == null || storedUid.length() == 0)
-            return null;
-
-        try {
-            return Integer.parseInt(storedUid);
-        } catch (NumberFormatException ignored) {
-            // Legacy exports may contain package names. Resolve those below.
-        }
-
-        return resolver == null ? null : resolver.resolve(storedUid);
-    }
-
-    /**
-     * Resolve package-name entries which were unavailable when settings were loaded.
-     *
-     * @param c Context
-     * @return Whether any pending entry was resolved
-     */
-    public synchronized boolean resolvePendingPackages(Context c) {
-        PackageUidResolver resolver = new PackageUidResolver() {
-            @Override
-            public Integer resolve(String packageName) {
-                try {
-                    return c.getPackageManager().getApplicationInfo(packageName, 0).uid;
-                } catch (PackageManager.NameNotFoundException ignored) {
-                    return null;
-                } catch (SecurityException ignored) {
-                    return null;
-                }
-            }
-        };
-
-        return resolvePendingPackages(resolver);
-    }
-
-    synchronized boolean resolvePendingPackages(PackageUidResolver resolver) {
-        boolean changed = false;
-        Iterator<String> pending = rawBlockmap.iterator();
-        while (pending.hasNext()) {
-            Integer uid = resolveStoredUid(pending.next(), resolver);
-            if (uid != null) {
-                blockmap.add(uid);
-                pending.remove();
-                changed = true;
-            }
-        }
-        return changed;
     }
 
     /**
@@ -153,15 +93,7 @@ public class InternetBlocklist {
      * @return Set of uids
      */
     public Set<Integer> getBlocklist() {
-        return blockmap;
-    }
-
-    /**
-     * Clear blocklist
-     */
-    public void clear() {
-        blockmap.clear();
-        rawBlockmap.clear();
+        return blockmap.keySet();
     }
 
     /**
@@ -177,9 +109,9 @@ public class InternetBlocklist {
     public synchronized void saveSettings(Context c) {
         SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
         Set<String> set = new HashSet<>();
-        for (Integer uid : blockmap)
+        for (Integer uid : blockmap.keySet())
             set.add(Integer.toString(uid));
-        set.addAll(rawBlockmap);
+        set.addAll(rawBlockmap.keySet());
 
         prefs.edit().putStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, set).apply();
     }
@@ -190,7 +122,7 @@ public class InternetBlocklist {
      * @param uid Uid of app to block internet
      */
     public synchronized void block(int uid) {
-        blockmap.add(uid);
+        blockmap.put(uid, Boolean.TRUE);
     }
 
     /**
@@ -250,6 +182,6 @@ public class InternetBlocklist {
      * @return If internet is blocked for given app
      */
     public synchronized boolean blockedInternet(int uid) {
-        return blockmap.contains(uid);
+        return blockmap.containsKey(uid);
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/PackageUids.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/PackageUids.java
@@ -1,0 +1,114 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ */
+package net.kollnig.missioncontrol.data;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+/**
+ * The one place that turns a package name into an Android UID, and that asks a
+ * UID whether it still has any package left.
+ * <p>
+ * Both questions have the same two failure modes, and the two must not be
+ * conflated: {@link PackageManager.NameNotFoundException} means <em>absent</em>,
+ * while a {@link SecurityException} — another user or work profile on Android
+ * 16+ — means <em>unknown</em>. Callers that clear state on "absent" would
+ * silently wipe a still-installed app's settings if they read "unknown" the
+ * same way, so the distinction is kept at the seam rather than re-derived by
+ * each caller.
+ */
+public final class PackageUids {
+    private static final String TAG = "TrackerControl.PackageUids";
+
+    private PackageUids() {
+    }
+
+    /**
+     * Resolves a stored package name to a runtime UID.
+     * <p>
+     * A seam so callers can be tested without a {@link PackageManager}.
+     */
+    public interface Resolver {
+        /**
+         * @param packageName Package name to resolve
+         * @return The package's UID, or {@code null} when it cannot be resolved
+         */
+        Integer resolve(String packageName);
+    }
+
+    /**
+     * Reports which packages, if any, still share a UID.
+     * <p>
+     * A seam so callers can be tested without a {@link PackageManager}. Unlike
+     * {@link Resolver} this deliberately lets a {@link SecurityException}
+     * escape: "unknown" and "none left" must stay distinguishable.
+     */
+    public interface Lookup {
+        String[] getPackagesForUid(int uid);
+    }
+
+    /**
+     * Resolve a package name to its UID.
+     *
+     * @param c           Context
+     * @param packageName Package name to resolve
+     * @return The package's UID, or {@code null} when the package is not
+     * installed or its UID cannot be inspected. Callers keep such an entry
+     * pending rather than dropping it.
+     */
+    public static Integer resolve(Context c, String packageName) {
+        if (packageName == null || packageName.length() == 0)
+            return null;
+
+        try {
+            return c.getPackageManager().getApplicationInfo(packageName, 0).uid;
+        } catch (PackageManager.NameNotFoundException ignored) {
+            // Not installed (yet).
+            return null;
+        } catch (SecurityException ex) {
+            Log.w(TAG, "Cannot resolve " + packageName + ": " + ex.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * @param c Context
+     * @return A {@link Resolver} backed by the platform {@link PackageManager}
+     */
+    public static Resolver resolver(final Context c) {
+        return new Resolver() {
+            @Override
+            public Integer resolve(String packageName) {
+                return PackageUids.resolve(c, packageName);
+            }
+        };
+    }
+
+    /**
+     * @param c Context
+     * @return A {@link Lookup} backed by the platform {@link PackageManager}
+     */
+    public static Lookup lookup(final Context c) {
+        return new Lookup() {
+            @Override
+            public String[] getPackagesForUid(int uid) {
+                return c.getPackageManager().getPackagesForUid(uid);
+            }
+        };
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
@@ -18,45 +18,25 @@ package net.kollnig.missioncontrol.data;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.pm.PackageManager;
 
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Stores what trackers are blocked, for each app.
  */
-public class TrackerBlocklist {
+public class TrackerBlocklist extends UidKeyedStore<Set<String>> {
     public static final String SHARED_PREFS_BLOCKLIST_APPS_KEY = "APPS_BLOCKLIST_APPS_KEY";
     final public static String PREF_BLOCKLIST = "blocklist";
     public static String NECESSARY_CATEGORY = "Content";
     private static TrackerBlocklist instance;
-    /**
-     * Whilst blockmap is a list of apps to block, the set is a set of trackers not
-     * to block.
-     */
-    private final Map<Integer, Set<String>> blockmap = new ConcurrentHashMap<>();
-    /**
-     * Legacy package-name entries which cannot be represented by a runtime UID.
-     * Entries retained here are written back under their original raw key so a
-     * later install can resolve them.
-     */
-    private final Map<String, Set<String>> rawBlockmap = new HashMap<>();
-    /** Raw legacy keys retained because a canonical numeric UID won a collision. */
-    private final Map<String, Integer> retainedRawUids = new HashMap<>();
-
-    interface PackageUidResolver {
-        Integer resolve(String packageName);
-    }
 
     private TrackerBlocklist(Context c) {
         // Initialize Concurrent Set using values from shared preferences if possible.
@@ -102,22 +82,9 @@ public class TrackerBlocklist {
     public synchronized void loadSettings(Context c) {
         SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
         Set<String> set = prefs.getStringSet(SHARED_PREFS_BLOCKLIST_APPS_KEY, null);
-        PackageUidResolver resolver = new PackageUidResolver() {
-            @Override
-            public Integer resolve(String packageName) {
-                try {
-                    return c.getPackageManager().getApplicationInfo(packageName, 0).uid;
-                } catch (PackageManager.NameNotFoundException ignored) {
-                    return null;
-                } catch (SecurityException ignored) {
-                    return null;
-                }
-            }
-        };
+        PackageUids.Resolver resolver = PackageUids.resolver(c);
 
-        blockmap.clear();
-        rawBlockmap.clear();
-        retainedRawUids.clear();
+        clear();
         if (set != null) {
             List<String> storedIds = new ArrayList<>(set);
             Collections.sort(storedIds);
@@ -129,8 +96,8 @@ public class TrackerBlocklist {
                 if (!StringUtils.isNumeric(appUid))
                     continue;
 
-                int uid = resolveStoredUid(appUid, null);
-                if (uid >= 0)
+                Integer uid = resolveStoredUid(appUid, null);
+                if (uid != null)
                     blockmap.put(uid, loadSubset(prefs, appUid));
                 else
                     // Numeric, but too large to be a UID. Keep the entry as
@@ -146,9 +113,9 @@ public class TrackerBlocklist {
                 Set<String> rawSubset = loadRawSubset(prefs, appUid);
 
                 // Retrieve uid
-                int uid = resolveStoredUid(appUid, resolver);
+                Integer uid = resolveStoredUid(appUid, resolver);
 
-                if (uid < 0) {
+                if (uid == null) {
                     rawBlockmap.put(appUid, rawSubset);
                 } else if (blockmap.containsKey(uid)) {
                     // A numeric entry wins. Retain the legacy entry under its
@@ -203,70 +170,19 @@ public class TrackerBlocklist {
         return subset;
     }
 
-    static int resolveStoredUid(String storedUid, PackageUidResolver resolver) {
-        if (storedUid == null)
-            return -1;
-
-        if (StringUtils.isNumeric(storedUid)) {
-            try {
-                return Integer.parseInt(storedUid);
-            } catch (NumberFormatException ignored) {
-                return -1;
-            }
+    @Override
+    protected Resolution absorb(int uid, String rawKey, Set<String> raw) {
+        if (!blockmap.containsKey(uid)) {
+            blockmap.put(uid, migrateSubset(raw));
+            return Resolution.ABSORBED;
         }
 
-        if (resolver == null)
-            return -1;
-
-        Integer uid = resolver.resolve(storedUid);
-        return uid == null ? -1 : uid;
-    }
-
-    /**
-     * Resolve package-name entries which were unavailable when settings were loaded.
-     *
-     * @param c Context
-     * @return Whether any pending entry was resolved
-     */
-    public synchronized boolean resolvePendingPackages(Context c) {
-        PackageUidResolver resolver = new PackageUidResolver() {
-            @Override
-            public Integer resolve(String packageName) {
-                try {
-                    return c.getPackageManager().getApplicationInfo(packageName, 0).uid;
-                } catch (PackageManager.NameNotFoundException ignored) {
-                    return null;
-                } catch (SecurityException ignored) {
-                    return null;
-                }
-            }
-        };
-
-        return resolvePendingPackages(resolver);
-    }
-
-    synchronized boolean resolvePendingPackages(PackageUidResolver resolver) {
-        boolean changed = false;
-        Iterator<Map.Entry<String, Set<String>>> pending = rawBlockmap.entrySet().iterator();
-        while (pending.hasNext()) {
-            Map.Entry<String, Set<String>> entry = pending.next();
-            int uid = resolveStoredUid(entry.getKey(), resolver);
-            if (uid < 0)
-                continue;
-
-            if (blockmap.containsKey(uid)) {
-                // A numeric entry remains canonical if a package-name entry
-                // resolves to the same UID. The entry stays pending, so report
-                // the collision only the first time: otherwise every later call
-                // would claim a change and force a needless save.
-                changed |= retainedRawUids.put(entry.getKey(), uid) == null;
-            } else {
-                blockmap.put(uid, migrateSubset(entry.getValue()));
-                pending.remove();
-                changed = true;
-            }
-        }
-        return changed;
+        // A numeric entry remains canonical if a package-name entry resolves to
+        // the same UID. The entry stays pending, so report the collision only
+        // the first time: otherwise every later call would claim a change and
+        // force a needless save.
+        return retainedRawUids.put(rawKey, uid) == null
+                ? Resolution.RETAINED : Resolution.UNCHANGED;
     }
 
     public synchronized boolean hasSubset(int uid) {
@@ -350,21 +266,15 @@ public class TrackerBlocklist {
     }
 
     /**
-     * Completely clear blocklist.
-     */
-    public synchronized void clear() {
-        blockmap.clear();
-        rawBlockmap.clear();
-        retainedRawUids.clear();
-    }
-
-    /**
      * Clear all blocked trackers for a specific app
      *
      * @param uid Uid of app
+     * @return Whether anything was cleared. {@link #saveSettings(Context)}
+     * rewrites every key in the preferences file, so callers use this to skip
+     * that work when the app had no state to begin with.
      */
-    public synchronized void clear(int uid) {
-        blockmap.remove(uid);
+    public synchronized boolean clear(int uid) {
+        boolean changed = blockmap.remove(uid) != null;
 
         // Drop any legacy package-name entry that lost a collision to this uid:
         // the app is gone, so retaining it would resurrect stale settings if a
@@ -375,8 +285,10 @@ public class TrackerBlocklist {
             if (entry.getValue() == uid) {
                 rawBlockmap.remove(entry.getKey());
                 retained.remove();
+                changed = true;
             }
         }
+        return changed;
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/data/UidKeyedStore.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/UidKeyedStore.java
@@ -1,0 +1,177 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ */
+package net.kollnig.missioncontrol.data;
+
+import android.content.Context;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Shared machinery for the two per-app stores that are keyed by Android UID:
+ * {@link TrackerBlocklist} and {@link InternetBlocklist}.
+ * <p>
+ * Both keep the same two tiers. {@link #blockmap} is canonical and UID-keyed.
+ * {@link #rawBlockmap} holds entries whose key could not be turned into a UID —
+ * a package name from an import whose app is not installed yet, or a numeric
+ * string too large to be a UID. Those are written back under their original key
+ * so a later install can still claim them, rather than being dropped.
+ *
+ * @param <V> Per-UID payload; {@link Boolean} where membership is the whole
+ *            state, a set of tracker keys where it is not
+ */
+public abstract class UidKeyedStore<V> {
+    /**
+     * Canonical, UID-keyed state.
+     * <p>
+     * Concurrent because it is read from native packet threads while the UI
+     * thread may be writing.
+     */
+    protected final Map<Integer, V> blockmap = new ConcurrentHashMap<>();
+    /**
+     * Entries retained under a non-UID key because none could be resolved.
+     * <p>
+     * A plain map: it is only touched under the instance monitor, and unlike
+     * {@link #blockmap} it must be able to hold a {@code null} payload.
+     */
+    protected final Map<String, V> rawBlockmap = new HashMap<>();
+    /** Raw keys retained because a canonical numeric UID won a collision. */
+    protected final Map<String, Integer> retainedRawUids = new HashMap<>();
+
+    /** What {@link #absorb} did with one newly-resolved raw entry. */
+    protected enum Resolution {
+        /** Folded into {@link #blockmap}; the raw entry can be dropped. */
+        ABSORBED,
+        /** {@link #blockmap} already owns the UID; the raw entry stays, and this is news. */
+        RETAINED,
+        /** Already retained on an earlier pass; nothing changed. */
+        UNCHANGED
+    }
+
+    /**
+     * Turn a stored key into a UID.
+     * <p>
+     * A numeric key is canonical and never costs a {@link PackageUids} call.
+     * Numeric but unparseable means the key is not a UID and never will be, so
+     * it is not offered to the resolver either — only a genuine package name is.
+     *
+     * @param storedUid Key as written in shared preferences
+     * @param resolver  Resolver for package-name keys; may be {@code null} to
+     *                  resolve numeric keys only
+     * @return The UID, or {@code null} when the key cannot be resolved
+     */
+    static Integer resolveStoredUid(String storedUid, PackageUids.Resolver resolver) {
+        if (storedUid == null || storedUid.length() == 0)
+            return null;
+
+        if (StringUtils.isNumeric(storedUid)) {
+            try {
+                return Integer.parseInt(storedUid);
+            } catch (NumberFormatException ignored) {
+                // Numeric, but too large to be a UID. Keep the entry as written
+                // rather than dropping settings we cannot parse.
+                return null;
+            }
+        }
+
+        return resolver == null ? null : resolver.resolve(storedUid);
+    }
+
+    /**
+     * Fold one resolved raw entry into {@link #blockmap}.
+     *
+     * @param uid    The UID the raw key resolved to
+     * @param rawKey The raw key, still present in {@link #rawBlockmap}
+     * @param raw    Its payload
+     * @return What was done with it
+     */
+    protected abstract Resolution absorb(int uid, String rawKey, V raw);
+
+    /**
+     * Resolve every pending entry.
+     * <p>
+     * This costs one {@link PackageUids} call per pending entry, so it belongs
+     * on rare paths — process start, a settings import — and not on a broadcast
+     * that arrives once per app install <em>and</em> once per app update. Use
+     * {@link #resolvePendingPackage(Context, String)} there instead.
+     *
+     * @param c Context
+     * @return Whether anything changed, i.e. whether a save is warranted
+     */
+    public synchronized boolean resolvePendingPackages(Context c) {
+        return resolvePendingPackages(PackageUids.resolver(c));
+    }
+
+    synchronized boolean resolvePendingPackages(PackageUids.Resolver resolver) {
+        boolean changed = false;
+        Iterator<Map.Entry<String, V>> pending = rawBlockmap.entrySet().iterator();
+        while (pending.hasNext()) {
+            Map.Entry<String, V> entry = pending.next();
+            Integer uid = resolveStoredUid(entry.getKey(), resolver);
+            if (uid == null)
+                continue;
+
+            Resolution resolution = absorb(uid, entry.getKey(), entry.getValue());
+            if (resolution == Resolution.ABSORBED)
+                pending.remove();
+            changed |= resolution != Resolution.UNCHANGED;
+        }
+        return changed;
+    }
+
+    /**
+     * Resolve just the entry a package-added broadcast is about.
+     * <p>
+     * The common case is a hash lookup that misses, so no {@link PackageUids}
+     * call is made at all; at most one is made when the name is actually
+     * pending.
+     *
+     * @param c           Context
+     * @param packageName Package that was just installed; {@code null} is a no-op
+     * @return Whether anything changed, i.e. whether a save is warranted
+     */
+    public synchronized boolean resolvePendingPackage(Context c, String packageName) {
+        return resolvePendingPackage(PackageUids.resolver(c), packageName);
+    }
+
+    synchronized boolean resolvePendingPackage(PackageUids.Resolver resolver, String packageName) {
+        if (packageName == null || !rawBlockmap.containsKey(packageName))
+            return false;
+
+        Integer uid = resolveStoredUid(packageName, resolver);
+        if (uid == null)
+            return false;
+
+        Resolution resolution = absorb(uid, packageName, rawBlockmap.get(packageName));
+        if (resolution == Resolution.ABSORBED)
+            rawBlockmap.remove(packageName);
+        return resolution != Resolution.UNCHANGED;
+    }
+
+    /**
+     * Completely clear the store.
+     */
+    public synchronized void clear() {
+        blockmap.clear();
+        rawBlockmap.clear();
+        retainedRawUids.clear();
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/ActivitySettingsTest.java
+++ b/app/src/test/java/eu/faircode/netguard/ActivitySettingsTest.java
@@ -11,12 +11,17 @@ package eu.faircode.netguard;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.util.Xml;
 
+import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Set;
+
+import org.xmlpull.v1.XmlSerializer;
 
 import net.kollnig.missioncontrol.data.InternetBlocklist;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
@@ -64,5 +69,31 @@ public class ActivitySettingsTest {
         assertFalse(trackerBlocklist.hasSubset(1001));
 
         assertFalse(internetBlocklist.resolvePendingPackages(context));
+    }
+
+    @Test
+    public void exportCarriesAnUnresolvedPackagesSubset() throws Exception {
+        String packageName = "com.example.importedlater";
+        SharedPreferences prefs = context
+                .getSharedPreferences(TrackerBlocklist.PREF_BLOCKLIST, Context.MODE_PRIVATE);
+        prefs.edit()
+                .putStringSet(TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + packageName,
+                        Collections.singleton("Advertising | Example"))
+                .commit();
+
+        StringWriter writer = new StringWriter();
+        XmlSerializer serializer = Xml.newSerializer();
+        serializer.setOutput(writer);
+        serializer.startDocument("UTF-8", true);
+        serializer.startTag(null, "application");
+        // A pending entry is keyed by package name on both sides, so it is
+        // exported verbatim rather than dropped for failing to parse as a UID.
+        ActivitySettings.exportTrackerSubset(prefs, serializer, packageName, packageName);
+        serializer.endTag(null, "application");
+        serializer.endDocument();
+
+        String xml = writer.toString();
+        assertTrue(xml, xml.contains("APPS_BLOCKLIST_PACKAGES_KEY_" + packageName));
+        assertTrue(xml, xml.contains("Advertising | Example"));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/InternetBlocklistTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/InternetBlocklistTest.java
@@ -141,7 +141,7 @@ public class InternetBlocklistTest {
         InternetBlocklist blocklist = InternetBlocklist.getInstance(context);
         assertFalse(blocklist.blockedInternet(1001));
 
-        assertTrue(blocklist.resolvePendingPackages(new InternetBlocklist.PackageUidResolver() {
+        assertTrue(blocklist.resolvePendingPackages(new PackageUids.Resolver() {
             @Override
             public Integer resolve(String storedPackageName) {
                 assertEquals(packageName, storedPackageName);
@@ -149,5 +149,34 @@ public class InternetBlocklistTest {
             }
         }));
         assertTrue(blocklist.blockedInternet(1001));
+    }
+
+    @Test
+    public void resolvingOnePackageSkipsThePackageManagerWhenNothingIsPending() {
+        String packageName = "com.example.later";
+        SharedPreferences prefs = context.getSharedPreferences(
+                TrackerBlocklist.PREF_BLOCKLIST, Context.MODE_PRIVATE);
+        prefs.edit().putStringSet(
+                InternetBlocklist.SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY,
+                Collections.singleton(packageName)).commit();
+
+        InternetBlocklist blocklist = InternetBlocklist.getInstance(context);
+        PackageUids.Resolver strict = new PackageUids.Resolver() {
+            @Override
+            public Integer resolve(String storedPackageName) {
+                assertEquals(packageName, storedPackageName);
+                return 1001;
+            }
+        };
+
+        // A package-added broadcast for any other app must not cost a
+        // PackageManager call.
+        assertFalse(blocklist.resolvePendingPackage(strict, "com.example.unrelated"));
+        assertFalse(blocklist.resolvePendingPackage(strict, null));
+        assertFalse(blocklist.blockedInternet(1001));
+
+        assertTrue(blocklist.resolvePendingPackage(strict, packageName));
+        assertTrue(blocklist.blockedInternet(1001));
+        assertFalse(blocklist.resolvePendingPackage(strict, packageName));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerBlocklistTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerBlocklistTest.java
@@ -16,6 +16,7 @@ package net.kollnig.missioncontrol.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -112,19 +113,32 @@ public class TrackerBlocklistTest {
 
     @Test
     public void resolveStoredUidParsesNumericIdsWithoutResolver() {
-        assertEquals(UID, TrackerBlocklist.resolveStoredUid(Integer.toString(UID), null));
+        assertEquals(Integer.valueOf(UID),
+                UidKeyedStore.resolveStoredUid(Integer.toString(UID), null));
     }
 
     @Test
     public void resolveStoredUidMigratesLegacyPackageNames() {
-        assertEquals(UID, TrackerBlocklist.resolveStoredUid("com.example.app",
-                new TrackerBlocklist.PackageUidResolver() {
+        assertEquals(Integer.valueOf(UID), UidKeyedStore.resolveStoredUid("com.example.app",
+                new PackageUids.Resolver() {
                     @Override
                     public Integer resolve(String packageName) {
                         assertEquals("com.example.app", packageName);
                         return UID;
                     }
                 }));
+    }
+
+    @Test
+    public void resolveStoredUidNeverOffersANumericKeyToTheResolver() {
+        // "Numeric but unparseable" is not a package name, so it must not cost
+        // a PackageManager call.
+        assertNull(UidKeyedStore.resolveStoredUid("2147483648", new PackageUids.Resolver() {
+            @Override
+            public Integer resolve(String packageName) {
+                throw new AssertionError("resolver called for " + packageName);
+            }
+        }));
     }
 
     @Test
@@ -177,7 +191,7 @@ public class TrackerBlocklistTest {
         TrackerBlocklist blocklist = TrackerBlocklist.getInstance(RuntimeEnvironment.getApplication());
         assertTrue(blocklist.getBlocklist().isEmpty());
 
-        assertTrue(blocklist.resolvePendingPackages(new TrackerBlocklist.PackageUidResolver() {
+        assertTrue(blocklist.resolvePendingPackages(new PackageUids.Resolver() {
             @Override
             public Integer resolve(String packageName) {
                 assertEquals(rawId, packageName);
@@ -185,6 +199,38 @@ public class TrackerBlocklistTest {
             }
         }));
         assertEquals(subset, blocklist.getSubset(UID));
+    }
+
+    @Test
+    public void resolvingOnePackageSkipsThePackageManagerWhenNothingIsPending() {
+        SharedPreferences prefs = blocklistPreferences();
+        String rawId = "com.example.later";
+        Set<String> subset = new HashSet<>(Collections.singleton("Advertising | Example"));
+        prefs.edit()
+                .putStringSet(TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY,
+                        Collections.singleton(rawId))
+                .putStringSet(TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY + "_" + rawId, subset)
+                .commit();
+
+        TrackerBlocklist blocklist = TrackerBlocklist.getInstance(RuntimeEnvironment.getApplication());
+        PackageUids.Resolver strict = new PackageUids.Resolver() {
+            @Override
+            public Integer resolve(String packageName) {
+                assertEquals(rawId, packageName);
+                return UID;
+            }
+        };
+
+        // The overwhelmingly common case: some other app was installed, so no
+        // PackageManager call may be made at all.
+        assertFalse(blocklist.resolvePendingPackage(strict, "com.example.unrelated"));
+        assertFalse(blocklist.resolvePendingPackage(strict, null));
+        assertTrue(blocklist.getBlocklist().isEmpty());
+
+        // The package that is actually pending resolves, once.
+        assertTrue(blocklist.resolvePendingPackage(strict, rawId));
+        assertEquals(subset, blocklist.getSubset(UID));
+        assertFalse(blocklist.resolvePendingPackage(strict, rawId));
     }
 
     @Test


### PR DESCRIPTION
Stacked on #829 — base is `claude/uid-cleanup`, so the diff here is only the
follow-up. Merge into #829, or rebase onto `master` if #829 lands first.

## Context

Two things came out of reading #829: the per-broadcast cost of its pending-entry
resolution, and the duplication that resolution introduced across the two
UID-keyed stores. Codex's two review findings on #829 are fixed here too.

## 1. Battery: resolve only the package the broadcast is about

`resolvePendingPackages` swept **every** pending entry on **every**
`ACTION_PACKAGE_ADDED` — app updates included, which is the frequent case —
costing one `PackageManager` call per entry on the service's main thread with the
screen off. An entry that never resolves never leaves the pending set, and the
collision entries in `retainedRawUids` stay pending *by design*, so that sweep
repeated for the life of the install. A Play Store batch updating 30 apps
overnight paid it 30 times.

`ACTION_PACKAGE_ADDED` names its package, so `resolvePendingPackage` resolves
just that one: a hash lookup that misses costs nothing, and at most one
`PackageManager` call is made when the name is actually pending.
`EXTRA_REPLACING` is skipped outright — a replaced package resolved at load time
and its UID does not change on update.

This is the `AGENTS.md` "battery is a first-class constraint" rule: the work is
small per event, but it was unbounded in *time* and landed on a screen-off path.

## 2. Dedupe: one resolver, one two-tier store

Package-name-to-UID resolution existed in six copies that had already drifted on
the `SecurityException` case. `PackageUids` now owns it, along with the
packages-for-UID lookup, keeping **absent** (`NameNotFoundException`) and
**unknown** (`SecurityException`) distinguishable in one place;
`ReceiverPackageRemoved` and the import path use it too.

`UidKeyedStore` holds the `blockmap` / `rawBlockmap` / `retainedRawUids` tiers,
`resolveStoredUid` and the pending-resolution loop. The two stores supply only
what actually differs, via `absorb()`:

- `TrackerBlocklist` retains a colliding entry — it has a subset to lose.
- `InternetBlocklist` absorbs it — membership is the whole state.

`InternetBlocklist`'s javadoc already claimed it was an "analogous
implementation to TrackerBlocklist"; that is now true rather than aspirational.

`Blocklist` / `BlocklistManager` are a different concept — downloadable host
lists, not UID-keyed per-app state — and are untouched.

## 3. Review findings from #829

**Resolve pending entries before rule defaults are created.** Moved the sweep
into `Rule.getRules`, ahead of the `ensureDefaults` loop, rather than relying on
the dynamic receiver. A numeric default created first wins the collision and
strands the imported subset under its package-name key; `Rule.getRules` is also
the only path covering an install made while the VPN was stopped and
`packageChangedReceiver` unregistered — and it covers the UI process, not just
the service.

**Carry pending package-name entries through export.** `xmlExport` treated every
entry in both blocklist ID sets as a numeric UID, so `Integer.parseInt` dropped
exactly the entries #829 preserves, along with their tracker subsets — the export
is package-keyed anyway, so a pending entry now passes through verbatim. The
subset writer is extracted to `exportTrackerSubset` and shared by both branches.

## Also

`ReceiverPackageRemoved` skips the full preference rewrite when
`TrackerBlocklist.clear(uid)` had nothing to clear — `saveSettings` rewrites
every key in the file.

Left alone deliberately: `getInstance` being `synchronized` sits on the packet
path (`isAddressAllowed`, called per flow from native), but it is an uncontended
thin lock and it closes a real unsafe-publication hole on a static field the
native thread reads.

## Testing

347 tests, 0 failures (343 before). Against the Android SDK:
`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and
`:app:lintGithubDebug` all exit 0.

- `TrackerBlocklistTest` / `InternetBlocklistTest` — a package-added broadcast
  for an unrelated app makes no resolver call at all; the pending name resolves
  once and not again.
- `TrackerBlocklistTest` — a numeric-but-unparseable key is never offered to the
  resolver.
- `ActivitySettingsTest` — an unresolved package's tracker subset survives
  export.

Not covered by a test: the `Rule.getRules` ordering fix, which would need the
full `getRules` path under Robolectric. The store-level collision semantics it
depends on are already covered by
`numericUidWinsLegacyCollisionButLegacyEntryIsRetained`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E51DV7ZUPWmjtyrr7DkYXc)_