### PR TITLE
Blocking-mode UX: timeline pointer, mode-independent compatibility exclusions, per-app essential blocking

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1502,6 +1502,10 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         // Upgrade imported settings
         ReceiverAutostart.upgrade(true, this);
 
+        // Reconcile imported apply preferences with auto-exclusions immediately,
+        // rather than waiting for the next process start.
+        BlockingMode.syncAutoExclusions(this);
+
         DatabaseHelper.clearCache();
 
         // Refresh UI

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1084,6 +1084,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         SharedPreferences tracker_protect = getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = tracker_protect.edit();
 
+        // Deliberately leave tracker_essential alone: bulk disabling and then
+        // re-enabling tracker protection returns an essential-only app to its
+        // previous ESSENTIAL_ONLY choice.
         for (android.content.pm.PackageInfo pkg : Rule.getPackages(this))
             editor.putBoolean(pkg.packageName, enabled);
 
@@ -1300,6 +1303,10 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         xmlExport(getSharedPreferences("tracker_protect", Context.MODE_PRIVATE), serializer);
         serializer.endTag(null, "tracker_protect");
 
+        serializer.startTag(null, "tracker_essential");
+        xmlExport(getSharedPreferences("tracker_essential", Context.MODE_PRIVATE), serializer);
+        serializer.endTag(null, "tracker_essential");
+
         serializer.startTag(null, Rule.PREF_WG_ROUTE);
         xmlExport(getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE), serializer);
         serializer.endTag(null, Rule.PREF_WG_ROUTE);
@@ -1491,6 +1498,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         xmlImport(handler.application, prefs);
         xmlImport(handler.apply, getSharedPreferences("apply", Context.MODE_PRIVATE));
         xmlImport(handler.tracker_protect, getSharedPreferences("tracker_protect", Context.MODE_PRIVATE));
+        xmlImport(handler.tracker_essential, getSharedPreferences("tracker_essential", Context.MODE_PRIVATE));
         xmlImport(handler.wg_route, getSharedPreferences(Rule.PREF_WG_ROUTE, Context.MODE_PRIVATE));
         xmlImport(handler.notify, getSharedPreferences("notify", Context.MODE_PRIVATE));
         xmlImport(handler.blocklist, getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE));
@@ -1550,6 +1558,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         public Map<String, Object> roaming = new HashMap<>();
         public Map<String, Object> apply = new HashMap<>();
         public Map<String, Object> tracker_protect = new HashMap<>();
+        public Map<String, Object> tracker_essential = new HashMap<>();
         public Map<String, Object> wg_route = new HashMap<>();
         public Map<String, Object> notify = new HashMap<>();
         public Map<String, Object> blocklist = new HashMap<>();
@@ -1590,6 +1599,8 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
             else if (qName.equals("tracker_protect"))
                 current = tracker_protect;
+            else if (qName.equals("tracker_essential"))
+                current = tracker_essential;
             else if (qName.equals(Rule.PREF_WG_ROUTE))
                 current = wg_route;
 

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -245,8 +245,11 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         final Rule rule = listFiltered.get(position);
         final InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
         final boolean blockedInternet = internetBlocklist.blockedInternet(rule.uid);
+        final SharedPreferences essentialOnly =
+                context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
         final AppProtectionState state = AppProtectionState.resolve(
-                rule.apply, rule.tracker_protect, blockedInternet);
+                rule.apply, rule.tracker_protect, blockedInternet,
+                BlockingMode.isEssentialOnlyApp(context, essentialOnly, rule.packageName));
         // The Internet toggle below is available for every app TrackerControl
         // still sees. Reading it off the shared state model keeps the main list
         // and the details screen in agreement — in particular, an app with its

