### PR TITLE
Finish the Material 3 migration in the theme and cards

### DIFF
--- a/app/src/main/res/layout/activity_insights.xml
+++ b/app/src/main/res/layout/activity_insights.xml
@@ -19,7 +19,7 @@
         android:padding="16dp">
 
         <!-- Hero Card: Total Tracking Attempts -->
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
@@ -78,7 +78,7 @@
                     tools:text="Your apps tried to contact 34 tracking companies this week!" />
 
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
         <!-- Protection Stats Row -->
         <LinearLayout
@@ -278,7 +278,7 @@
             android:layout_marginTop="8dp"
             android:visibility="gone" />
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
@@ -296,7 +296,7 @@
                 <!-- Will be populated dynamically -->
 
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
         <!-- Top Tracker Companies Section (hidden - unclear metric) -->
         <TextView
@@ -308,7 +308,7 @@
             android:layout_marginBottom="8dp"
             android:visibility="gone" />
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
@@ -326,7 +326,7 @@
                 <!-- Will be populated dynamically -->
 
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
         <!-- Pervasive Trackers Section -->
         <TextView
@@ -337,7 +337,7 @@
             android:textStyle="bold"
             android:layout_marginBottom="8dp" />
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
@@ -354,7 +354,7 @@
                 <!-- Will be populated dynamically -->
 
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
         <!-- Top Domains Section -->
         <TextView
@@ -365,7 +365,7 @@
             android:textStyle="bold"
             android:layout_marginBottom="8dp" />
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="16dp"
@@ -382,7 +382,7 @@
                 <!-- Will be populated dynamically -->
 
             </LinearLayout>
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
         <!-- Protection Badge -->
 

--- a/app/src/main/res/layout/activity_libraries.xml
+++ b/app/src/main/res/layout/activity_libraries.xml
@@ -44,11 +44,10 @@
             android:paddingEnd="16dp"
             android:paddingBottom="24dp">
 
-            <androidx.cardview.widget.CardView
+            <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
-                app:cardCornerRadius="4dp"
                 app:cardElevation="1dp"
                 app:cardMaxElevation="@dimen/z_card">
 
@@ -135,7 +134,7 @@
 
                 </LinearLayout>
 
-            </androidx.cardview.widget.CardView>
+            </com.google.android.material.card.MaterialCardView>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_protection.xml
+++ b/app/src/main/res/layout/activity_protection.xml
@@ -45,12 +45,11 @@
             android:paddingEnd="16dp"
             android:paddingBottom="24dp">
 
-            <androidx.cardview.widget.CardView
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/cardPause"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="16dp"
-                app:cardCornerRadius="4dp"
                 app:cardElevation="1dp"
                 app:cardMaxElevation="@dimen/z_card">
 
@@ -86,7 +85,7 @@
 
                 </LinearLayout>
 
-            </androidx.cardview.widget.CardView>
+            </com.google.android.material.card.MaterialCardView>
 
             <TextView
                 android:id="@+id/tvLockdownNote"
@@ -131,11 +130,10 @@
                 android:textColor="?android:textColorSecondary"
                 android:visibility="gone" />
 
-            <androidx.cardview.widget.CardView
+            <com.google.android.material.card.MaterialCardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                app:cardCornerRadius="4dp"
                 app:cardElevation="1dp"
                 app:cardMaxElevation="@dimen/z_card">
 
@@ -239,19 +237,18 @@
 
                 </LinearLayout>
 
