### PR TITLE
Minimal mode: monitor with every tracker list, block only the DuckDuckGo set

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3041,6 +3041,13 @@ public class ServiceSinkhole extends VpnService {
             boolean sawFirstRow = false;
             boolean sawTrackerEvidence = false;
             boolean sawNonTrackerEvidence = false;
+            // Blocking evidence, classified against the DuckDuckGo-only map.
+            // Detection above uses the full map in every mode, so the blocking
+            // verdict has to be tracked separately to stay DDG-compatible.
+            String essentialCategory = null;
+            boolean sawEssentialCategory = false;
+            boolean sawEssentialTrackerEvidence = false;
+            boolean sawNonEssentialTrackerEvidence = false;
             try (Cursor lookup = dh.getQAName(uid, daddr)) {
                 // Loop through all fresh DNS candidates for this IP and only fail closed
                 // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
@@ -3077,6 +3084,23 @@ public class ServiceSinkhole extends VpnService {
                             }
                         }
 
+                        // Resolve the DDG verdict here, while both names are in
+                        // hand: a later lookup by the cached hostname alone would
+                        // miss a DDG match on an uncloaked CNAME target.
+                        Tracker candidateEssential = qname == null
+                                ? null : TrackerList.findEssentialTracker(qname);
+                        if (candidateEssential == null && aname != null)
+                            candidateEssential = TrackerList.findEssentialTracker(aname);
+
+                        if (candidateEssential != null) {
+                            sawEssentialTrackerEvidence = true;
+                            if (!sawEssentialCategory) {
+                                sawEssentialCategory = true;
+                                essentialCategory = candidateEssential.category;
+                            }
+                        } else if (qname != null || aname != null)
+                            sawNonEssentialTrackerEvidence = true;
+
                         if (candidateTracker != null) {
                             sawTrackerEvidence = true;
                             if (tracker == null) {
@@ -3098,6 +3122,10 @@ public class ServiceSinkhole extends VpnService {
                 Log.d(TAG, "Allowing mixed tracker evidence for " + daddr);
                 tracker = NO_TRACKER;
             }
+
+            if (sawEssentialTrackerEvidence && sawNonEssentialTrackerEvidence
+                    && !blockAmbiguousTrackers)
+                essentialCategory = null;
 
             // No success in finding dname or tracker?
             if (dname == null)
@@ -3131,7 +3159,8 @@ public class ServiceSinkhole extends VpnService {
             // stale verdict that a racing insert already made obsolete.
             // Skipping is cheap and correct: the next packet to this IP
             // simply re-reads the DB.
-            TrackerCache.Entry cacheEntry = new TrackerCache.Entry(dname, tracker, expiry);
+            TrackerCache.Entry cacheEntry = new TrackerCache.Entry(dname, tracker,
+                    essentialCategory, expiry);
             trackerCache.putIfGeneration(daddr, cacheEntry, generationBefore);
             // Keep the exact snapshot used for the decision for logging;
             // the shared cache may be invalidated or replaced meanwhile.
@@ -3155,27 +3184,15 @@ public class ServiceSinkhole extends VpnService {
             }
         } else {
             if (tracker != null && tracker != NO_TRACKER) {
-                if (!BlockingMode.MODE_MINIMAL.equals(blockingMode) && essentialOnlyApp(uid)) {
-                    String hostname = cached == null ? null : cached.getHostname();
-                    Tracker essentialTracker = hostname == null
-                            ? null : TrackerList.findEssentialTracker(hostname);
-                    // Strict mode retains tracker evidence for mixed-evidence
-                    // IPs where Minimal mode would collapse it to NO_TRACKER;
-                    // this accepted deviation can block slightly more here.
+                // Minimal mode and essential-only apps share one verdict: block
+                // exactly the non-Content DuckDuckGo set, whatever else the
+                // broader detection map knows about this flow.
+                if (BlockingMode.MODE_MINIMAL.equals(blockingMode) || essentialOnlyApp(uid))
                     return BlockingModeLogic.shouldBlockEssentialOnly(
-                            essentialTracker == null ? null : essentialTracker.category);
-                }
+                            cached == null ? null : cached.getEssentialCategory());
 
-                boolean blockedByGranularRule = false;
-                if (!BlockingMode.MODE_MINIMAL.equals(blockingMode)) {
-                    TrackerBlocklist b = TrackerBlocklist.getInstance(ServiceSinkhole.this);
-                    blockedByGranularRule = b.blockedTracker(uid, tracker);
-                }
-
-                return BlockingModeLogic.shouldBlockKnownTracker(
-                        blockingMode,
-                        tracker.category,
-                        blockedByGranularRule);
+                TrackerBlocklist b = TrackerBlocklist.getInstance(ServiceSinkhole.this);
+                return b.blockedTracker(uid, tracker);
             }
         }
 

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3048,6 +3048,13 @@ public class ServiceSinkhole extends VpnService {
             boolean sawEssentialCategory = false;
             boolean sawEssentialTrackerEvidence = false;
             boolean sawNonEssentialTrackerEvidence = false;
+            // Expiry of the DNS record essentialCategory was derived from,
+            // tracked separately from chosenTime/chosenTtl: the DDG row that
+            // supplies essentialCategory need not be the same row that
+            // supplies the (broader-map) tracker, so the verdict must expire
+            // with its own evidence rather than an unrelated row's TTL.
+            long essentialChosenTime = -1;
+            long essentialChosenTtl = -1;
             try (Cursor lookup = dh.getQAName(uid, daddr)) {
                 // Loop through all fresh DNS candidates for this IP and only fail closed
                 // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
@@ -3097,6 +3104,8 @@ public class ServiceSinkhole extends VpnService {
                             if (!sawEssentialCategory) {
                                 sawEssentialCategory = true;
                                 essentialCategory = candidateEssential.category;
+                                essentialChosenTime = rowTime;
+                                essentialChosenTtl = rowTtl;
                             }
                         } else if (qname != null || aname != null)
                             sawNonEssentialTrackerEvidence = true;
@@ -3151,6 +3160,14 @@ public class ServiceSinkhole extends VpnService {
                 expiry = (chosenTime >= 0)
                         ? chosenTime + chosenTtl
                         : firstTime + firstTtl;
+                // The essential (DDG) verdict can be derived from a
+                // different row than the broader-map tracker above; expire
+                // with whichever evidence goes stale first so a blocking
+                // verdict never outlives the record it came from.
+                if (essentialCategory != null && essentialChosenTime >= 0) {
+                    long essentialExpiry = essentialChosenTime + essentialChosenTtl;
+                    expiry = Math.min(expiry, essentialExpiry);
+                }
             }
 
             // Save dname and tracker, but only if no concurrent

--- a/app/src/main/java/eu/faircode/netguard/TrackerCache.java
+++ b/app/src/main/java/eu/faircode/netguard/TrackerCache.java
@@ -28,11 +28,13 @@ final class TrackerCache {
     static final class Entry {
         private final String hostname;
         private final Tracker tracker;
+        private final String essentialCategory;
         private final long expires;
 
-        Entry(String hostname, Tracker tracker, long expires) {
+        Entry(String hostname, Tracker tracker, String essentialCategory, long expires) {
             this.hostname = Objects.requireNonNull(hostname);
             this.tracker = Objects.requireNonNull(tracker);
+            this.essentialCategory = essentialCategory;
             this.expires = expires;
         }
 
@@ -42,6 +44,17 @@ final class TrackerCache {
 
         Tracker getTracker() {
             return tracker;
+        }
+
+        /**
+         * The DuckDuckGo category behind the blocking verdict for this IP, or
+         * null when no DDG tracker was seen. Resolved while both the qname and
+         * the aname are still in hand, so a DDG match on an uncloaked CNAME
+         * target is not lost the way a verdict-time hostname lookup would lose
+         * it.
+         */
+        String getEssentialCategory() {
+            return essentialCategory;
         }
 
         boolean isExpired(long now) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingModeLogic.java
@@ -38,15 +38,11 @@ public final class BlockingModeLogic {
         return MODE_STRICT.equals(mode);
     }
 
-    public static boolean shouldBlockKnownTracker(String mode,
-            String trackerCategory,
-            boolean blockedByGranularRule) {
-        if (MODE_MINIMAL.equals(mode))
-            return !CONTENT_CATEGORY.equals(trackerCategory);
-
-        return blockedByGranularRule;
-    }
-
+    /**
+     * The blocking verdict for Minimal mode and for essential-only apps: block
+     * iff the flow matched a non-Content DuckDuckGo tracker. The category must
+     * come from the DDG-only map, never from the (broader) detection map.
+     */
     public static boolean shouldBlockEssentialOnly(@Nullable String essentialCategory) {
         return essentialCategory != null && !CONTENT_CATEGORY.equals(essentialCategory);
     }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
@@ -324,17 +324,13 @@ class InsightsDataProvider(context: Context) {
             return false
         }
 
-        val blockedByGranularRule = if (BlockingMode.MODE_MINIMAL == blockingMode) {
-            false
-        } else {
-            trackerBlocklist.blockedTracker(uid, tracker)
+        if (BlockingMode.MODE_MINIMAL == blockingMode) {
+            // Minimal mode detects with every list but blocks only the DDG set.
+            val essentialTracker = TrackerList.findEssentialTracker(daddr)
+            return BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker?.category)
         }
 
-        return BlockingModeLogic.shouldBlockKnownTracker(
-            blockingMode,
-            tracker.category,
-            blockedByGranularRule
-        )
+        return trackerBlocklist.blockedTracker(uid, tracker)
     }
 
     companion object {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
@@ -368,14 +368,4 @@ public class TrackerBlocklist extends UidKeyedStore<Set<String>> {
         return blocked(uid, t.category)
                 && blocked(uid, getBlockingKey(t));
     }
-
-    /**
-     * In minimal (DDG-compatible) mode, block all trackers except those in
-     * the "Content" category (which maps to DDG's "ignore" action).
-     * No granular per-app per-tracker control — just block or don't.
-     */
-    public static boolean blockedTrackerMinimal(Tracker t) {
-        // "Content" category = DDG "ignore" action = essential services, don't block
-        return !NECESSARY_CATEGORY.equals(t.category);
-    }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -191,7 +191,9 @@ public class TrackerList {
         Map<String, Tracker> hostnameToTracker = snapshot.hostnameToTracker;
         Tracker t = lookupHost(hostnameToTracker, hostname);
 
-        // In minimal mode, skip hosts-file based lookups (only use DDG tracker list)
+        // In minimal mode, skip hosts-file based lookups: the hosts list is a
+        // blocking feature of unattributed single-domain entries, not curated
+        // tracker intelligence, so it stays out of minimal-mode detection.
         if (t == null && !snapshot.minimalBlockingMode
                 && ServiceSinkhole.mapHostsBlocked.containsKey(hostname))
             if (snapshot.domainBasedBlocking)
@@ -237,6 +239,20 @@ public class TrackerList {
      * Whether any observed host belongs to a non-Content DDG tracker.
      */
     public static boolean isEssentiallyBlocked(Tracker tracker) {
+        return anyHostMatchesEssential(tracker, true);
+    }
+
+    /**
+     * Whether any observed host is known to the DDG list at all, whatever its
+     * action. A tracker that is detected only through X-Ray, Disconnect or the
+     * hosts file is neither blocked nor "allowed" by DDG — it is merely
+     * monitored, and the UI must say so rather than implying either verdict.
+     */
+    public static boolean isEssentiallyKnown(Tracker tracker) {
+        return anyHostMatchesEssential(tracker, false);
+    }
+
+    private static boolean anyHostMatchesEssential(Tracker tracker, boolean requireBlocked) {
         if (tracker == null)
             return false;
 
@@ -246,8 +262,10 @@ public class TrackerList {
             String hostname = host.endsWith(" *")
                     ? host.substring(0, host.length() - 2) : host;
             Tracker essentialTracker = findEssentialTracker(hostname);
-            if (essentialTracker != null
-                    && BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker.category))
+            if (essentialTracker == null)
+                continue;
+            if (!requireBlocked
+                    || BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker.category))
                 return true;
         }
 
@@ -296,21 +314,17 @@ public class TrackerList {
             String blockingMode = BlockingMode.getMode(c);
             boolean minimalBlockingMode = BlockingMode.MODE_MINIMAL.equals(blockingMode);
             Map<String, Tracker> loadedTrackers = new ConcurrentHashMap<>();
-            Map<String, Tracker> essentialTrackers = minimalBlockingMode
-                    ? loadedTrackers : new HashMap<>();
+            Map<String, Tracker> essentialTrackers = new HashMap<>();
 
-            boolean loaded;
-            if (minimalBlockingMode) {
-                // In minimal mode, only load DDG trackers (skip X-Ray and Disconnect)
-                // This ensures only confirmed, breakage-tested trackers are blocked
-                loaded = loadDuckDuckGoTrackers(c, loadedTrackers, essentialTrackers,
-                        domainBasedBlocking);
-            } else {
-                loaded = loadXrayTrackers(c, loadedTrackers, domainBasedBlocking);
-                loaded = loaded && loadDisconnectTrackers(c, loadedTrackers, domainBasedBlocking);
-                loaded = loaded && loadDuckDuckGoTrackers(c, loadedTrackers, essentialTrackers,
-                        domainBasedBlocking);
-            }
+            // Detection is mode-independent: every mode loads all curated lists
+            // into the detection map, so the trackers list, counts, timeline and
+            // traffic log show the same evidence everywhere. What minimal mode
+            // narrows is *blocking*, and that verdict comes from the separate
+            // DDG-only map below (see BlockingModeLogic#shouldBlockEssentialOnly).
+            boolean loaded = loadXrayTrackers(c, loadedTrackers, domainBasedBlocking);
+            loaded = loaded && loadDisconnectTrackers(c, loadedTrackers, domainBasedBlocking);
+            loaded = loaded && loadDuckDuckGoTrackers(c, loadedTrackers, essentialTrackers,
+                    domainBasedBlocking);
 
             if (!loaded) {
                 Log.w(TAG, "Keeping previous tracker snapshot after asset loading failure");
@@ -319,7 +333,7 @@ public class TrackerList {
 
             trackerSnapshot = new TrackerSnapshot(
                     loadedTrackers,
-                    minimalBlockingMode ? essentialTrackers : Collections.unmodifiableMap(essentialTrackers),
+                    Collections.unmodifiableMap(essentialTrackers),
                     domainBasedBlocking, minimalBlockingMode, blockingMode, true);
             invalidateTrackerCountCache();
             return true;

--- a/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ProtectionActivity.java
@@ -425,12 +425,13 @@ public class ProtectionActivity extends AppCompatActivity {
             boolean essentialOnly = state == AppProtectionState.ESSENTIAL_ONLY;
             boolean readOnlyMinimal = minimal || essentialOnly;
             categorySwitch.setEnabled(!readOnlyMinimal && state == AppProtectionState.PROTECTED);
-            boolean categoryEssentiallyBlocked = essentialOnly && category.getChildren().stream()
+            // Both read-only modes block exactly the non-Content DDG set, so the
+            // switch reflects whether anything in this category is in it, rather
+            // than assuming every non-Content category is blocked.
+            boolean categoryEssentiallyBlocked = readOnlyMinimal && category.getChildren().stream()
                     .anyMatch(TrackerList::isEssentiallyBlocked);
-            categorySwitch.setChecked(essentialOnly
+            categorySwitch.setChecked(readOnlyMinimal
                     ? trackerProtectionEnabled && categoryEssentiallyBlocked
-                    : readOnlyMinimal
-                    ? trackerProtectionEnabled && !TrackerBlocklist.NECESSARY_CATEGORY.equals(category.getCategoryName())
                     : blocklist.blocked(appUid, category.getCategoryName()));
             categorySwitch.setOnCheckedChangeListener((buttonView, checked) -> {
                 if (!buttonView.isPressed())
@@ -457,11 +458,17 @@ public class ProtectionActivity extends AppCompatActivity {
                 } else {
                     companyBlocked = state == AppProtectionState.PROTECTED
                             && trackerProtectionEnabled
-                            && (minimal ? TrackerBlocklist.blockedTrackerMinimal(tracker)
+                            && (minimal ? TrackerList.isEssentiallyBlocked(tracker)
                             : blocklist.blockedTracker(appUid, tracker));
                 }
+                // Same three states as the trackers list: in Minimal mode a
+                // company the DDG list does not know is monitored, not allowed.
+                boolean monitoredOnly = minimal && !companyBlocked
+                        && !TrackerList.isEssentiallyKnown(tracker);
                 String status = getString(ambiguousAllowed ? R.string.allowed_shared_ip
-                        : (companyBlocked ? R.string.blocked : R.string.allowed));
+                        : companyBlocked ? R.string.blocked
+                        : monitoredOnly ? R.string.tracker_monitored_minimal
+                        : R.string.allowed);
                 chip.setText(tracker.getName() + "  " + status);
                 chip.setTextColor(ContextCompat.getColor(this, R.color.colorPrimary));
                 chip.setChipStrokeColorResource(R.color.colorPrimaryLight);

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersListAdapter.java
@@ -249,13 +249,18 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     Spannable spannable;
                     boolean showStatus;
                     boolean companyBlocked;
+                    // Minimal mode detects far more than it blocks; a company
+                    // known only to X-Ray/Disconnect is monitored, and saying
+                    // "allowed" would read as a deliberate exemption.
+                    boolean monitoredOnly = false;
 
                     if (!trackerProtectionEnabled) {
                         showStatus = true;
                         companyBlocked = false;
                     } else if (BlockingMode.isMinimalMode(getContext())) {
                         showStatus = true;
-                        companyBlocked = TrackerBlocklist.blockedTrackerMinimal(t);
+                        companyBlocked = TrackerList.isEssentiallyBlocked(t);
+                        monitoredOnly = !companyBlocked && !TrackerList.isEssentiallyKnown(t);
                     } else if (essentialOnlyApp) {
                         showStatus = true;
                         companyBlocked = TrackerList.isEssentiallyBlocked(t);
@@ -280,7 +285,9 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     } else {
                         String status = getContext().getString(uncertainAllowed
                                 ? R.string.allowed_shared_ip
-                                : (companyBlocked ? R.string.blocked : R.string.allowed));
+                                : companyBlocked ? R.string.blocked
+                                : monitoredOnly ? R.string.tracker_monitored_minimal
+                                : R.string.allowed);
                         int color = ContextCompat.getColor(getContext(),
                                 companyBlocked ? R.color.colorPrimary : R.color.colorAccent);
 
@@ -311,8 +318,18 @@ public class TrackersListAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                 // Minimal-style modes: show read-only blocking status (no granular control)
                 holder.mSwitchTracker.setVisibility(View.VISIBLE);
                 holder.mSwitchTracker.setEnabled(false);
-                holder.mSwitchTracker.setChecked(trackerProtectionEnabled &&
-                        !TrackerBlocklist.NECESSARY_CATEGORY.equals(trackerCategoryName));
+                // Checked only if the category actually contains something that
+                // gets blocked: with detection broadened beyond the DDG list, a
+                // category whose observed members are all detection-only would
+                // otherwise show a "blocked" switch that lies.
+                boolean categoryEssentiallyBlocked = false;
+                for (Tracker t : trackerCategory.getChildren())
+                    if (TrackerList.isEssentiallyBlocked(t)) {
+                        categoryEssentiallyBlocked = true;
+                        break;
+                    }
+                holder.mSwitchTracker.setChecked(
+                        trackerProtectionEnabled && categoryEssentiallyBlocked);
                 holder.mSwitchTracker.setOnCheckedChangeListener(null);
                 holder.mCompaniesList.setOnItemClickListener(null);
             } else {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -758,6 +758,7 @@ Sincerely,\n\n]]></string>
     <string name="blocked">BLOCKED</string>
     <string name="allowed">ALLOWED</string>
     <string name="allowed_shared_ip">Allowed — shared IP; enable Strict mode to block</string>
+    <string name="tracker_monitored_minimal">Monitored — not blocked in Minimal mode</string>
 
     <string name="setting_domain_based_blocked">Domain-based Blocking</string>
     <string name="summary_domain_based_blocking">Allows more granular blocking. Still in development.</string>

--- a/app/src/test/java/eu/faircode/netguard/TrackerCacheTest.java
+++ b/app/src/test/java/eu/faircode/netguard/TrackerCacheTest.java
@@ -25,7 +25,7 @@ public class TrackerCacheTest {
     public void publicationNeverExposesHalfEntry() throws Exception {
         TrackerCache cache = new TrackerCache();
         Tracker tracker = tracker("Example");
-        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker, NEVER_EXPIRES);
+        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker, null, NEVER_EXPIRES);
         CountDownLatch readerReady = new CountDownLatch(1);
         CountDownLatch start = new CountDownLatch(1);
         CountDownLatch published = new CountDownLatch(1);
@@ -77,7 +77,7 @@ public class TrackerCacheTest {
     public void expiredEntryIsRemovedAsOneSnapshot() {
         TrackerCache cache = new TrackerCache();
         TrackerCache.Entry entry = new TrackerCache.Entry(
-                "tracker.example", tracker("Example"), System.currentTimeMillis() - 1);
+                "tracker.example", tracker("Example"), null, System.currentTimeMillis() - 1);
 
         assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
         assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
@@ -86,7 +86,7 @@ public class TrackerCacheTest {
     @Test
     public void expiryBoundaryIsStillValid() {
         TrackerCache cache = new TrackerCache();
-        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker("Example"), 100L);
+        TrackerCache.Entry entry = new TrackerCache.Entry("tracker.example", tracker("Example"), null, 100L);
 
         assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
         assertNotNull(cache.get(ADDRESS, 100L));
@@ -96,7 +96,7 @@ public class TrackerCacheTest {
     @Test
     public void invalidationRejectsStalePublication() {
         TrackerCache cache = new TrackerCache();
-        TrackerCache.Entry entry = new TrackerCache.Entry("old.example", tracker("Old"), NEVER_EXPIRES);
+        TrackerCache.Entry entry = new TrackerCache.Entry("old.example", tracker("Old"), null, NEVER_EXPIRES);
         long generationBefore = cache.generation();
         assertTrue(cache.putIfGeneration(ADDRESS, entry, generationBefore));
 
@@ -105,7 +105,7 @@ public class TrackerCacheTest {
         assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
         assertFalse(cache.putIfGeneration(
                 ADDRESS,
-                new TrackerCache.Entry("stale.example", tracker("Stale"), NEVER_EXPIRES),
+                new TrackerCache.Entry("stale.example", tracker("Stale"), null, NEVER_EXPIRES),
                 generationBefore));
         assertNull(cache.get(ADDRESS, System.currentTimeMillis()));
         assertEquals(generationBefore + 1, cache.generation());
@@ -117,11 +117,11 @@ public class TrackerCacheTest {
         long generationBefore = cache.generation();
         assertTrue(cache.putIfGeneration(
                 ADDRESS,
-                new TrackerCache.Entry("one.example", tracker("One"), NEVER_EXPIRES),
+                new TrackerCache.Entry("one.example", tracker("One"), null, NEVER_EXPIRES),
                 generationBefore));
         assertTrue(cache.putIfGeneration(
                 "192.0.2.2",
-                new TrackerCache.Entry("two.example", tracker("Two"), NEVER_EXPIRES),
+                new TrackerCache.Entry("two.example", tracker("Two"), null, NEVER_EXPIRES),
                 generationBefore));
 
         cache.clear();
@@ -145,7 +145,7 @@ public class TrackerCacheTest {
     public void blockingSnapshotAlwaysContainsTracker() {
         TrackerCache cache = new TrackerCache();
         TrackerCache.Entry entry = new TrackerCache.Entry(
-                ServiceSinkhole.NO_DNAME, ServiceSinkhole.NO_TRACKER, NEVER_EXPIRES);
+                ServiceSinkhole.NO_DNAME, ServiceSinkhole.NO_TRACKER, null, NEVER_EXPIRES);
 
         assertTrue(cache.putIfGeneration(ADDRESS, entry, cache.generation()));
         TrackerCache.Entry blockingSnapshot = cache.get(ADDRESS, System.currentTimeMillis());
@@ -157,7 +157,7 @@ public class TrackerCacheTest {
     @Test
     public void nullTrackerCannotEnterCache() {
         try {
-            new TrackerCache.Entry("tracker.example", null, NEVER_EXPIRES);
+            new TrackerCache.Entry("tracker.example", null, null, NEVER_EXPIRES);
             fail("null tracker must not be cacheable");
         } catch (NullPointerException expected) {
             // The blocking path can only read entries made through this value.
@@ -167,7 +167,7 @@ public class TrackerCacheTest {
     @Test
     public void nullHostnameCannotEnterCache() {
         try {
-            new TrackerCache.Entry(null, tracker("Example"), NEVER_EXPIRES);
+            new TrackerCache.Entry(null, tracker("Example"), null, NEVER_EXPIRES);
             fail("null hostname must not be cacheable");
         } catch (NullPointerException expected) {
             // The blocking path can only read complete snapshots.
@@ -180,7 +180,7 @@ public class TrackerCacheTest {
             long generation = cache.generation();
             assertTrue(cache.putIfGeneration(
                     ADDRESS,
-                    new TrackerCache.Entry("old.example", tracker("Old"), NEVER_EXPIRES),
+                    new TrackerCache.Entry("old.example", tracker("Old"), null, NEVER_EXPIRES),
                     generation));
             CyclicBarrier barrier = new CyclicBarrier(3);
             AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -190,7 +190,7 @@ public class TrackerCacheTest {
                     barrier.await();
                     cache.putIfGeneration(
                             ADDRESS,
-                            new TrackerCache.Entry("stale.example", tracker("Stale"), NEVER_EXPIRES),
+                            new TrackerCache.Entry("stale.example", tracker("Stale"), null, NEVER_EXPIRES),
                             generation);
                 } catch (Throwable ex) {
                     failure.compareAndSet(null, ex);

--- a/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/BlockingModeLogicTest.java
@@ -28,31 +28,12 @@ import java.util.Set;
 public class BlockingModeLogicTest {
 
     @Test
-    public void minimalBlocksOnlyNonContentTrackers() {
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_MINIMAL,
-                "Advertising",
-                false));
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_MINIMAL,
-                BlockingModeLogic.CONTENT_CATEGORY,
-                true));
-    }
-
-    @Test
-    public void standardAndStrictFollowGranularRules() {
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                "Advertising",
-                false));
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                BlockingModeLogic.CONTENT_CATEGORY,
-                true));
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STRICT,
-                BlockingModeLogic.CONTENT_CATEGORY,
-                true));
+    public void minimalBlocksOnlyNonContentDuckDuckGoTrackers() {
+        assertTrue(BlockingModeLogic.shouldBlockEssentialOnly("Advertising"));
+        assertFalse(BlockingModeLogic.shouldBlockEssentialOnly(
+                BlockingModeLogic.CONTENT_CATEGORY));
+        // Detected by another list, but unknown to DuckDuckGo: monitored, not blocked.
+        assertFalse(BlockingModeLogic.shouldBlockEssentialOnly(null));
     }
 
     @Test
@@ -208,66 +189,40 @@ public class BlockingModeLogicTest {
     }
 
     @Test
-    public void minimalIgnoresGranularRuleParameter() {
-        // Even when blockedByGranularRule is false, minimal still blocks non-Content
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_MINIMAL,
-                "Advertising",
-                false));
-        // Even when blockedByGranularRule is true, minimal still allows Content
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_MINIMAL,
-                BlockingModeLogic.CONTENT_CATEGORY,
-                true));
-    }
-
-    @Test
-    public void minimalBlocksAllNonContentCategories() {
+    public void minimalBlocksAllNonContentDuckDuckGoCategories() {
         for (String category : new String[]{
                 "Advertising", "Analytics", "Social", "Fingerprinting",
                 "Email", "Uncategorised"}) {
             assertTrue("Should block " + category,
-                    BlockingModeLogic.shouldBlockKnownTracker(
-                            BlockingModeLogic.MODE_MINIMAL, category, false));
+                    BlockingModeLogic.shouldBlockEssentialOnly(category));
         }
     }
 
     @Test
     public void standardWithGranularFalseDoesNotBlock() {
-        // In standard mode, if granular rule says not blocked, it's not blocked
-        // regardless of category
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                "Advertising",
-                false));
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                "Analytics",
-                false));
-    }
+        // In standard mode, the granular rule is the whole verdict
+        TrackerBlocklist.resetForTests();
+        TrackerBlocklist blocklist = TrackerBlocklist.getInstance(null);
+        int uid = 1001;
 
-    @Test
-    public void strictWithGranularTrueBlocksContent() {
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STRICT,
-                BlockingModeLogic.CONTENT_CATEGORY,
-                true));
+        blocklist.ensureDefaults(uid, false);
+        Tracker tracker = new Tracker("Branch", "Advertising");
+        blocklist.unblock(uid, tracker.category);
+
+        assertFalse(blocklist.blockedTracker(uid, tracker));
     }
 
     @Test
     public void endToEndMinimalBlocksAdvertisingTrackerRegardlessOfBlocklist() {
-        // Simulates the full decision chain for minimal mode:
-        // TrackerBlocklist is not consulted, only category matters
+        // Minimal mode never consults TrackerBlocklist: the DuckDuckGo category
+        // of the flow is the whole verdict.
         TrackerBlocklist.resetForTests();
         TrackerBlocklist blocklist = TrackerBlocklist.getInstance(null);
         Tracker tracker = new Tracker("Branch", "Advertising");
 
-        // Even if user hasn't set up any rules (no ensureDefaults), minimal blocks
-        boolean blockedByGranular = blocklist.blockedTracker(1001, tracker);
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_MINIMAL,
-                tracker.category,
-                blockedByGranular));
+        blocklist.unblock(1001, tracker.category);
+        assertFalse(blocklist.blockedTracker(1001, tracker));
+        assertTrue(BlockingModeLogic.shouldBlockEssentialOnly(tracker.category));
     }
 
     @Test
@@ -282,10 +237,6 @@ public class BlockingModeLogicTest {
         boolean blockedByGranular = blocklist.blockedTracker(uid, contentTracker);
         assertFalse("Content should not be blocked by granular rule in standard defaults",
                 blockedByGranular);
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                contentTracker.category,
-                blockedByGranular));
     }
 
     @Test
@@ -300,10 +251,6 @@ public class BlockingModeLogicTest {
         boolean blockedByGranular = blocklist.blockedTracker(uid, contentTracker);
         assertTrue("Content should be blocked by granular rule in strict defaults",
                 blockedByGranular);
-        assertTrue(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STRICT,
-                contentTracker.category,
-                blockedByGranular));
     }
 
     @Test
@@ -319,10 +266,6 @@ public class BlockingModeLogicTest {
 
         // User unblocks Branch specifically
         blocklist.unblock(uid, tracker);
-        boolean blockedByGranular = blocklist.blockedTracker(uid, tracker);
-        assertFalse(BlockingModeLogic.shouldBlockKnownTracker(
-                BlockingModeLogic.MODE_STANDARD,
-                tracker.category,
-                blockedByGranular));
+        assertFalse(blocklist.blockedTracker(uid, tracker));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerBlocklistTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerBlocklistTest.java
@@ -104,14 +104,6 @@ public class TrackerBlocklistTest {
     }
 
     @Test
-    public void minimalModeOnlyAllowsContentCategory() {
-        assertFalse(TrackerBlocklist.blockedTrackerMinimal(
-                new Tracker("Google", TrackerBlocklist.NECESSARY_CATEGORY)));
-        assertTrue(TrackerBlocklist.blockedTrackerMinimal(
-                new Tracker("Branch", "Advertising")));
-    }
-
-    @Test
     public void resolveStoredUidParsesNumericIdsWithoutResolver() {
         assertEquals(Integer.valueOf(UID),
                 UidKeyedStore.resolveStoredUid(Integer.toString(UID), null));

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListEssentialTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListEssentialTest.java
@@ -15,9 +15,9 @@
 package net.kollnig.missioncontrol.data;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import android.content.Context;
@@ -75,16 +75,82 @@ public class TrackerListEssentialTest {
     }
 
     @Test
-    public void minimalModeUsesTheMainDdgMapForEssentialLookup() {
+    public void minimalModeDetectsWithEveryListButKeepsTheDdgMapForBlocking() {
+        switchToMinimalMode();
+
+        // Detected through X-Ray/Disconnect, so it shows up in the trackers
+        // list, counts and timeline — but it is not part of the DDG set that
+        // minimal mode blocks.
+        assertNotNull(TrackerList.findTracker("crashlytics.com"));
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
+
+        // A DDG tracker stays blockable, with its DDG category.
+        Tracker essentialTracker = TrackerList.findEssentialTracker("2mdn.net");
+        assertNotNull(essentialTracker);
+        assertEquals("Google", essentialTracker.getName());
+        assertTrue(BlockingModeLogic.shouldBlockEssentialOnly(essentialTracker.category));
+    }
+
+    @Test
+    public void minimalModeStillSkipsHostsFileDetection() {
+        switchToMinimalMode();
+        ServiceSinkhole.mapHostsBlocked.put("hosts-only.example", true);
+
+        assertNull(TrackerList.findTracker("hosts-only.example"));
+        assertNull(TrackerList.findEssentialTracker("hosts-only.example"));
+    }
+
+    @Test
+    public void detectionMapKeepsDuckDuckGoCategoryConflictResolutionInMinimalMode() {
+        switchToMinimalMode();
+
+        // X-Ray claimed 2mdn.net with a real category; DDG must not overwrite it
+        // in the detection map, exactly as in standard mode.
+        Tracker mainTracker = TrackerList.findTracker("2mdn.net");
+        assertNotNull(mainTracker);
+        assertEquals("Fingerprinting", mainTracker.category);
+        assertEquals(TrackerCategory.UNCATEGORISED,
+                TrackerList.findEssentialTracker("2mdn.net").category);
+    }
+
+    @Test
+    public void essentialMapIsIdenticalAcrossModes() {
+        Tracker standard = TrackerList.findEssentialTracker("2mdn.net");
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
+
+        switchToMinimalMode();
+        Tracker minimal = TrackerList.findEssentialTracker("2mdn.net");
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
+
+        assertNotNull(minimal);
+        assertEquals(standard.getName(), minimal.getName());
+        assertEquals(standard.category, minimal.category);
+    }
+
+    @Test
+    public void detectionOnlyTrackerIsMonitoredRatherThanBlockedOrAllowed() {
+        switchToMinimalMode();
+
+        Tracker detectionOnly = TrackerList.findTracker("crashlytics.com");
+        detectionOnly.addHost("crashlytics.com");
+        assertFalse(TrackerList.isEssentiallyBlocked(detectionOnly));
+        assertFalse(TrackerList.isEssentiallyKnown(detectionOnly));
+
+        Tracker ddgTracker = TrackerList.findTracker("2mdn.net");
+        ddgTracker.addHost("2mdn.net");
+        assertTrue(TrackerList.isEssentiallyBlocked(ddgTracker));
+        assertTrue(TrackerList.isEssentiallyKnown(ddgTracker));
+
+        Tracker ddgContent = TrackerList.findTracker("ajax.googleapis.com");
+        ddgContent.addHost("ajax.googleapis.com");
+        assertFalse(TrackerList.isEssentiallyBlocked(ddgContent));
+        assertTrue(TrackerList.isEssentiallyKnown(ddgContent));
+    }
+
+    private void switchToMinimalMode() {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString(BlockingMode.PREF_BLOCKING_MODE, BlockingMode.MODE_MINIMAL)
                 .commit();
         assertTrue(TrackerList.reloadTrackerData(context));
-
-        assertSame(TrackerList.findTracker("2mdn.net"),
-                TrackerList.findEssentialTracker("2mdn.net"));
-        ServiceSinkhole.mapHostsBlocked.put("hosts-only.example", true);
-        assertNull(TrackerList.findTracker("hosts-only.example"));
-        assertNull(TrackerList.findEssentialTracker("hosts-only.example"));
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/TrackerListReloadTest.java
@@ -170,17 +170,22 @@ public class TrackerListReloadTest {
     }
 
     @Test
-    public void modeSelectionPublishesOnlyTheSelectedLists() {
+    public void everyModePublishesTheFullDetectionMapAndTheDdgBlockingMap() {
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString(BLOCKING_MODE, BlockingMode.MODE_MINIMAL).commit();
         TrackerList.getInstance(context);
+        // Detection is mode-independent...
         assertNotNull(TrackerList.findTracker("creativecdn.com"));
-        assertNull(TrackerList.findTracker("crashlytics.com"));
+        assertNotNull(TrackerList.findTracker("crashlytics.com"));
+        // ...while blocking stays limited to the DuckDuckGo list.
+        assertNotNull(TrackerList.findEssentialTracker("creativecdn.com"));
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
 
         PreferenceManager.getDefaultSharedPreferences(context).edit()
                 .putString(BLOCKING_MODE, BlockingMode.MODE_STANDARD).commit();
         assertTrue(TrackerList.reloadTrackerData(context));
         assertNotNull(TrackerList.findTracker("crashlytics.com"));
+        assertNull(TrackerList.findEssentialTracker("crashlytics.com"));
     }
 
     @Test


### PR DESCRIPTION
Implements the design in #838.

## What changed

**Loading** (`TrackerList.loadTrackers`) — every mode now loads X-Ray → Disconnect → DDG into the detection map, and `essentialHostnameToTracker` is a separate DDG-only map in *all* modes instead of aliasing the detection map in minimal mode. The snapshot invariants are now mode-independent:

- `hostnameToTracker` — all curated lists; feeds `findTracker`, so display, counts, timeline and logging broaden automatically.
- `essentialHostnameToTracker` — DDG-only; the blocking authority for minimal mode and for essential-only apps.

Hosts-file lookups stay skipped in minimal-mode detection (unchanged, §1 of the design).

**Blocking verdict** (`ServiceSinkhole.blockKnownTracker`) — minimal mode and essential-only apps share one verdict: block iff the flow matched a non-Content DDG tracker. The essential category is resolved during candidate resolution, where both `qname` and `aname` are in hand, and cached in `TrackerCache.Entry`; a verdict-time lookup by the cached hostname alone would have missed a DDG match on an uncloaked CNAME target (the essential-only-app path had that miss today — fixed for free). Mixed-evidence IPs are classified by DDG membership for the blocking decision, so the broadened detection map cannot flip a previously allowed mixed IP to blocked.

`TrackerBlocklist.blockedTrackerMinimal` and `BlockingModeLogic.shouldBlockKnownTracker` both encoded the "the map is DDG-only" assumption and are deleted; `InsightsDataProvider` follows the same essential-lookup path in minimal mode.

**UI** — per-company status gains a third state, `tracker_monitored_minimal` ("Monitored — not blocked in Minimal mode"), so a detection-only company is never displayed as "Allowed" (trackers list and protection chips). Read-only category switches are checked only when some member of the category is essentially blocked, instead of assuming every non-Content category is blocked.

No new preference: detection breadth is not a knob.

## Note for the release notes

Tracker counts will *rise* for minimal-mode users after upgrade — that is the point, but it deserves a changelog line so it isn't read as "the update added tracking". Blocking behaviour is unchanged, so no Play-policy delta for TC Slim is expected.

## Tests

`./gradlew :app:testGithubDebugUnitTest` (370 tests) and `:app:lintGithubDebug` pass.

- Loading: minimal mode resolves an X-Ray-only domain via `findTracker` but not `findEssentialTracker`; the essential map is identical across modes; DDG still loses category conflicts in the detection map.
- Blocking logic: minimal blocks only non-Content DDG categories; a detection-only domain yields no verdict.
- UI logic: a detection-only tracker is monitored (neither blocked nor DDG-known); a DDG Content tracker is known but not blocked.
- Existing `BlockingModeLogic`/`TrackerCache`/reload tests updated to the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)