### PR TITLE
Surface Proton VPN setup on the VPN tab

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -45,6 +45,12 @@ import eu.faircode.netguard.ServiceSinkhole;
 import eu.faircode.netguard.Util;
 
 public class ActivityWireGuardProfiles extends AppCompatActivity {
+    // Lets other screens (the VPN tab) jump straight to a setup route instead
+    // of hiding it behind the add-profile dialog.
+    public static final String EXTRA_SETUP = "setup";
+    public static final String SETUP_IMPORT = "import";
+    public static final String SETUP_PROTON = "proton";
+
     private static final String PROTON_DASHBOARD_URL =
             "https://account.protonvpn.com/downloads#wireguard-configuration";
 
@@ -76,6 +82,14 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
         fab.setOnClickListener(v -> showAddProfileChoice());
 
         refresh();
+
+        if (savedInstanceState == null) {
+            String setup = getIntent() == null ? null : getIntent().getStringExtra(EXTRA_SETUP);
+            if (SETUP_PROTON.equals(setup))
+                showProtonDialog();
+            else if (SETUP_IMPORT.equals(setup))
+                showProfileDialog(null);
+        }
     }
 
     @Override

--- a/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
@@ -356,8 +356,15 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
     }
 
     private void openWireGuardProfiles() {
+        openWireGuardProfiles(null);
+    }
+
+    private void openWireGuardProfiles(String setup) {
         prefs.edit().putString(PREF_VPN_MODE, MODE_WIREGUARD).apply();
-        startActivity(new Intent(requireContext(), ActivityWireGuardProfiles.class));
+        Intent intent = new Intent(requireContext(), ActivityWireGuardProfiles.class);
+        if (setup != null)
+            intent.putExtra(ActivityWireGuardProfiles.EXTRA_SETUP, setup);
+        startActivity(intent);
     }
 
     private void setProviderMode(String mode) {
@@ -935,6 +942,8 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
             holder.ivpn.setOnClickListener(v -> openIvpnSetup());
             holder.ivpnAccount.setOnClickListener(v -> openIvpnAccountPage());
             holder.wireGuard.setOnClickListener(v -> openWireGuardProfiles());
+            holder.proton.setOnClickListener(v ->
+                    openWireGuardProfiles(ActivityWireGuardProfiles.SETUP_PROTON));
         }
 
         private int listStartPosition() {
@@ -1088,7 +1097,9 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
             holder.text.setText(customProfiles().isEmpty()
                     ? R.string.vpn_import_wireguard_profile
                     : R.string.vpn_manage_wireguard_profiles);
-            holder.itemView.setOnClickListener(v -> openWireGuardProfiles());
+            holder.text.setOnClickListener(v -> openWireGuardProfiles());
+            holder.proton.setOnClickListener(v ->
+                    openWireGuardProfiles(ActivityWireGuardProfiles.SETUP_PROTON));
         }
     }
 
@@ -1136,6 +1147,7 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
         final Button ivpn;
         final Button ivpnAccount;
         final Button wireGuard;
+        final Button proton;
 
         IntroViewHolder(View itemView) {
             super(itemView);
@@ -1144,6 +1156,7 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
             ivpn = itemView.findViewById(R.id.vpnIntroIvpnAction);
             ivpnAccount = itemView.findViewById(R.id.vpnIntroIvpnAccountAction);
             wireGuard = itemView.findViewById(R.id.vpnIntroWireGuardAction);
+            proton = itemView.findViewById(R.id.vpnIntroProtonAction);
         }
     }
 
@@ -1204,10 +1217,12 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
 
     private static class FooterViewHolder extends RecyclerView.ViewHolder {
         final TextView text;
+        final TextView proton;
 
         FooterViewHolder(View itemView) {
             super(itemView);
             text = itemView.findViewById(R.id.vpnCustomProfiles);
+            proton = itemView.findViewById(R.id.vpnProtonSetup);
         }
     }
 }