-            </androidx.cardview.widget.CardView>
+            </com.google.android.material.card.MaterialCardView>
 
             <!--
               Remote-VPN routing lives beside the protection state because both
               decide how this app's traffic is handled, but they stay separate
               controls: filtering and tunnelling are independent choices (#723).
             -->
-            <androidx.cardview.widget.CardView
+            <com.google.android.material.card.MaterialCardView
                 android:id="@+id/cardAppRoute"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="8dp"
-                app:cardCornerRadius="4dp"
                 app:cardElevation="1dp"
                 app:cardMaxElevation="@dimen/z_card">
 
@@ -322,7 +319,7 @@
 
                 </LinearLayout>
 
-            </androidx.cardview.widget.CardView>
+            </com.google.android.material.card.MaterialCardView>
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_actions.xml
+++ b/app/src/main/res/layout/fragment_actions.xml
@@ -12,12 +12,11 @@
         android:orientation="vertical"
         android:padding="16dp">
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
             android:clipToPadding="false"
-            app:cardCornerRadius="4dp"
             app:cardElevation="1dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -102,15 +101,14 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="4dp"
             android:clipToPadding="false"
-            app:cardCornerRadius="4dp"
             app:cardElevation="1dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -206,15 +204,14 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
-        <androidx.cardview.widget.CardView
+        <com.google.android.material.card.MaterialCardView
             android:id="@+id/adsettings_card"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
             android:clipToPadding="false"
-            app:cardCornerRadius="4dp"
             app:cardElevation="1dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
@@ -279,7 +276,7 @@
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 
-        </androidx.cardview.widget.CardView>
+        </com.google.android.material.card.MaterialCardView>
 
 
     </LinearLayout>

--- a/app/src/main/res/layout/item_insights_header.xml
+++ b/app/src/main/res/layout/item_insights_header.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Hero card for insights displayed at top of MainActivity RecyclerView -->
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -205,4 +205,4 @@
 
     </LinearLayout>
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_protection_category.xml
+++ b/app/src/main/res/layout/item_protection_category.xml
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="8dp"
-    app:cardCornerRadius="4dp"
     app:cardElevation="1dp"
     app:cardMaxElevation="@dimen/z_card">
 
@@ -67,4 +66,4 @@
 
     </LinearLayout>
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/item_vpn_status.xml
+++ b/app/src/main/res/layout/item_vpn_status.xml
@@ -56,7 +56,8 @@
             android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/vpn_settings"
             android:padding="12dp"
-            android:src="?attr/iconSettings" />
+            android:src="@drawable/ic_settings_black_24dp"
+            app:tint="?attr/colorControlNormal" />
 
         <com.google.android.material.materialswitch.MaterialSwitch
             android:id="@+id/vpnEnabledSwitch"

--- a/app/src/main/res/layout/legend.xml
+++ b/app/src/main/res/layout/legend.xml
@@ -1,4 +1,5 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical"
@@ -77,7 +78,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="?attr/iconQueue"
+                    android:src="@drawable/ic_hourglass_empty_black_24dp"
+                    app:tint="?attr/colorControlNormal"
                     android:importantForAccessibility="no"/>
 
                 <TextView
@@ -100,7 +102,8 @@
                     android:layout_height="24dp"
                     android:layout_gravity="center_vertical"
                     android:layout_margin="4dp"
-                    android:src="?attr/iconMetered"
+                    android:src="@drawable/ic_attach_money_black_24dp"
+                    app:tint="?attr/colorControlNormal"
                     android:importantForAccessibility="no"/>
 
                 <TextView

--- a/app/src/main/res/layout/list_item_trackers.xml
+++ b/app/src/main/res/layout/list_item_trackers.xml
@@ -1,10 +1,9 @@
-<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_marginBottom="8dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
-    app:cardCornerRadius="4dp"
     app:cardElevation="1dp"
     app:cardMaxElevation="@dimen/z_card">
 
@@ -69,4 +68,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.cardview.widget.CardView>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -5,14 +5,13 @@
     android:layout_height="wrap_content"
     android:orientation="vertical">
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardNotSupported"
         android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_marginBottom="8dp"
         android:clipToPadding="false"
-        app:cardCornerRadius="4dp"
         app:cardElevation="1dp"
         app:cardMaxElevation="@dimen/z_card">
 
@@ -48,7 +47,7 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
     <!--
       Two summary rows only. Protection and remote-VPN routing share one row
@@ -57,13 +56,12 @@
       rather than from observed traffic. Both open a dedicated screen, so the
       per-company list below starts as close to the top as possible.
     -->
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardAppControls"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
         android:clipToPadding="false"
-        app:cardCornerRadius="4dp"
         app:cardElevation="1dp"
         app:cardMaxElevation="@dimen/z_card">
 
@@ -189,6 +187,6 @@
 
         </LinearLayout>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
 </LinearLayout>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -1,8 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#fb8c00</color>
-    <color name="colorPrimaryDark">#c25e00</color>
+    <!-- Brand red, same as light mode. Used for the app bar fill, where white
+         title text on #B71C1C is the standard Material red-900 pairing. -->
+    <color name="colorPrimary">#B71C1C</color>
+    <color name="colorPrimaryDark">#7f0000</color>
+
     <color name="colorAccent">#4db6ac</color>
+
+    <!-- colorRedOn feeds ?attr/colorOff, which is used as a *text* colour on
+         the near-black dark background (main.xml, legend.xml,
+         item_vpn_status.xml, item_vpn_empty.xml). The brand red only reaches
+         3.5:1 there, below WCAG AA for body text, so dark mode lightens it to
+         red 400 (6.0:1). The app bar keeps the true brand red via colorPrimary
+         above; this only affects text and state icons. -->
+    <color name="colorRedOn">#EF5350</color>
 
     <!-- Brighter than colorAccent for low-contrast text links on the dark
          (near-black) surface, e.g. the "Manage WireGuard profiles" footer

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -7,12 +7,4 @@
         <item name="android:windowBackground">@color/black</item>
         <item name="android:colorBackground">@color/black</item>
     </style>
-
-    <style name="AppThemeRed" parent="BaseThemeLight">
-        <item name="colorPrimary">@color/colorRedPrimary</item>
-        <item name="colorPrimaryDark">@color/colorRedPrimaryDark</item>
-        <item name="colorAccent">@color/colorRedAccent</item>
-        <item name="colorOn">@color/colorRedOff</item>
-        <item name="colorOff">@color/colorRedOn</item>
-    </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,15 +1,6 @@
 <resources>
     <attr name="colorOn" format="reference" />
     <attr name="colorOff" format="reference" />
-    <attr name="expander" format="reference" />
-    <attr name="iconQueue" format="reference" />
-    <attr name="iconMetered" format="reference" />
-    <attr name="iconSettings" format="reference" />
-    <attr name="iconDatasaver" format="reference" />
-    <attr name="iconLaunch" format="reference" />
-    <attr name="iconDelete" format="reference" />
-    <attr name="iconPlay" format="reference" />
-    <attr name="iconPause" format="reference" />
 
     <style name="AppTheme" parent="Theme.Material3.DayNight">
         <item name="colorPrimary">@color/colorPrimary</item>
@@ -20,49 +11,24 @@
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
     </style>
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.Material3.Dark.ActionBar"/>
 
     <style name="PrimaryFlatButton" parent="Theme.Material3.Light">
         <item name="colorPrimary">@color/colorPrimary</item>
     </style>
 
-    <style name="BaseThemeDark" parent="Theme.Material3.Light">
+    <!-- Single base theme. Day/night is handled by Theme.Material3.DayNight;
+         icons are tinted via ?attr/colorControlNormal rather than duplicated
+         as black/white drawables behind theme attributes. -->
+    <style name="BaseTheme" parent="Theme.Material3.DayNight">
         <item name="windowActionBar">true</item>
         <item name="windowNoTitle">false</item>
-        <item name="expander">@drawable/expander_black</item>
-        <item name="iconQueue">@drawable/ic_hourglass_empty_black_24dp</item>
-        <item name="iconMetered">@drawable/ic_attach_money_black_24dp</item>
-        <item name="iconSettings">@drawable/ic_settings_black_24dp</item>
-        <item name="iconDatasaver">@drawable/ic_perm_data_setting_black_24dp</item>
-        <item name="iconLaunch">@drawable/ic_launch_black_24dp</item>
-        <item name="iconDelete">@drawable/ic_delete_black_24dp</item>
-        <item name="iconPlay">@drawable/ic_play_arrow_black_24dp</item>
-        <item name="iconPause">@drawable/ic_pause_black_24dp</item>
         <item name="android:windowDisablePreview">true</item>
         <item name="actionBarStyle">@style/ActionBar.Red</item>
         <item name="actionBarTheme">@style/ActionBarTheme.Red</item>
         <item name="toolbarStyle">@style/Toolbar.Red</item>
     </style>
 
-    <style name="BaseThemeLight" parent="Theme.Material3.DayNight">
-        <item name="windowActionBar">true</item>
-        <item name="windowNoTitle">false</item>
-        <item name="expander">@drawable/expander_white</item>
-        <item name="iconQueue">@drawable/ic_hourglass_empty_white_24dp</item>
-        <item name="iconMetered">@drawable/ic_attach_money_white_24dp</item>
-        <item name="iconSettings">@drawable/ic_settings_white_24dp</item>
-        <item name="iconDatasaver">@drawable/ic_perm_data_setting_white_24dp</item>
-        <item name="iconLaunch">@drawable/ic_launch_white_24dp</item>
-        <item name="iconDelete">@drawable/ic_delete_white_24dp</item>
-        <item name="iconPlay">@drawable/ic_play_arrow_white_24dp</item>
-        <item name="iconPause">@drawable/ic_pause_white_24dp</item>
-        <item name="android:windowDisablePreview">true</item>
-        <item name="actionBarStyle">@style/ActionBar.Red</item>
-        <item name="actionBarTheme">@style/ActionBarTheme.Red</item>
-        <item name="toolbarStyle">@style/Toolbar.Red</item>
-    </style>
-
-    <style name="AppThemeRed" parent="BaseThemeDark">
+    <style name="AppThemeRed" parent="BaseTheme">
         <item name="colorPrimary">@color/colorRedPrimary</item>
         <item name="colorPrimaryDark">@color/colorRedPrimaryDark</item>
         <item name="colorAccent">@color/colorRedAccent</item>
@@ -101,7 +67,7 @@
     </style>
 
     <!-- ActionBar with colorPrimary background and white icons/text -->
-    <style name="ActionBar.Red" parent="Widget.AppCompat.ActionBar.Solid">
+    <style name="ActionBar.Red" parent="Widget.Material3.ActionBar.Solid">
         <item name="background">@color/colorPrimary</item>
         <item name="backgroundTint">@color/colorPrimary</item>
         <item name="titleTextStyle">@style/ActionBarTitleText</item>


### PR DESCRIPTION
The app already targeted Material 3 — `material:1.14.0`, every theme parent `Theme.Material3.*` — but the styles *inside* those themes were still Material 2. This clears the leftovers. **The red brand and the rocket toggle are untouched.**

### Theme

- Dropped 9 custom theme attrs. Eight (`expander`, `iconDatasaver`, `iconLaunch`, `iconDelete`, `iconPlay`, `iconPause`, …) had **zero** references anywhere in `app/src`. The three live ones (`iconQueue`, `iconMetered`, `iconSettings`) now use a single drawable tinted with `?attr/colorControlNormal` instead of a black/white pair swapped by theme.
- That icon tinting was the *only* thing `BaseThemeDark` and `BaseThemeLight` differed by, so they collapse into one `BaseTheme` on `Theme.Material3.DayNight` — which in turn makes the entire `AppThemeRed` override in `values-night/styles.xml` redundant. Day/night resolution is unchanged.
- `ActionBar.Red` moves off `Widget.AppCompat.ActionBar.Solid` (AppCompat, pre-Material) to the Material3 parent. Red fill unchanged.
- Removed the unused `AppTheme.AppBarOverlay`.

### Dark mode: the orange is gone

`colorPrimary` was `#fb8c00`, so the app was orange at night and red by day.

It wasn't a straight swap, though. `colorPrimary` also fed `?attr/colorOff`, which is used as a **text** colour on the near-black dark background (`main.xml`, `legend.xml`, `item_vpn_status.xml`, `item_vpn_empty.xml`). The brand red only reaches **3.5:1** there — below WCAG AA for body text — which is very likely why the orange (~8:1) was chosen in the first place. So the two are decoupled rather than merged:

| | before | after |
|---|---|---|
| app bar fill | `#fb8c00` orange | `#B71C1C` brand red (white-on-red, standard Material red-900 pairing) |
| `?attr/colorOff` text | `#fb8c00` orange | `#EF5350` red 400 — 6.0:1, passes AA |

### Cards

- Swapped 34 `androidx.cardview.widget.CardView` tags for `MaterialCardView` across 8 layouts. This is a real fix, not cosmetic: androidx `CardView` hardcodes `@color/cardview_dark_background` (`#424242`) in dark mode, so these cards never matched the M3 dark surface. `ProtectionActivity.cardPause` still binds — `MaterialCardView` extends `CardView`.
- Dropped the 11 `app:cardCornerRadius="4dp"` overrides so those cards inherit `?attr/shapeAppearanceMediumComponent` (12dp). The deliberate `8dp`/`16dp` radii on the newer screens are left alone.

### Deliberately not done

- **`Button` → `MaterialButton`.** `Theme.Material3.*` already inflates plain `<Button>` as `MaterialButton` via `MaterialComponentsViewInflater`, so the swap would be 20+ files of churn with zero runtime effect. The real gap there is that unstyled buttons default to *filled* — `fragment_actions.xml` renders six filled buttons in a row — but choosing which become tonal/outlined/text is a visual design decision, not a mechanical one.
- **The legacy NetGuard screens** (`ActivityDns`, `ActivityForwarding`, `ActivityLog`) are out of scope. They hold most of the remaining `ListView` and unstyled-`Button` usage.

### Verification

`:app:compileGithubDebugJavaWithJavac` and `:app:lintGithubDebug` both pass — **0 errors**, 539 warnings (one fewer than baseline, from the dead style removed).

⚠️ **Not verified on a screen.** The contrast figures above are computed, not observed, and the 12dp corners haven't been looked at. Worth a visual pass before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)