--- a/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
@@ -125,7 +125,7 @@ public class ApplicationEx extends Application {
         BlockingMode.enforcePlayStoreMode(this);
 
         // Keep VPN exclusions aligned with the selected blocking mode on startup.
-        BlockingMode.syncModeExclusions(this);
+        BlockingMode.syncAutoExclusions(this);
 
         registerActivityLifecycleCallbacks(new ActivityLifecycleCallbacks() {
             @Override

--- a/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
@@ -43,6 +43,9 @@ public class ReceiverPackageRemoved extends BroadcastReceiver {
             int uid = intent.getIntExtra(Intent.EXTRA_UID, 0);
             String packageName = intent.getData() == null ? null : intent.getData().getSchemeSpecificPart();
             PausedApps.onPackageRemoved(context, packageName, uid);
+            if (packageName != null)
+                context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE)
+                        .edit().remove(packageName).apply();
             if (uid > 0) {
                 DatabaseHelper dh = DatabaseHelper.getInstance(context);
                 dh.clearLog(uid);

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -351,6 +351,7 @@ public class ServiceSinkhole extends VpnService {
     // Cached preferences for shouldTrackApp() - refreshed in reload()
     private volatile SharedPreferences cachedTrackerProtectPrefs;
     private volatile SharedPreferences cachedApplyPrefs;
+    private volatile SharedPreferences cachedEssentialPrefs;
     private volatile boolean cachedManageSystem;
 
     private static final int NOTIFY_ENFORCING = 1;
@@ -848,6 +849,7 @@ public class ServiceSinkhole extends VpnService {
             // Refresh cached preferences for shouldTrackApp()
             cachedTrackerProtectPrefs = getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
             cachedApplyPrefs = getSharedPreferences("apply", Context.MODE_PRIVATE);
+            cachedEssentialPrefs = getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
             cachedManageSystem = prefs.getBoolean("manage_system", false);
 
             if (state != State.enforcing) {
@@ -2989,6 +2991,19 @@ public class ServiceSinkhole extends VpnService {
         return true;
     }
 
+    private boolean essentialOnlyApp(int uid) {
+        String packageName = uidToPackage.get(uid);
+        if (packageName == null)
+            return false;
+
+        SharedPreferences essentialPrefs = cachedEssentialPrefs;
+        if (essentialPrefs == null)
+            essentialPrefs = getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
+        // Shared-UID attribution deliberately follows shouldTrackApp: use the
+        // first package cached for the UID, inheriting that method's caveat.
+        return BlockingMode.isEssentialOnlyApp(this, essentialPrefs, packageName);
+    }
+
     private boolean blockKnownTracker(String daddr, int uid) {
         if (!shouldTrackApp(uid)) {
             return false;
@@ -3140,6 +3155,17 @@ public class ServiceSinkhole extends VpnService {
             }
         } else {
             if (tracker != null && tracker != NO_TRACKER) {
+                if (!BlockingMode.MODE_MINIMAL.equals(blockingMode) && essentialOnlyApp(uid)) {
+                    String hostname = cached == null ? null : cached.getHostname();
+                    Tracker essentialTracker = hostname == null
+                            ? null : TrackerList.findEssentialTracker(hostname);
+                    // Strict mode retains tracker evidence for mixed-evidence
+                    // IPs where Minimal mode would collapse it to NO_TRACKER;
+                    // this accepted deviation can block slightly more here.
+                    return BlockingModeLogic.shouldBlockEssentialOnly(
+                            essentialTracker == null ? null : essentialTracker.category);
+                }
+
                 boolean blockedByGranularRule = false;
                 if (!BlockingMode.MODE_MINIMAL.equals(blockingMode)) {
                     TrackerBlocklist b = TrackerBlocklist.getInstance(ServiceSinkhole.this);

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -42,6 +42,7 @@ import androidx.core.app.NavUtils;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import androidx.preference.PreferenceManager;
 import androidx.viewpager2.widget.ViewPager2;
 
 import com.google.android.material.appbar.AppBarLayout;
@@ -129,6 +130,10 @@ public class DetailsActivity extends AppCompatActivity {
         appPackageName = intent.getStringExtra(INTENT_EXTRA_APP_PACKAGENAME);
         appUid = intent.getIntExtra(INTENT_EXTRA_APP_UID, -1);
         String appName = intent.getStringExtra(INTENT_EXTRA_APP_NAME);
+        // Opening Details means the user has found where to adjust protection.
+        PreferenceManager.getDefaultSharedPreferences(this).edit()
+                .putBoolean("hint_timeline_tap_entry", false)
+                .apply();
 
         // Set up paging
         detailsStateAdapter = new DetailsStateAdapter(

--- a/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
@@ -51,6 +51,7 @@ public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntr
     private TimelineAdapter timelineAdapter;
     private InsightsHeaderAdapter insightsAdapter;
     private TimelineEmptyAdapter emptyAdapter;
+    private TimelineHintAdapter hintAdapter;
     private RecyclerView rvTimeline;
     private SwipeRefreshLayout swipeRefresh;
 
@@ -88,9 +89,15 @@ public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntr
         rvTimeline.setLayoutManager(new LinearLayoutManager(requireContext()));
         insightsAdapter = new InsightsHeaderAdapter(requireContext());
         emptyAdapter = new TimelineEmptyAdapter();
+        hintAdapter = new TimelineHintAdapter(() -> {
+            PreferenceManager.getDefaultSharedPreferences(requireContext()).edit()
+                    .putBoolean("hint_timeline_tap_entry", false)
+                    .apply();
+            hintAdapter.setVisible(false);
+        });
         timelineAdapter = new TimelineAdapter(requireContext(), this);
 
-        ConcatAdapter concat = new ConcatAdapter(insightsAdapter, emptyAdapter, timelineAdapter);
+        ConcatAdapter concat = new ConcatAdapter(insightsAdapter, emptyAdapter, hintAdapter, timelineAdapter);
         rvTimeline.setAdapter(concat);
 
         swipeRefresh.setOnRefreshListener(this::refreshAll);
@@ -151,7 +158,7 @@ public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntr
 
             @Override
             protected void onPostExecute(List<TimelineEntry> entries) {
-                if (!isAdded())
+                if (!isAdded() || getView() == null)
                     return;
                 timelineAdapter.setEntries(entries);
                 swipeRefresh.setRefreshing(false);
@@ -162,6 +169,9 @@ public class TimelineFragment extends Fragment implements TimelineAdapter.OnEntr
                 emptyAdapter.setTrackerRecordingAvailable(
                         !Util.isPlayStoreInstall(requireContext()));
                 emptyAdapter.setVisible(entries.isEmpty());
+                hintAdapter.setVisible(TimelineHintAdapter.shouldShow(
+                        !entries.isEmpty(),
+                        prefs.getBoolean("hint_timeline_tap_entry", true)));
             }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }

--- a/app/src/main/java/net/kollnig/missioncontrol/TimelineHintAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/TimelineHintAdapter.java
@@ -1,0 +1,66 @@
+package net.kollnig.missioncontrol;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.button.MaterialButton;
+
+public class TimelineHintAdapter extends RecyclerView.Adapter<TimelineHintAdapter.ViewHolder> {
+
+    private final Runnable onDismiss;
+    private boolean visible = false;
+
+    public TimelineHintAdapter(Runnable onDismiss) {
+        this.onDismiss = onDismiss;
+    }
+
+    public void setVisible(boolean visible) {
+        if (this.visible == visible)
+            return;
+        this.visible = visible;
+        if (visible)
+            notifyItemInserted(0);
+        else
+            notifyItemRemoved(0);
+    }
+
+    @Override
+    public int getItemCount() {
+        return visible ? 1 : 0;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(R.layout.item_timeline_hint, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        holder.tvHintText.setText(R.string.timeline_hint_tap_entry);
+        holder.btnHintDismiss.setText(R.string.timeline_hint_dismiss);
+        holder.btnHintDismiss.setOnClickListener(v -> onDismiss.run());
+    }
+
+    static boolean shouldShow(boolean hasEntries, boolean hintEnabled) {
+        return hasEntries && hintEnabled;
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+        TextView tvHintText;
+        MaterialButton btnHintDismiss;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+            tvHintText = itemView.findViewById(R.id.tvHintText);
+            btnHintDismiss = itemView.findViewById(R.id.btnHintDismiss);
+        }
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionState.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionState.java
@@ -17,17 +17,19 @@ package net.kollnig.missioncontrol.data;
 /**
  * The single per-app protection state shown in the app details header.
  * <p>
- * It is a derived view over three pre-existing stores — the per-package
- * "apply" and "tracker_protect" preferences and the per-UID internet
- * blocklist — none of which change format here. Those stores are written by
+ * It is a derived view over four stores — the per-package "apply",
+ * "tracker_protect", and "tracker_essential" preferences and the per-UID
+ * internet blocklist — none of which change format here. Those stores are written by
  * more actors than the two UI paths (bulk settings actions, the beta
  * vpn_exclude migration, blocking-mode exclusion sync, XML import), so every
- * one of the eight combinations can legitimately exist on disk.
+ * one of the sixteen combinations can legitimately exist on disk.
  * {@link #resolve} is therefore a total derivation, not an invariant.
  */
 public enum AppProtectionState {
     /** Routed through the VPN, trackers blocked and recorded. */
     PROTECTED,
+    /** Routed through the VPN, with only essential trackers blocked and recorded. */
+    ESSENTIAL_ONLY,
     /** Routed through the VPN, but trackers are neither blocked nor recorded. */
     TRACKERS_ALLOWED,
     /** Routed through the VPN, but all connections are dropped. */
@@ -36,7 +38,7 @@ public enum AppProtectionState {
     BYPASSED;
 
     /**
-     * Derive the state from the three stores.
+     * Derive the state from the four stores.
      * <p>
      * Precedence is Bypass, then No-internet, then the protection flag. Bypass
      * dominates for a mechanical reason rather than as a UI convention: an app
@@ -50,15 +52,25 @@ public enum AppProtectionState {
      *                        already applied (see
      *                        {@link BlockingMode#isTrackerProtectionEnabled})
      * @param internetBlocked whether the app's UID is in the internet blocklist
+     * @param essentialOnly   whether only essential trackers should be blocked
      */
     public static AppProtectionState resolve(boolean apply,
             boolean trackerProtect,
             boolean internetBlocked) {
+        return resolve(apply, trackerProtect, internetBlocked, false);
+    }
+
+    public static AppProtectionState resolve(boolean apply,
+            boolean trackerProtect,
+            boolean internetBlocked,
+            boolean essentialOnly) {
         if (!apply)
             return BYPASSED;
         if (internetBlocked)
             return NO_INTERNET;
-        return trackerProtect ? PROTECTED : TRACKERS_ALLOWED;
+        if (!trackerProtect)
+            return TRACKERS_ALLOWED;
+        return essentialOnly ? ESSENTIAL_ONLY : PROTECTED;
     }
 
     /**
@@ -71,31 +83,36 @@ public enum AppProtectionState {
     public static Change of(AppProtectionState target) {
         switch (target) {
             case PROTECTED:
-                return new Change(true, Boolean.TRUE, Boolean.FALSE);
+                return new Change(true, Boolean.TRUE, Boolean.FALSE, Boolean.FALSE);
+            case ESSENTIAL_ONLY:
+                return new Change(true, Boolean.TRUE, Boolean.FALSE, Boolean.TRUE);
             case TRACKERS_ALLOWED:
-                return new Change(true, Boolean.FALSE, Boolean.FALSE);
+                return new Change(true, Boolean.FALSE, Boolean.FALSE, null);
             case NO_INTERNET:
-                return new Change(true, null, Boolean.TRUE);
+                return new Change(true, null, Boolean.TRUE, null);
             case BYPASSED:
-                return new Change(false, null, null);
+                return new Change(false, null, null, null);
             default:
                 throw new IllegalArgumentException("Unknown state " + target);
         }
     }
 
     /**
-     * A write plan over the three stores. A {@code null} field means the store
-     * is left untouched.
+     * A write plan over the four stores. A {@code null} field means the store is
+     * left untouched.
      */
     public static final class Change {
         public final boolean apply;
         public final Boolean trackerProtect;
         public final Boolean internetBlocked;
+        public final Boolean essentialOnly;
 
-        Change(boolean apply, Boolean trackerProtect, Boolean internetBlocked) {
+        Change(boolean apply, Boolean trackerProtect, Boolean internetBlocked,
+                Boolean essentialOnly) {
             this.apply = apply;
             this.trackerProtect = trackerProtect;
             this.internetBlocked = internetBlocked;
+            this.essentialOnly = essentialOnly;
         }
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionWriter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionWriter.java
@@ -17,7 +17,7 @@ import eu.faircode.netguard.Rule;
 import eu.faircode.netguard.ServiceSinkhole;
 
 /**
- * Writes the three existing stores behind the per-app protection state.
+ * Writes the four stores behind the per-app protection state.
  */
 public final class AppProtectionWriter {
     private AppProtectionWriter() {
@@ -43,7 +43,7 @@ public final class AppProtectionWriter {
     public static void applyScheduled(Context context, String packageName, int uid,
             boolean applyValue) {
         Context appContext = context.getApplicationContext();
-        apply(appContext, packageName, uid, applyValue, null, null);
+        apply(appContext, packageName, uid, applyValue, null, null, null);
     }
 
     /** Apply one scheduled apply value to a UID's packages in one preference edit. */
@@ -73,13 +73,15 @@ public final class AppProtectionWriter {
     private static void apply(Context context, String packageName, int uid,
             AppProtectionState.Change change) {
         apply(context, packageName, uid, change.apply, change.trackerProtect,
-                change.internetBlocked);
+                change.internetBlocked, change.essentialOnly);
     }
 
     private static void apply(Context context, String packageName, int uid,
-            boolean applyValue, Boolean trackerProtectValue, Boolean internetBlocked) {
+            boolean applyValue, Boolean trackerProtectValue, Boolean internetBlocked,
+            Boolean essentialOnlyValue) {
         SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
         SharedPreferences trackerProtect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+        SharedPreferences essentialOnly = context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
 
         boolean applyBefore = apply.getBoolean(packageName, true);
         boolean protectBefore = BlockingMode.isTrackerProtectionEnabled(context, trackerProtect, packageName);
@@ -90,9 +92,13 @@ public final class AppProtectionWriter {
 
         if (trackerProtectValue != null)
             trackerProtect.edit().putBoolean(packageName, trackerProtectValue).apply();
+        if (essentialOnlyValue != null)
+            essentialOnly.edit().putBoolean(packageName, essentialOnlyValue).apply();
 
         InternetBlocklist.getInstance(context).apply(context, uid, internetBlocked);
 
+        // The service reads this per-package flag through the live preferences
+        // handle, so changing it alone needs no service reload.
         boolean needsReload = applyValue != applyBefore
                 || (trackerProtectValue != null && trackerProtectValue != protectBefore);
         if (!needsReload)

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
@@ -97,6 +97,17 @@ public class BlockingMode {
         return resolveTrackerProtection(isBrowserApp(c, packageName), configured);
     }
 
+    /**
+     * Check whether this package has selected essential-only protection. The
+     * global Minimal mode already applies the same policy to every app, so a
+     * stored per-app flag must not change the state shown there.
+     */
+    public static boolean isEssentialOnlyApp(Context c,
+            SharedPreferences essentialPrefs,
+            String packageName) {
+        return !isMinimalMode(c) && essentialPrefs.getBoolean(packageName, false);
+    }
+
     static boolean resolveTrackerProtection(boolean browser, Boolean configured) {
         return configured == null ? !browser : configured;
     }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
@@ -36,12 +36,14 @@ import eu.faircode.netguard.ServiceSinkhole;
 import net.kollnig.missioncontrol.BuildConfig;
 
 /**
- * Manages the DDG Minimal Blocking mode.
+ * Manages DDG blocking-mode behavior and compatibility VPN exclusions.
+ *
+ * Mode-independent behavior:
+ * - Known VPN-incompatible apps are auto-excluded from VPN
  *
  * In minimal mode:
  * - Only DDG trackers with "block" action are blocked (not "ignore")
  * - Browsers stay routed through the VPN, but tracker protection defaults off
- * - Known VPN-incompatible apps are auto-excluded from VPN
  * - Hosts-file based blocking is disabled
  * - The "Content" category is never blocked (no strict_blocking)
  * - No granular per-tracker controls
@@ -49,6 +51,7 @@ import net.kollnig.missioncontrol.BuildConfig;
 public class BlockingMode {
     private static final String TAG = BlockingMode.class.getSimpleName();
     public static final String PREF_BLOCKING_MODE = "blocking_mode";
+    // Keep the legacy key name so existing auto-exclusion bookkeeping survives upgrades.
     private static final String PREF_MINIMAL_AUTO_EXCLUDED_APPS = "minimal_auto_excluded_apps";
     public static final String MODE_MINIMAL = BlockingModeLogic.MODE_MINIMAL;
     public static final String MODE_STANDARD = BlockingModeLogic.MODE_STANDARD;
@@ -134,7 +137,7 @@ public class BlockingMode {
     }
 
     /**
-     * Get the set of package names that should be excluded from VPN in minimal mode.
+     * Get the set of package names that should be excluded from VPN for compatibility.
      * Browser packages are deliberately excluded from this set; browser
      * compatibility is handled by disabling tracker protection by default, not
      * by bypassing the VPN route.
@@ -144,15 +147,6 @@ public class BlockingMode {
             excludedApps = loadExcludedApps(c);
 
         return excludedApps;
-    }
-
-    /**
-     * Check if a specific app should be excluded in minimal mode.
-     */
-    public static boolean isAppExcludedInMinimalMode(Context c, String packageName) {
-        if (!isMinimalMode(c))
-            return false;
-        return getExcludedApps(c).contains(packageName);
     }
 
     /**
@@ -177,7 +171,7 @@ public class BlockingMode {
             String json = new String(buffer, StandardCharsets.UTF_8);
             apps.addAll(BlockingModeLogic.parseExcludedAppsJson(json));
 
-            Log.i(TAG, "Loaded " + apps.size() + " excluded apps for minimal mode");
+            Log.i(TAG, "Loaded " + apps.size() + " compatibility VPN exclusions");
         } catch (IOException e) {
             Log.e(TAG, "Failed to load excluded apps", e);
         }
@@ -205,15 +199,12 @@ public class BlockingMode {
     }
 
     /**
-     * Synchronize auto-managed VPN exclusions with the selected blocking mode.
-     * Minimal mode auto-excludes known incompatible apps; standard/strict restore
-     * any exclusions that were added automatically when minimal mode was active.
+     * Synchronize auto-managed compatibility VPN exclusions with the DDG list.
      */
-    public static void syncModeExclusions(Context c) {
+    public static void syncAutoExclusions(Context c) {
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(c);
         SharedPreferences apply = c.getSharedPreferences("apply", Context.MODE_PRIVATE);
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                getMode(c),
                 getExcludedApps(c),
                 getBooleanPrefs(apply),
                 getAutoExcludedApps(prefs));
@@ -234,14 +225,14 @@ public class BlockingMode {
             prefsEditor.putStringSet(PREF_MINIMAL_AUTO_EXCLUDED_APPS, result.autoExcludedApps);
         prefsEditor.apply();
 
-        Log.i(TAG, (isMinimalMode(c) ? "Applied" : "Restored") + " mode-managed VPN exclusions");
+        Log.i(TAG, "Synchronized compatibility VPN exclusions");
     }
 
     /**
      * Apply all runtime side effects of the current blocking mode.
      */
     public static void applyMode(Context c) {
-        syncModeExclusions(c);
+        syncAutoExclusions(c);
 
         TrackerBlocklist trackerBlocklist = TrackerBlocklist.getInstance(c);
         if (trackerBlocklist.applyStrictModeToAll(isStrictMode(c)))
@@ -261,7 +252,7 @@ public class BlockingMode {
      * minimal mode exclusions.
      */
     public static void applyMinimalModeExclusions(Context c) {
-        syncModeExclusions(c);
+        syncAutoExclusions(c);
     }
 
     public static void clearAutoExcludedApp(Context c, String packageName) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
@@ -21,7 +21,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * Pure helpers for mode-specific blocking behavior and VPN exclusion syncing.
+ * Pure helpers for mode-specific blocking behavior and compatibility VPN exclusion syncing.
  */
 public final class BlockingModeLogic {
     public static final String MODE_MINIMAL = "minimal";
@@ -45,36 +45,28 @@ public final class BlockingModeLogic {
         return blockedByGranularRule;
     }
 
-    public static ExclusionSyncResult syncVpnExclusions(String mode,
-            Set<String> excludedApps,
+    public static ExclusionSyncResult syncVpnExclusions(Set<String> excludedApps,
             Map<String, Boolean> applyPrefs,
             Set<String> autoExcludedApps) {
         Set<String> nextAutoExcludedApps = new HashSet<>(autoExcludedApps);
         Set<String> applyFalsePackages = new HashSet<>();
         Set<String> applyRemovals = new HashSet<>();
 
-        if (MODE_MINIMAL.equals(mode)) {
-            for (String packageName : new HashSet<>(nextAutoExcludedApps)) {
-                if (!excludedApps.contains(packageName)) {
-                    if (Boolean.FALSE.equals(applyPrefs.get(packageName)))
-                        applyRemovals.add(packageName);
-                    nextAutoExcludedApps.remove(packageName);
-                }
-            }
-
-            for (String packageName : excludedApps) {
-                if (!applyPrefs.containsKey(packageName)) {
-                    applyFalsePackages.add(packageName);
-                    nextAutoExcludedApps.add(packageName);
-                } else if (Boolean.TRUE.equals(applyPrefs.get(packageName))) {
-                    nextAutoExcludedApps.remove(packageName);
-                }
-            }
-        } else {
-            for (String packageName : nextAutoExcludedApps)
+        for (String packageName : new HashSet<>(nextAutoExcludedApps)) {
+            if (!excludedApps.contains(packageName)) {
                 if (Boolean.FALSE.equals(applyPrefs.get(packageName)))
                     applyRemovals.add(packageName);
-            nextAutoExcludedApps.clear();
+                nextAutoExcludedApps.remove(packageName);
+            }
+        }
+
+        for (String packageName : excludedApps) {
+            if (!applyPrefs.containsKey(packageName)) {
+                applyFalsePackages.add(packageName);
+                nextAutoExcludedApps.add(packageName);
+            } else if (Boolean.TRUE.equals(applyPrefs.get(packageName))) {
+                nextAutoExcludedApps.remove(packageName);
+            }
         }
 
         return new ExclusionSyncResult(nextAutoExcludedApps, applyFalsePackages, applyRemovals);

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
@@ -14,6 +14,8 @@
 
 package net.kollnig.missioncontrol.data;
 
+import androidx.annotation.Nullable;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -43,6 +45,10 @@ public final class BlockingModeLogic {
             return !CONTENT_CATEGORY.equals(trackerCategory);
 
         return blockedByGranularRule;
+    }
+
+    public static boolean shouldBlockEssentialOnly(@Nullable String essentialCategory) {
+        return essentialCategory != null && !CONTENT_CATEGORY.equals(essentialCategory);
     }
 
     public static ExclusionSyncResult syncVpnExclusions(Set<String> excludedApps,

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
@@ -56,6 +56,7 @@ class InsightsDataProvider(context: Context) {
         val showSystem = prefs.getBoolean("show_system", false)
         val applyPrefs = context.getSharedPreferences("apply", Context.MODE_PRIVATE)
         val trackerProtectPrefs = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE)
+        val essentialOnlyPrefs = context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE)
         val blockingMode = BlockingMode.getMode(context)
 
         // Cache for UID -> package info lookups
@@ -116,6 +117,9 @@ class InsightsDataProvider(context: Context) {
                         if (!BlockingMode.isTrackerProtectionEnabled(context, trackerProtectPrefs, packageName)) continue
                     }
 
+                    val essentialOnly = packageName != null
+                        && BlockingMode.isEssentialOnlyApp(context, essentialOnlyPrefs, packageName)
+
                     // Find tracker company for this hostname
                     val tracker = TrackerList.findTracker(daddr) ?: continue
                     val allowed = if (allowedIndex >= 0 && !cursor.isNull(allowedIndex))
@@ -136,10 +140,12 @@ class InsightsDataProvider(context: Context) {
 
                     val isBlocked = isTrackerContactBlocked(
                         uid,
+                        daddr,
                         tracker,
                         allowed,
                         uncertainty,
-                        blockingMode
+                        blockingMode,
+                        essentialOnly
                     )
                     if (isBlocked) {
                         data.blockedTrackingAttempts += 1
@@ -298,13 +304,20 @@ class InsightsDataProvider(context: Context) {
 
     private fun isTrackerContactBlocked(
         uid: Int,
+        daddr: String,
         tracker: Tracker,
         allowed: Int,
         uncertainty: Int,
-        blockingMode: String
+        blockingMode: String,
+        essentialOnly: Boolean
     ): Boolean {
         if (allowed >= 0)
             return allowed == 0
+
+        if (blockingMode != BlockingMode.MODE_MINIMAL && essentialOnly) {
+            val essentialTracker = TrackerList.findEssentialTracker(daddr)
+            return BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker?.category)
+        }
 
         if (!BlockingMode.isStrictMode(context)
             && uncertainty == DatabaseHelper.ACCESS_UNCERTAIN_MIXED_TRACKER_AND_NON_TRACKER) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -95,6 +95,7 @@ public class TrackerList {
      */
     private static final class TrackerSnapshot {
         private final Map<String, Tracker> hostnameToTracker;
+        private final Map<String, Tracker> essentialHostnameToTracker;
         private final boolean domainBasedBlocking;
         private final boolean minimalBlockingMode;
         private final String blockingMode;
@@ -106,7 +107,16 @@ public class TrackerList {
         private TrackerSnapshot(Map<String, Tracker> hostnameToTracker,
                 boolean domainBasedBlocking, boolean minimalBlockingMode, String blockingMode,
                 boolean loaded) {
+            this(hostnameToTracker, hostnameToTracker, domainBasedBlocking,
+                    minimalBlockingMode, blockingMode, loaded);
+        }
+
+        private TrackerSnapshot(Map<String, Tracker> hostnameToTracker,
+                Map<String, Tracker> essentialHostnameToTracker,
+                boolean domainBasedBlocking, boolean minimalBlockingMode, String blockingMode,
+                boolean loaded) {
             this.hostnameToTracker = hostnameToTracker;
+            this.essentialHostnameToTracker = essentialHostnameToTracker;
             this.domainBasedBlocking = domainBasedBlocking;
             this.minimalBlockingMode = minimalBlockingMode;
             this.blockingMode = blockingMode;
@@ -179,20 +189,7 @@ public class TrackerList {
 
         TrackerSnapshot snapshot = trackerSnapshot;
         Map<String, Tracker> hostnameToTracker = snapshot.hostnameToTracker;
-
-        Tracker t = null;
-
-        if (hostnameToTracker.containsKey(hostname)) {
-            t = hostnameToTracker.get(hostname);
-        } else { // check subdomains
-            for (int i = 0; i < hostname.length(); i++) {
-                if (hostname.charAt(i) == '.') {
-                    t = hostnameToTracker.get(hostname.substring(i + 1));
-                    if (t != null)
-                        break;
-                }
-            }
-        }
+        Tracker t = lookupHost(hostnameToTracker, hostname);
 
         // In minimal mode, skip hosts-file based lookups (only use DDG tracker list)
         if (t == null && !snapshot.minimalBlockingMode
@@ -206,6 +203,55 @@ public class TrackerList {
             }
 
         return t;
+    }
+
+    /**
+     * Find a hostname in a tracker map, including its parent domains.
+     */
+    private static Tracker lookupHost(Map<String, Tracker> hostnameToTracker, String hostname) {
+        Tracker t = hostnameToTracker.get(hostname);
+        if (t != null)
+            return t;
+
+        for (int i = 0; i < hostname.length(); i++) {
+            if (hostname.charAt(i) == '.') {
+                t = hostnameToTracker.get(hostname.substring(i + 1));
+                if (t != null)
+                    return t;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find a hostname in the DDG-only map. Unlike {@link #findTracker}, this
+     * never consults or mutates the hosts-file map.
+     */
+    public static Tracker findEssentialTracker(@NonNull String hostname) {
+        hostname = hostname.toLowerCase(Locale.ROOT);
+        return lookupHost(trackerSnapshot.essentialHostnameToTracker, hostname);
+    }
+
+    /**
+     * Whether any observed host belongs to a non-Content DDG tracker.
+     */
+    public static boolean isEssentiallyBlocked(Tracker tracker) {
+        if (tracker == null)
+            return false;
+
+        for (String host : tracker.getHosts()) {
+            if (host == null)
+                continue;
+            String hostname = host.endsWith(" *")
+                    ? host.substring(0, host.length() - 2) : host;
+            Tracker essentialTracker = findEssentialTracker(hostname);
+            if (essentialTracker != null
+                    && BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker.category))
+                return true;
+        }
+
+        return false;
     }
 
     /**
@@ -250,16 +296,20 @@ public class TrackerList {
             String blockingMode = BlockingMode.getMode(c);
             boolean minimalBlockingMode = BlockingMode.MODE_MINIMAL.equals(blockingMode);
             Map<String, Tracker> loadedTrackers = new ConcurrentHashMap<>();
+            Map<String, Tracker> essentialTrackers = minimalBlockingMode
+                    ? loadedTrackers : new HashMap<>();
 
             boolean loaded;
             if (minimalBlockingMode) {
                 // In minimal mode, only load DDG trackers (skip X-Ray and Disconnect)
                 // This ensures only confirmed, breakage-tested trackers are blocked
-                loaded = loadDuckDuckGoTrackers(c, loadedTrackers, domainBasedBlocking);
+                loaded = loadDuckDuckGoTrackers(c, loadedTrackers, essentialTrackers,
+                        domainBasedBlocking);
             } else {
                 loaded = loadXrayTrackers(c, loadedTrackers, domainBasedBlocking);
                 loaded = loaded && loadDisconnectTrackers(c, loadedTrackers, domainBasedBlocking);
-                loaded = loaded && loadDuckDuckGoTrackers(c, loadedTrackers, domainBasedBlocking);
+                loaded = loaded && loadDuckDuckGoTrackers(c, loadedTrackers, essentialTrackers,
+                        domainBasedBlocking);
             }
 
             if (!loaded) {
@@ -268,7 +318,9 @@ public class TrackerList {
             }
 
             trackerSnapshot = new TrackerSnapshot(
-                    loadedTrackers, domainBasedBlocking, minimalBlockingMode, blockingMode, true);
+                    loadedTrackers,
+                    minimalBlockingMode ? essentialTrackers : Collections.unmodifiableMap(essentialTrackers),
+                    domainBasedBlocking, minimalBlockingMode, blockingMode, true);
             invalidateTrackerCountCache();
             return true;
         }
@@ -644,7 +696,7 @@ public class TrackerList {
      * @param c Context
      */
     private boolean loadDuckDuckGoTrackers(Context c, Map<String, Tracker> hostnameToTracker,
-            boolean domainBasedBlocking) {
+            Map<String, Tracker> essentialHostnameToTracker, boolean domainBasedBlocking) {
         // Stream-parse to avoid materialising the whole file as a String plus a
         // JSONObject DOM. Produces the exact same map as the previous DOM-based
         // parse (this list is loaded in every mode, so it also helps minimal mode).
@@ -694,6 +746,18 @@ public class TrackerList {
                     if (isIgnoredDomain(domain))
                         continue;
 
+                    // Keep the DDG category before checking whether another
+                    // blocklist already claimed the domain in the main map.
+                    String category;
+                    if ("ignore".equals(defaultAction)) {
+                        category = "Content"; // Similar to necessary trackers
+                    } else {
+                        category = UNCATEGORISED; // Default to uncategorised instead of Advertisement
+                    }
+
+                    Tracker tracker = new Tracker(displayName, category);
+                    addTrackerDomain(tracker, domain, essentialHostnameToTracker, domainBasedBlocking);
+
                     // Check if tracker already exists (e.g., from Disconnect list)
                     Tracker existingTracker = hostnameToTracker.get(domain);
 
@@ -704,17 +768,6 @@ public class TrackerList {
                         // Don't overwrite non-Content categories from Disconnect
                         continue;
                     }
-
-                    // Determine category based on default action
-                    String category;
-                    if ("ignore".equals(defaultAction)) {
-                        category = "Content"; // Similar to necessary trackers
-                    } else {
-                        category = UNCATEGORISED; // Default to uncategorised instead of Advertisement
-                    }
-
-                    // Create tracker with owner's display name
-                    Tracker tracker = new Tracker(displayName, category);
 
                     // Add domain to tracker map
                     addTrackerDomain(tracker, domain, hostnameToTracker, domainBasedBlocking);

--- a/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
@@ -112,6 +112,7 @@ public class ProtectionActivity extends AppCompatActivity {
         tvRecordingUnavailable = findViewById(R.id.tvRecordingUnavailable);
         tvStateNoInternetDesc = findViewById(R.id.tvStateNoInternetDesc);
         stateGroup = findViewById(R.id.rgAppState);
+        updateEssentialOnlyVisibility();
 
         btnPauseResume.setOnClickListener(v -> pauseOrResume());
         stateGroup.setOnCheckedChangeListener((group, checkedId) -> {
@@ -154,6 +155,7 @@ public class ProtectionActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         if (stateGroup != null) {
+            updateEssentialOnlyVisibility();
             updateProtectionState();
             loadBlockedTrackers();
         }
@@ -173,7 +175,8 @@ public class ProtectionActivity extends AppCompatActivity {
         AppProtectionState state = AppProtectionState.resolve(
                 stores.apply.getBoolean(appPackageName, true),
                 BlockingMode.isTrackerProtectionEnabled(this, stores.trackerProtect, appPackageName),
-                InternetBlocklist.getInstance(this).blockedInternet(appUid));
+                InternetBlocklist.getInstance(this).blockedInternet(appUid),
+                BlockingMode.isEssentialOnlyApp(this, stores.essentialOnly, appPackageName));
         boolean paused = PausedApps.isPaused(this, appPackageName);
 
         List<String> sharedPackages = PausedApps.getSharedUidPackages(this, appPackageName, appUid);
@@ -191,6 +194,7 @@ public class ProtectionActivity extends AppCompatActivity {
             expiryHandler.postDelayed(expiryRunnable,
                     PausedApps.remainingMillis(this, appPackageName) + 1_000L);
         } else if (state == AppProtectionState.PROTECTED
+                || state == AppProtectionState.ESSENTIAL_ONLY
                 || state == AppProtectionState.TRACKERS_ALLOWED) {
             cardPause.setVisibility(View.VISIBLE);
             tvPauseStatus.setText(stateLabel(state));
@@ -257,8 +261,11 @@ public class ProtectionActivity extends AppCompatActivity {
         AppProtectionState state = AppProtectionState.resolve(
                 stores.apply.getBoolean(appPackageName, true),
                 BlockingMode.isTrackerProtectionEnabled(this, stores.trackerProtect, appPackageName),
-                InternetBlocklist.getInstance(this).blockedInternet(appUid));
-        if (state != AppProtectionState.PROTECTED && state != AppProtectionState.TRACKERS_ALLOWED)
+                InternetBlocklist.getInstance(this).blockedInternet(appUid),
+                BlockingMode.isEssentialOnlyApp(this, stores.essentialOnly, appPackageName));
+        if (state != AppProtectionState.PROTECTED
+                && state != AppProtectionState.ESSENTIAL_ONLY
+                && state != AppProtectionState.TRACKERS_ALLOWED)
             return;
 
         if (Util.lockdownState(this) == Util.LockdownState.ENABLED) {
@@ -319,8 +326,10 @@ public class ProtectionActivity extends AppCompatActivity {
                     this, trackerProtect, appPackageName);
             boolean minimal = BlockingMode.isMinimalMode(this);
             AppProtectionState state = currentState();
-            categorySwitch.setEnabled(!minimal && state == AppProtectionState.PROTECTED);
-            categorySwitch.setChecked(minimal
+            boolean essentialOnly = state == AppProtectionState.ESSENTIAL_ONLY;
+            boolean readOnlyMinimal = minimal || essentialOnly;
+            categorySwitch.setEnabled(!readOnlyMinimal && state == AppProtectionState.PROTECTED);
+            categorySwitch.setChecked(readOnlyMinimal
                     ? trackerProtectionEnabled && !TrackerBlocklist.NECESSARY_CATEGORY.equals(category.getCategoryName())
                     : blocklist.blocked(appUid, category.getCategoryName()));
             categorySwitch.setOnCheckedChangeListener((buttonView, checked) -> {
@@ -342,10 +351,15 @@ public class ProtectionActivity extends AppCompatActivity {
                         && !minimal
                         && !BlockingMode.isStrictMode(this)
                         && tracker.isAllowedInStandardMode();
-                boolean companyBlocked = state == AppProtectionState.PROTECTED
-                        && trackerProtectionEnabled
-                        && (minimal ? TrackerBlocklist.blockedTrackerMinimal(tracker)
-                        : blocklist.blockedTracker(appUid, tracker));
+                boolean companyBlocked;
+                if (essentialOnly) {
+                    companyBlocked = TrackerList.isEssentiallyBlocked(tracker);
+                } else {
+                    companyBlocked = state == AppProtectionState.PROTECTED
+                            && trackerProtectionEnabled
+                            && (minimal ? TrackerBlocklist.blockedTrackerMinimal(tracker)
+                            : blocklist.blockedTracker(appUid, tracker));
+                }
                 String status = getString(ambiguousAllowed ? R.string.allowed_shared_ip
                         : (companyBlocked ? R.string.blocked : R.string.allowed));
                 chip.setText(tracker.getName() + "  " + status);
@@ -353,7 +367,7 @@ public class ProtectionActivity extends AppCompatActivity {
                 chip.setChipStrokeColorResource(R.color.colorPrimaryLight);
                 chip.setChipStrokeWidth(1f);
                 chip.setEnsureMinTouchTargetSize(false);
-                boolean actionable = state == AppProtectionState.PROTECTED && !minimal;
+                boolean actionable = state == AppProtectionState.PROTECTED && !readOnlyMinimal;
                 chip.setEnabled(actionable);
                 if (actionable)
                     chip.setOnClickListener(v -> {
@@ -398,6 +412,8 @@ public class ProtectionActivity extends AppCompatActivity {
         switch (state) {
             case TRACKERS_ALLOWED:
                 return getString(R.string.app_state_trackers_allowed);
+            case ESSENTIAL_ONLY:
+                return getString(R.string.app_state_essential_only);
             case NO_INTERNET:
                 return getString(R.string.app_state_no_internet);
             case BYPASSED:
@@ -411,14 +427,18 @@ public class ProtectionActivity extends AppCompatActivity {
     private AppProtectionState currentState() {
         SharedPreferences apply = getSharedPreferences("apply", MODE_PRIVATE);
         SharedPreferences trackerProtect = getSharedPreferences("tracker_protect", MODE_PRIVATE);
+        SharedPreferences essentialOnly = getSharedPreferences("tracker_essential", MODE_PRIVATE);
         return AppProtectionState.resolve(
                 apply.getBoolean(appPackageName, true),
                 BlockingMode.isTrackerProtectionEnabled(this, trackerProtect, appPackageName),
-                InternetBlocklist.getInstance(this).blockedInternet(appUid));
+                InternetBlocklist.getInstance(this).blockedInternet(appUid),
+                BlockingMode.isEssentialOnlyApp(this, essentialOnly, appPackageName));
     }
 
     private static int radioIdFor(AppProtectionState state) {
         switch (state) {
+            case ESSENTIAL_ONLY:
+                return R.id.rbStateEssentialOnly;
             case TRACKERS_ALLOWED:
                 return R.id.rbStateTrackersAllowed;
             case NO_INTERNET:
@@ -434,6 +454,8 @@ public class ProtectionActivity extends AppCompatActivity {
     private static AppProtectionState stateForRadioId(int checkedId) {
         if (checkedId == R.id.rbStateProtected)
             return AppProtectionState.PROTECTED;
+        if (checkedId == R.id.rbStateEssentialOnly)
+            return AppProtectionState.ESSENTIAL_ONLY;
         if (checkedId == R.id.rbStateTrackersAllowed)
             return AppProtectionState.TRACKERS_ALLOWED;
         if (checkedId == R.id.rbStateNoInternet)
@@ -455,5 +477,14 @@ public class ProtectionActivity extends AppCompatActivity {
                 getSharedPreferences("apply", MODE_PRIVATE);
         final android.content.SharedPreferences trackerProtect =
                 getSharedPreferences("tracker_protect", MODE_PRIVATE);
+        final android.content.SharedPreferences essentialOnly =
+                getSharedPreferences("tracker_essential", MODE_PRIVATE);
+    }
+
+    private void updateEssentialOnlyVisibility() {
+        int visibility = BlockingMode.isMinimalMode(this) || Util.isPlayStoreInstall(this)
+                ? View.GONE : View.VISIBLE;
+        findViewById(R.id.rbStateEssentialOnly).setVisibility(visibility);
+        findViewById(R.id.tvStateEssentialOnlyDesc).setVisibility(visibility);
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
@@ -126,6 +126,8 @@ public class ProtectionActivity extends AppCompatActivity {
             AppProtectionWriter.applyManual(this, appPackageName, appUid,
                     AppProtectionState.of(selected));
             updateProtectionState();
+            if (blockedTrackerCategories != null)
+                displayBlockedTrackers(blockedTrackerCategories);
         });
 
         AppBarLayout appBar = findViewById(R.id.appbar);
@@ -329,7 +331,11 @@ public class ProtectionActivity extends AppCompatActivity {
             boolean essentialOnly = state == AppProtectionState.ESSENTIAL_ONLY;
             boolean readOnlyMinimal = minimal || essentialOnly;
             categorySwitch.setEnabled(!readOnlyMinimal && state == AppProtectionState.PROTECTED);
-            categorySwitch.setChecked(readOnlyMinimal
+            boolean categoryEssentiallyBlocked = essentialOnly && category.getChildren().stream()
+                    .anyMatch(TrackerList::isEssentiallyBlocked);
+            categorySwitch.setChecked(essentialOnly
+                    ? trackerProtectionEnabled && categoryEssentiallyBlocked
+                    : readOnlyMinimal
                     ? trackerProtectionEnabled && !TrackerBlocklist.NECESSARY_CATEGORY.equals(category.getCategoryName())
                     : blocklist.blocked(appUid, category.getCategoryName()));
             categorySwitch.setOnCheckedChangeListener((buttonView, checked) -> {

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -64,6 +64,7 @@ import net.kollnig.missioncontrol.data.PausedApps;
 import net.kollnig.missioncontrol.data.Tracker;
 import net.kollnig.missioncontrol.data.TrackerBlocklist;
 import net.kollnig.missioncontrol.data.TrackerCategory;
+import net.kollnig.missioncontrol.data.TrackerList;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,6 +88,7 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     private final Context mContext;
     private final SharedPreferences apply;
     private final SharedPreferences tracker_protect;
+    private final SharedPreferences essentialOnly;
     private List<TrackerCategory> mValues = new ArrayList<>();
 
     // Analysis UI elements (populated when header is created)
@@ -110,6 +112,7 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
         apply = mContext.getSharedPreferences("apply", Context.MODE_PRIVATE);
         tracker_protect = mContext.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+        essentialOnly = mContext.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
 
         // Removes blinks
         ((SimpleItemAnimator) Objects.requireNonNull(v.getItemAnimator())).setSupportsChangeAnimations(false);
@@ -266,7 +269,11 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             boolean trackerProtectionEnabled = BlockingMode.isTrackerProtectionEnabled(
                     mContext, tracker_protect, mAppId);
-            boolean allowGranularControl = !BlockingMode.isMinimalMode(mContext);
+            boolean minimal = BlockingMode.isMinimalMode(mContext);
+            AppProtectionState state = currentState(w);
+            boolean essentialOnlyApp = state == AppProtectionState.ESSENTIAL_ONLY;
+            boolean readOnlyMinimal = minimal || essentialOnlyApp;
+            boolean allowGranularControl = !readOnlyMinimal;
             holder.mBlockingTip.setVisibility(allowGranularControl ? View.VISIBLE : View.GONE);
 
             // Load data
@@ -315,7 +322,7 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                  */
                 private boolean isAmbiguousDeadToggle(Tracker t) {
                     return trackerProtectionEnabled
-                            && !BlockingMode.isMinimalMode(getContext())
+                            && !readOnlyMinimal
                             && !BlockingMode.isStrictMode(getContext())
                             && t.isAllowedInStandardMode();
                 }
@@ -345,6 +352,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     } else if (BlockingMode.isMinimalMode(getContext())) {
                         showStatus = true;
                         companyBlocked = TrackerBlocklist.blockedTrackerMinimal(t);
+                    } else if (essentialOnlyApp) {
+                        showStatus = true;
+                        companyBlocked = TrackerList.isEssentiallyBlocked(t);
                     } else {
                         boolean categoryBlocked = b.blocked(mAppUid, trackerCategoryName);
                         showStatus = true;
@@ -393,8 +403,8 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             };
             holder.mCompaniesList.setAdapter(trackersAdapter);
 
-            if (BlockingMode.isMinimalMode(mContext)) {
-                // Minimal mode: show read-only blocking status (no granular control)
+            if (readOnlyMinimal) {
+                // Minimal-style modes: show read-only blocking status (no granular control)
                 holder.mSwitchTracker.setVisibility(View.VISIBLE);
                 holder.mSwitchTracker.setEnabled(false);
                 holder.mSwitchTracker.setChecked(trackerProtectionEnabled &&
@@ -633,11 +643,14 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         return AppProtectionState.resolve(
                 apply.getBoolean(mAppId, true),
                 BlockingMode.isTrackerProtectionEnabled(mContext, tracker_protect, mAppId),
-                w.blockedInternet(mAppUid));
+                w.blockedInternet(mAppUid),
+                BlockingMode.isEssentialOnlyApp(mContext, essentialOnly, mAppId));
     }
 
     private static int stateLabelRes(AppProtectionState state) {
         switch (state) {
+            case ESSENTIAL_ONLY:
+                return R.string.app_state_essential_only;
             case TRACKERS_ALLOWED:
                 return R.string.app_state_trackers_allowed;
             case NO_INTERNET:

--- a/app/src/main/res/layout/activity_protection.xml
+++ b/app/src/main/res/layout/activity_protection.xml
@@ -176,6 +176,22 @@
                             android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
 
                         <RadioButton
+                            android:id="@+id/rbStateEssentialOnly"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/app_state_essential_only"
+                            android:textStyle="bold" />
+
+                        <TextView
+                            android:id="@+id/tvStateEssentialOnlyDesc"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="32dp"
+                            android:layout_marginBottom="8dp"
+                            android:text="@string/app_state_essential_only_explanation"
+                            android:textAppearance="@style/TextAppearance.Material3.LabelSmall" />
+
+                        <RadioButton
                             android:id="@+id/rbStateTrackersAllowed"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/item_timeline_hint.xml
+++ b/app/src/main/res/layout/item_timeline_hint.xml
@@ -1,0 +1,32 @@
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="8dp"
+    android:layout_marginTop="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardUseCompatPadding="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvHintText"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/timeline_hint_tap_entry"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnHintDismiss"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginTop="8dp"
+            android:text="@string/timeline_hint_dismiss" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,8 @@
     <string name="timeline_empty_recording_unavailable_subtitle">This version of TrackerControl does not expose tracker activity recording. Blocking still works, but this Timeline will stay empty.</string>
     <string name="timeline_open_app">Open an app</string>
     <string name="timeline_open_settings">Open settings</string>
+    <string name="timeline_hint_tap_entry">An app not working? Tap its entry to adjust its protection.</string>
+    <string name="timeline_hint_dismiss">Got it</string>
     <string name="unidentified_app_uid">Unidentified app (UID %1$d)</string>
     <string name="tab_timeline">Timeline</string>
     <string name="tab_apps">Apps</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -671,6 +671,8 @@ Sincerely,\n\n]]></string>
     <string name="app_state_heading">Protection</string>
     <string name="app_state_protected">Protected</string>
     <string name="app_state_protected_explanation">Trackers are blocked and recorded for this app.</string>
+    <string name="app_state_essential_only">Essential blocking only</string>
+    <string name="app_state_essential_only_explanation">Blocks only the confirmed trackers that Minimal mode blocks. Other trackers are still recorded, but allowed. Use this if standard blocking breaks the app.</string>
     <string name="app_state_trackers_allowed">Trackers allowed</string>
     <string name="app_state_trackers_allowed_explanation">The app keeps running through TrackerControl, but its trackers are neither blocked nor recorded. Use this if blocking breaks the app.</string>
     <string name="app_state_no_internet">No Internet</string>

--- a/app/src/test/java/net/kollnig/missioncontrol/TimelineHintAdapterTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/TimelineHintAdapterTest.java
@@ -1,0 +1,31 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class TimelineHintAdapterTest {
+
+    @Test
+    public void shouldShowOnlyWhenEntriesExistAndHintIsEnabled() {
+        assertTrue(TimelineHintAdapter.shouldShow(true, true));
+        assertFalse(TimelineHintAdapter.shouldShow(false, true));
+        assertFalse(TimelineHintAdapter.shouldShow(true, false));
+        assertFalse(TimelineHintAdapter.shouldShow(false, false));
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/data/AppProtectionStateTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/AppProtectionStateTest.java
@@ -40,9 +40,32 @@ public class AppProtectionStateTest {
     @Test
     public void internetBlockWinsOverProtectionFlag() {
         assertEquals(AppProtectionState.NO_INTERNET,
-                AppProtectionState.resolve(true, true, true));
+                AppProtectionState.resolve(true, true, true, true));
         assertEquals(AppProtectionState.NO_INTERNET,
-                AppProtectionState.resolve(true, false, true));
+                AppProtectionState.resolve(true, false, true, true));
+    }
+
+    @Test
+    public void fourArgResolveTruthTable() {
+        for (boolean apply : new boolean[] { true, false })
+            for (boolean trackerProtect : new boolean[] { true, false })
+                for (boolean internetBlocked : new boolean[] { true, false })
+                    for (boolean essentialOnly : new boolean[] { true, false }) {
+                        AppProtectionState expected;
+                        if (!apply)
+                            expected = AppProtectionState.BYPASSED;
+                        else if (internetBlocked)
+                            expected = AppProtectionState.NO_INTERNET;
+                        else if (!trackerProtect)
+                            expected = AppProtectionState.TRACKERS_ALLOWED;
+                        else
+                            expected = essentialOnly
+                                    ? AppProtectionState.ESSENTIAL_ONLY
+                                    : AppProtectionState.PROTECTED;
+
+                        assertEquals(expected, AppProtectionState.resolve(
+                                apply, trackerProtect, internetBlocked, essentialOnly));
+                    }
     }
 
     /**
@@ -58,19 +81,21 @@ public class AppProtectionStateTest {
     }
 
     /**
-     * XML import restores the three stores independently and never normalises
-     * them, so resolve() must be total over all eight inputs.
+     * XML import restores the four stores independently and never normalises
+     * them, so resolve() must be total over all sixteen inputs.
      */
     @Test
     public void resolveIsTotalOverAllCombinations() {
         int combinations = 0;
         for (boolean apply : new boolean[] { true, false })
             for (boolean trackerProtect : new boolean[] { true, false })
-                for (boolean internetBlocked : new boolean[] { true, false }) {
-                    assertNotNull(AppProtectionState.resolve(apply, trackerProtect, internetBlocked));
-                    combinations++;
-                }
-        assertEquals(8, combinations);
+                for (boolean internetBlocked : new boolean[] { true, false })
+                    for (boolean essentialOnly : new boolean[] { true, false }) {
+                        assertNotNull(AppProtectionState.resolve(
+                                apply, trackerProtect, internetBlocked, essentialOnly));
+                        combinations++;
+                    }
+        assertEquals(16, combinations);
     }
 
     @Test
@@ -80,16 +105,20 @@ public class AppProtectionStateTest {
 
             // Worst case: apply the change on top of every possible prior state.
             for (boolean priorProtect : new boolean[] { true, false })
-                for (boolean priorInternet : new boolean[] { true, false }) {
-                    boolean protect = change.trackerProtect == null
-                            ? priorProtect
-                            : change.trackerProtect;
-                    boolean internet = change.internetBlocked == null
-                            ? priorInternet
-                            : change.internetBlocked;
-                    assertEquals(state,
-                            AppProtectionState.resolve(change.apply, protect, internet));
-                }
+                for (boolean priorInternet : new boolean[] { true, false })
+                    for (boolean priorEssential : new boolean[] { true, false }) {
+                        boolean protect = change.trackerProtect == null
+                                ? priorProtect
+                                : change.trackerProtect;
+                        boolean internet = change.internetBlocked == null
+                                ? priorInternet
+                                : change.internetBlocked;
+                        boolean essential = change.essentialOnly == null
+                                ? priorEssential
+                                : change.essentialOnly;
+                        assertEquals(state,
+                                AppProtectionState.resolve(change.apply, protect, internet, essential));
+                    }
         }
     }
 
@@ -97,6 +126,7 @@ public class AppProtectionStateTest {
     public void noInternetKeepsTrackerProtectionChoice() {
         Change change = AppProtectionState.of(AppProtectionState.NO_INTERNET);
         assertNull(change.trackerProtect);
+        assertNull(change.essentialOnly);
         assertTrue(change.apply);
         assertEquals(Boolean.TRUE, change.internetBlocked);
     }
@@ -106,6 +136,18 @@ public class AppProtectionStateTest {
         Change change = AppProtectionState.of(AppProtectionState.BYPASSED);
         assertNull(change.trackerProtect);
         assertNull(change.internetBlocked);
+        assertNull(change.essentialOnly);
+    }
+
+    @Test
+    public void protectedAndEssentialOnlyWriteExplicitFlagValues() {
+        assertEquals(Boolean.FALSE,
+                AppProtectionState.of(AppProtectionState.PROTECTED).essentialOnly);
+        assertEquals(Boolean.TRUE,
+                AppProtectionState.of(AppProtectionState.ESSENTIAL_ONLY).essentialOnly);
+        assertNull(AppProtectionState.of(AppProtectionState.TRACKERS_ALLOWED).essentialOnly);
+        assertNull(AppProtectionState.of(AppProtectionState.NO_INTERNET).essentialOnly);
+        assertNull(AppProtectionState.of(AppProtectionState.BYPASSED).essentialOnly);
     }
 
     /**

--- a/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeAndroidTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeAndroidTest.java
@@ -42,30 +42,38 @@ public class BlockingModeAndroidTest {
     }
 
     @Test
-    public void syncModeExclusionsUsesRealExcludedAppsAsset() throws Exception {
+    public void syncAutoExclusionsUsesRealExcludedAppsAsset() throws Exception {
         Set<String> excludedApps = BlockingModeLogic.parseExcludedAppsJson(readExcludedAppsAsset());
         Map<String, Boolean> applyPrefs = new HashMap<>();
         applyPrefs.put("manual.false", false);
 
-        BlockingModeLogic.ExclusionSyncResult minimalResult = BlockingModeLogic.syncVpnExclusions(
-                BlockingMode.MODE_MINIMAL,
+        BlockingModeLogic.ExclusionSyncResult initialResult = BlockingModeLogic.syncVpnExclusions(
                 excludedApps,
                 applyPrefs,
                 Collections.emptySet());
 
-        assertFalse(minimalResult.applyFalsePackages.contains("com.android.chrome"));
-        assertTrue(minimalResult.applyFalsePackages.contains("com.whatsapp"));
-        assertFalse(minimalResult.applyRemovals.contains("manual.false"));
+        assertFalse(initialResult.applyFalsePackages.contains("com.android.chrome"));
+        assertTrue(initialResult.applyFalsePackages.contains("com.whatsapp"));
+        assertFalse(initialResult.applyRemovals.contains("manual.false"));
 
         applyPrefs.put("com.whatsapp", false);
-        BlockingModeLogic.ExclusionSyncResult standardResult = BlockingModeLogic.syncVpnExclusions(
-                BlockingMode.MODE_STANDARD,
-                excludedApps,
+        BlockingModeLogic.ExclusionSyncResult stableResult = BlockingModeLogic.syncVpnExclusions(
+                Set.of("com.whatsapp"),
                 applyPrefs,
                 Set.of("com.whatsapp"));
 
-        assertTrue(standardResult.applyRemovals.contains("com.whatsapp"));
-        assertFalse(standardResult.applyRemovals.contains("manual.false"));
+        assertTrue(stableResult.applyFalsePackages.isEmpty());
+        assertTrue(stableResult.applyRemovals.isEmpty());
+        assertTrue(stableResult.autoExcludedApps.contains("com.whatsapp"));
+
+        BlockingModeLogic.ExclusionSyncResult restoredResult = BlockingModeLogic.syncVpnExclusions(
+                Collections.emptySet(),
+                applyPrefs,
+                stableResult.autoExcludedApps);
+
+        assertTrue(restoredResult.applyRemovals.contains("com.whatsapp"));
+        assertFalse(restoredResult.applyRemovals.contains("manual.false"));
+        assertTrue(restoredResult.autoExcludedApps.isEmpty());
     }
 
     @Test
@@ -77,7 +85,6 @@ public class BlockingModeAndroidTest {
         applyPrefs.put("com.whatsapp", true);
 
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingMode.MODE_MINIMAL,
                 Set.of("com.whatsapp"),
                 applyPrefs,
                 Set.of("com.whatsapp"));

--- a/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
@@ -63,9 +63,8 @@ public class BlockingModeLogicTest {
     }
 
     @Test
-    public void enteringMinimalAutoExcludesUnsetIncompatibleApps() {
+    public void unsetIncompatibleAppIsAutoExcluded() {
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_MINIMAL,
                 Set.of("incompatible"),
                 Collections.emptyMap(),
                 Collections.emptySet());
@@ -76,14 +75,13 @@ public class BlockingModeLogicTest {
     }
 
     @Test
-    public void leavingMinimalRestoresOnlyAutoExcludedApps() {
+    public void leavingExcludedListRestoresOnlyAutoExcludedApps() {
         Map<String, Boolean> applyPrefs = new HashMap<>();
         applyPrefs.put("incompatible", false);
         applyPrefs.put("manual", false);
 
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_STANDARD,
-                Set.of("incompatible"),
+                Collections.emptySet(),
                 applyPrefs,
                 Set.of("incompatible"));
 
@@ -94,12 +92,11 @@ public class BlockingModeLogicTest {
     }
 
     @Test
-    public void explicitVpnInclusionStopsFutureAutoRestore() {
+    public void explicitVpnInclusionIsNeverOverriddenAndClearsAutoManagement() {
         Map<String, Boolean> applyPrefs = new HashMap<>();
         applyPrefs.put("incompatible", true);
 
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_MINIMAL,
                 Set.of("incompatible"),
                 applyPrefs,
                 Set.of("incompatible"));
@@ -115,7 +112,6 @@ public class BlockingModeLogicTest {
         applyPrefs.put("browser", false);
 
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_MINIMAL,
                 Collections.emptySet(),
                 applyPrefs,
                 Set.of("browser"));
@@ -133,24 +129,27 @@ public class BlockingModeLogicTest {
 
     /**
      * The UI must keep an auto-excluded app in the managed set while it stays
-     * excluded, otherwise toggling it off and on again before the next mode
-     * switch silently converts a Minimal-mode auto-exclusion into a permanent
-     * one. This is the pre-sync window: syncVpnExclusions self-heals on the
-     * next mode switch, but only if membership survived until then.
+     * excluded, otherwise it silently converts a compatibility auto-exclusion
+     * into a permanent one. The app is restored only after leaving the DDG list.
      */
     @Test
-    public void reExcludedAutoExcludedAppStillRestoresOnModeSwitch() {
+    public void reExcludedAutoExcludedAppRemainsManagedUntilItLeavesList() {
         Map<String, Boolean> applyPrefs = new HashMap<>();
         applyPrefs.put("incompatible", false);
 
-        // Membership is retained because the resulting apply is false.
-        Set<String> autoExcludedApps = Set.of("incompatible");
-
-        BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_STANDARD,
+        BlockingModeLogic.ExclusionSyncResult stable = BlockingModeLogic.syncVpnExclusions(
                 Set.of("incompatible"),
                 applyPrefs,
-                autoExcludedApps);
+                Set.of("incompatible"));
+
+        assertTrue(stable.applyFalsePackages.isEmpty());
+        assertTrue(stable.applyRemovals.isEmpty());
+        assertEquals(Set.of("incompatible"), stable.autoExcludedApps);
+
+        BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
+                Collections.emptySet(),
+                applyPrefs,
+                stable.autoExcludedApps);
 
         assertEquals(Set.of("incompatible"), result.applyRemovals);
         assertTrue(result.autoExcludedApps.isEmpty());
@@ -170,7 +169,6 @@ public class BlockingModeLogicTest {
         applyPrefs.put("incompatible", true);
 
         BlockingModeLogic.ExclusionSyncResult result = BlockingModeLogic.syncVpnExclusions(
-                BlockingModeLogic.MODE_MINIMAL,
                 Set.of("incompatible"),
                 applyPrefs,
                 autoExcludedApps);

--- a/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
@@ -56,6 +56,15 @@ public class BlockingModeLogicTest {
     }
 
     @Test
+    public void essentialOnlyBlocksOnlyNonContentCategories() {
+        assertTrue(BlockingModeLogic.shouldBlockEssentialOnly("Advertising"));
+        assertTrue(BlockingModeLogic.shouldBlockEssentialOnly("Uncategorised"));
+        assertFalse(BlockingModeLogic.shouldBlockEssentialOnly(
+                BlockingModeLogic.CONTENT_CATEGORY));
+        assertFalse(BlockingModeLogic.shouldBlockEssentialOnly(null));
+    }
+
+    @Test
     public void onlyStrictBlocksAmbiguousTrackerIps() {
         assertFalse(BlockingModeLogic.blocksAmbiguousTrackerIp(BlockingModeLogic.MODE_MINIMAL));
         assertFalse(BlockingModeLogic.blocksAmbiguousTrackerIp(BlockingModeLogic.MODE_STANDARD));

--- a/app/src/test/java/net/kollnig/missioncontrol/data/PausedAppsTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/PausedAppsTest.java
@@ -20,14 +20,20 @@ public class PausedAppsTest {
     private Context context;
     private SharedPreferences paused;
     private SharedPreferences apply;
+    private SharedPreferences trackerProtect;
+    private SharedPreferences essentialOnly;
 
     @Before
     public void setUp() {
         context = RuntimeEnvironment.getApplication();
         paused = context.getSharedPreferences(PausedApps.PREFS_NAME, Context.MODE_PRIVATE);
         apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
+        trackerProtect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
+        essentialOnly = context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
         paused.edit().clear().commit();
         apply.edit().clear().commit();
+        trackerProtect.edit().clear().commit();
+        essentialOnly.edit().clear().commit();
     }
 
     @Test
@@ -128,5 +134,45 @@ public class PausedAppsTest {
         apply.edit().putBoolean("com.example.app", false).commit();
 
         assertTrue(PausedApps.applyValuesWithoutPauses(context).isEmpty());
+    }
+
+    @Test
+    public void essentialOnlyAppCanBePausedAndSweepRestoresItsState() {
+        String packageName = "com.example.app";
+        apply.edit().putBoolean(packageName, true).commit();
+        trackerProtect.edit().putBoolean(packageName, true).commit();
+        essentialOnly.edit().putBoolean(packageName, true).commit();
+
+        PausedApps.pause(context, packageName, 0, 600_000L);
+        assertTrue(PausedApps.isPaused(context, packageName));
+        assertFalse(apply.getBoolean(packageName, true));
+
+        paused.edit().putString(packageName, "1|1").commit();
+        PausedApps.sweep(context);
+
+        assertTrue(apply.getBoolean(packageName, false));
+        assertEquals(AppProtectionState.ESSENTIAL_ONLY,
+                AppProtectionState.resolve(apply.getBoolean(packageName, true),
+                        trackerProtect.getBoolean(packageName, false), false,
+                        essentialOnly.getBoolean(packageName, false)));
+    }
+
+    @Test
+    public void selectingProtectedAfterBypassClearsEssentialOnlyFlag() {
+        String packageName = "com.example.app";
+        apply.edit().putBoolean(packageName, false).commit();
+        trackerProtect.edit().putBoolean(packageName, true).commit();
+        essentialOnly.edit().putBoolean(packageName, true).commit();
+
+        assertEquals(AppProtectionState.BYPASSED,
+                AppProtectionState.resolve(false, true, false, true));
+        AppProtectionWriter.applyManual(context, packageName, 0,
+                AppProtectionState.of(AppProtectionState.PROTECTED));
+
+        assertTrue(apply.getBoolean(packageName, false));
+        assertFalse(essentialOnly.getBoolean(packageName, true));
+        assertEquals(AppProtectionState.PROTECTED,
+                AppProtectionState.resolve(true, true, false,
+                        essentialOnly.getBoolean(packageName, false)));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListEssentialTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListEssentialTest.java
@@ -1,0 +1,90 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Copyright © 2026
+ */
+
+package net.kollnig.missioncontrol.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import eu.faircode.netguard.ServiceSinkhole;
+
+@RunWith(RobolectricTestRunner.class)
+public class TrackerListEssentialTest {
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = RuntimeEnvironment.getApplication();
+        ServiceSinkhole.mapHostsBlocked.clear();
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BlockingMode.PREF_BLOCKING_MODE, BlockingMode.MODE_STANDARD)
+                .putBoolean("domain_based_blocking", false)
+                .commit();
+        assertTrue(TrackerList.reloadTrackerData(context));
+    }
+
+    @After
+    public void tearDown() {
+        ServiceSinkhole.mapHostsBlocked.clear();
+    }
+
+    @Test
+    public void xrayClaimedDomainStillUsesItsDdgCategoryForEssentialLookup() {
+        Tracker mainTracker = TrackerList.findTracker("2mdn.net");
+        Tracker essentialTracker = TrackerList.findEssentialTracker("2mdn.net");
+
+        assertNotNull(mainTracker);
+        assertNotNull(essentialTracker);
+        assertEquals("Google", essentialTracker.getName());
+        assertEquals(TrackerCategory.UNCATEGORISED, essentialTracker.category);
+    }
+
+    @Test
+    public void hostsOnlyAndXrayOnlyHostsAreNotEssentialTrackers() {
+        ServiceSinkhole.mapHostsBlocked.put("hosts-only.example", true);
+
+        assertNotNull(TrackerList.findTracker("hosts-only.example"));
+        assertNull(TrackerList.findEssentialTracker("hosts-only.example"));
+        assertNotNull(TrackerList.findTracker("crashlytics.com"));
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
+    }
+
+    @Test
+    public void minimalModeUsesTheMainDdgMapForEssentialLookup() {
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BlockingMode.PREF_BLOCKING_MODE, BlockingMode.MODE_MINIMAL)
+                .commit();
+        assertTrue(TrackerList.reloadTrackerData(context));
+
+        assertSame(TrackerList.findTracker("2mdn.net"),
+                TrackerList.findEssentialTracker("2mdn.net"));
+        ServiceSinkhole.mapHostsBlocked.put("hosts-only.example", true);
+        assertNull(TrackerList.findTracker("hosts-only.example"));
+        assertNull(TrackerList.findEssentialTracker("hosts-only.example"));
+    }
+}


### PR DESCRIPTION
Follow-up to #826, covering three of the four items settled in that discussion.

## Point users at per-app protection (Q1)

Users notice breakage at the OS level and have no idea the fix lives behind a
per-app screen. The Timeline now carries a one-time dismissible banner saying
so; opening any app's Details screen also dismisses it, since arriving there
means the user has found the control.

## Mode-independent compatibility exclusions (Q4)

DuckDuckGo's known-VPN-incompatible apps were only excluded from the VPN in
minimal mode. They are now excluded in every mode: the same apps break the same
way regardless of how aggressively trackers are blocked.

`syncModeExclusions` becomes `syncAutoExclusions` and loses its mode parameter.
The bookkeeping preference key stays `minimal_auto_excluded_apps` so existing
installs keep their auto-exclusion state across the upgrade. An explicit user
choice to route an app through the VPN still wins and permanently drops the app
from automatic management; the restore trigger is now "the app left the DDG
list" rather than "the mode changed". XML import reconciles immediately instead
of waiting for the next process start.

## Per-app "Essential blocking only" (Q2)

A fifth per-app protection state, between *Protected* and *Trackers allowed*,
applying minimal-mode blocking to a single app: only DuckDuckGo trackers with a
block action are blocked. The per-category and per-company controls render
read-only, exactly as they do when minimal mode is active globally. It is hidden
in minimal mode (where it would be a no-op) and on Play Store builds, which
already hide the blocking-mode selector.

One wrinkle worth flagging: the DuckDuckGo list loads last and skips domains
another blocklist already claimed, so the merged map cannot answer "is this a
DDG tracker?". `TrackerList` therefore keeps a second, DDG-only map alongside
the merged one, published in the same immutable snapshot; in minimal mode both
references point at the same map.

The flag lives in a `tracker_essential` preference store, threaded through
`AppProtectionState`/`AppProtectionWriter`, the insights verdicts, XML
import/export and package-removal cleanup. The service reads it through its live
preferences handle and recomputes verdicts per packet from cached tracker
identity, so toggling it alone needs no VPN reload.

The flag deliberately survives a trip through *Trackers allowed* — only
selecting *Protected* clears it — so bulk-disabling and re-enabling tracker
protection returns an app to its previous essential-only choice.

## Not included

Q3 (company-first trackers view) is postponed and tracked separately: it needs a
scalability answer for long per-app company lists before implementation.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest` and
`:app:lintGithubDebug` all pass. Not yet exercised on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
