### PR TITLE
Address Codex review findings on PR #834

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
@@ -126,6 +126,8 @@ public class ProtectionActivity extends AppCompatActivity {
             AppProtectionWriter.applyManual(this, appPackageName, appUid,
                     AppProtectionState.of(selected));
             updateProtectionState();
+            if (blockedTrackerCategories != null)
+                displayBlockedTrackers(blockedTrackerCategories);
         });
 
         AppBarLayout appBar = findViewById(R.id.appbar);
@@ -329,7 +331,11 @@ public class ProtectionActivity extends AppCompatActivity {
             boolean essentialOnly = state == AppProtectionState.ESSENTIAL_ONLY;
             boolean readOnlyMinimal = minimal || essentialOnly;
             categorySwitch.setEnabled(!readOnlyMinimal && state == AppProtectionState.PROTECTED);
-            categorySwitch.setChecked(readOnlyMinimal
+            boolean categoryEssentiallyBlocked = essentialOnly && category.getChildren().stream()
+                    .anyMatch(TrackerList::isEssentiallyBlocked);
+            categorySwitch.setChecked(essentialOnly
+                    ? trackerProtectionEnabled && categoryEssentiallyBlocked
+                    : readOnlyMinimal
                     ? trackerProtectionEnabled && !TrackerBlocklist.NECESSARY_CATEGORY.equals(category.getCategoryName())
                     : blocklist.blocked(appUid, category.getCategoryName()));
             categorySwitch.setOnCheckedChangeListener((buttonView, checked) -> {


### PR DESCRIPTION
Stacked on #834, fixing two of the three Codex review findings there.

## Fixed

- **Refresh tracker controls after changing protection state** (`ProtectionActivity.java`): the radio-group listener only called `updateProtectionState()`, so switching between *Protected* and *Essential-only* while the Details screen stayed open left the per-category and per-company switches showing the previous state's read-only/enabled bits until the activity resumed. It now also re-runs `displayBlockedTrackers()`.
- **Derive essential-only category status from DDG block-action membership**: the per-category switch's checked state for an essential-only app was computed from the category name (`!= Content`), same as global Minimal mode, so a category containing only non-DDG-essential trackers showed as blocked even though every company chip beneath it correctly showed "allowed". It now checks `TrackerList.isEssentiallyBlocked` across the category's trackers, matching the chip logic directly below it.

## Not changed

- **"Ignore essential-only preferences in Play Store builds"**: I read this as a false positive. `BlockingMode.isEssentialOnlyApp` already gates on `!isMinimalMode(c)`, and `isMinimalMode` calls `getMode`, which runs every stored value through `normalizeModeForBuild` — that function unconditionally returns `MODE_MINIMAL` for `BuildConfig.FLAVOR == "play"`. So on Play builds `isEssentialOnlyApp` already returns `false` regardless of what an imported XML wrote into the `tracker_essential` store; there's no separate runtime check to add. Happy to revisit if I'm missing a code path that resolves essential-only without going through `isMinimalMode`.

## Verification

`:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest`, and `:app:lintGithubDebug` all pass. Not exercised on a device.


---
_Generated by [Claude Code](https://claude.ai/code/session_0126FPeiSD5XmE53KF4TLxrK)_