--- a/app/src/main/res/layout/item_vpn_footer.xml
+++ b/app/src/main/res/layout/item_vpn_footer.xml
@@ -1,10 +1,29 @@
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/vpnCustomProfiles"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center"
-    android:padding="16dp"
-    android:text="@string/vpn_manage_wireguard_profiles"
-    android:textAppearance="@style/TextSmall"
-    android:textColor="@color/colorFooterLink"
-    android:textStyle="bold" />
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/vpnCustomProfiles"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:padding="16dp"
+        android:text="@string/vpn_manage_wireguard_profiles"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="@color/colorFooterLink"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/vpnProtonSetup"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingStart="16dp"
+        android:paddingEnd="16dp"
+        android:paddingBottom="16dp"
+        android:text="@string/setting_wg_proton_setup"
+        android:textAppearance="@style/TextSmall"
+        android:textColor="@color/colorFooterLink"
+        android:textStyle="bold" />
+</LinearLayout>

--- a/app/src/main/res/layout/item_vpn_intro.xml
+++ b/app/src/main/res/layout/item_vpn_intro.xml
@@ -102,6 +102,30 @@
         </LinearLayout>
 
         <TextView
+            android:id="@+id/vpnIntroProtonTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="14dp"
+            android:text="@string/vpn_intro_proton_title"
+            android:textAppearance="@style/TextMedium" />
+
+        <TextView
+            android:id="@+id/vpnIntroProtonBody"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/vpn_intro_proton_body"
+            android:textAppearance="@style/TextSmall" />
+
+        <Button
+            android:id="@+id/vpnIntroProtonAction"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="@string/setting_wg_proton_setup" />
+
+        <TextView
             android:id="@+id/vpnIntroWireGuardTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,6 +263,8 @@
     <string name="vpn_intro_mullvad_body">A privacy-focused VPN provider. It costs €5 per month and uses account numbers instead of email addresses. Enter an account number, then choose a country in TrackerControl.</string>
     <string name="vpn_intro_ivpn_title">IVPN</string>
     <string name="vpn_intro_ivpn_body">A privacy-focused VPN provider with WireGuard support. Enter an IVPN account ID, then choose a country in TrackerControl.</string>
+    <string name="vpn_intro_proton_title">Proton VPN</string>
+    <string name="vpn_intro_proton_body">Download a WireGuard configuration from your Proton VPN account and paste it into TrackerControl. Your Proton credentials are never entered here.</string>
     <string name="vpn_intro_wireguard_title">WireGuard</string>
     <string name="vpn_intro_wireguard_body">Use this if you already have a WireGuard config from another VPN provider, your own server, or your workplace.</string>
     <string name="vpn_enter_mullvad_account">Enter account number</string>


### PR DESCRIPTION
## What

The Proton VPN config route existed but was effectively undiscoverable: VPN tab → *Manage WireGuard profiles* → add-profile FAB → third item in a dialog.

This puts it on the VPN tab itself:

- **First-run intro card** gets a *Proton VPN* section (title, body, "Use a Proton VPN config" button) alongside Mullvad / IVPN / WireGuard.
- **Footer** in WireGuard mode is now two links — "Manage WireGuard profiles" and "Use a Proton VPN config" — so it stays reachable once profiles exist.

## How

`ActivityWireGuardProfiles` gains an `EXTRA_SETUP` intent extra (`proton` / `import`) that opens the matching dialog on launch. Both new entry points route through it, so the existing Proton flow is reused rather than duplicated. The auto-open is guarded on `savedInstanceState == null` so it doesn't reappear on rotation.

New strings: `vpn_intro_proton_title`, `vpn_intro_proton_body`. The buttons reuse the existing `setting_wg_proton_setup`.

## Notes for review

- No change to the Proton flow itself — still credential-free, still just guides the user to download a config and paste it.
- `./gradlew :app:compileGithubDebugJavaWithJavac` passes. Not verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)