### PR TITLE
Refresh copyright notices

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityDns.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityDns.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;
@@ -102,6 +102,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 public class ActivityMain extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "TrackerControl.Main";
@@ -186,6 +187,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             Log.i(TAG, "SDK=" + Build.VERSION.SDK_INT);
             super.onCreate(savedInstanceState);
             setContentView(R.layout.android);
+            setCopyright(findViewById(android.R.id.content));
             return;
         }
 
@@ -194,6 +196,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             Log.i(TAG, "Xposed running");
             super.onCreate(savedInstanceState);
             setContentView(R.layout.xposed);
+            setCopyright(findViewById(android.R.id.content));
             return;
         }
 
@@ -1559,10 +1562,19 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         dialogLegend.show();
     }
 
+    private void setCopyright(View view) {
+        TextView tvCopyright = view.findViewById(R.id.tvCopyright);
+        if (tvCopyright != null)
+            tvCopyright.setText(getString(R.string.app_copyright).replaceFirst(
+                    "(?<=2019[–-])20\\d{2}",
+                    new SimpleDateFormat("yyyy", Locale.US).format(new Date())));
+    }
+
     private void menu_about() {
         // Create view
         LayoutInflater inflater = LayoutInflater.from(this);
         View view = inflater.inflate(R.layout.about, null, false);
+        setCopyright(view);
         TextView tvVersionName = view.findViewById(R.id.tvVersionName);
         TextView tvVersionCode = view.findViewById(R.id.tvVersionCode);
         Button btnRate = view.findViewById(R.id.btnRate);

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/AdapterDns.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterDns.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Allowed.java
+++ b/app/src/main/java/eu/faircode/netguard/Allowed.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ApplicationExFilter.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationExFilter.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2022 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ExpandedListView.java
+++ b/app/src/main/java/eu/faircode/netguard/ExpandedListView.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Forward.java
+++ b/app/src/main/java/eu/faircode/netguard/Forward.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/FragmentSettings.java
+++ b/app/src/main/java/eu/faircode/netguard/FragmentSettings.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/GlideHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/GlideHelper.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/IPUtil.java
+++ b/app/src/main/java/eu/faircode/netguard/IPUtil.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Packet.java
+++ b/app/src/main/java/eu/faircode/netguard/Packet.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverAutostart.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
+++ b/app/src/main/java/eu/faircode/netguard/ReceiverPackageRemoved.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ResourceRecord.java
+++ b/app/src/main/java/eu/faircode/netguard/ResourceRecord.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ServiceExternal.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceExternal.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/SwitchPreference.java
+++ b/app/src/main/java/eu/faircode/netguard/SwitchPreference.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Usage.java
+++ b/app/src/main/java/eu/faircode/netguard/Usage.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2020 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
+++ b/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/eu/faircode/netguard/WidgetMain.java
+++ b/app/src/main/java/eu/faircode/netguard/WidgetMain.java
@@ -14,8 +14,8 @@
  * You should have received a copy of the GNU General Public License
  * along with NetGuard.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2015–2020 by Marcel Bokhorst (M66B), Konrad
- * Kollnig (University of Oxford)
+ * Copyright © 2015–2020 Marcel Bokhorst (M66B)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package eu.faircode.netguard;

--- a/app/src/main/java/net/kollnig/missioncontrol/Common.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/Common.kt
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 package net.kollnig.missioncontrol
 

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol;

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsStateAdapter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsStateAdapter.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2022 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol;

--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/AnalysisException.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/AnalysisException.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2022 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/AnalysisProgressCallback.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/AnalysisProgressCallback.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/SignatureTrie.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/SignatureTrie.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisManager.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerLibraryAnalyser.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerLibraryAnalyser.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2021 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.analysis;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlockingMode.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InsightsData.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InsightsData.kt
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InsightsDataProvider.kt
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data

--- a/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/InternetBlocklist.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 package net.kollnig.missioncontrol.data;
 

--- a/app/src/main/java/net/kollnig/missioncontrol/data/PackageUids.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/PackageUids.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 package net.kollnig.missioncontrol.data;
 

--- a/app/src/main/java/net/kollnig/missioncontrol/data/Pair.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/Pair.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2022 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/PlayStore.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/PlayStore.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2022 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/Tracker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/Tracker.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerBlocklist.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 package net.kollnig.missioncontrol.data;
 

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerCategory.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerCategory.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.data;

--- a/app/src/main/java/net/kollnig/missioncontrol/data/UidKeyedStore.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/UidKeyedStore.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 package net.kollnig.missioncontrol.data;
 

--- a/app/src/main/java/net/kollnig/missioncontrol/details/ActionsFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ActionsFragment.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.details;

--- a/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
@@ -12,7 +12,7 @@
  * You should have received a copy of the GNU General Public License
  * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+ * Copyright © 2019–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.details;

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -4,7 +4,7 @@
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
- * Copyright © 2024 Konrad Kollnig (University of Oxford)
+ * Copyright © 2024–2026 Konrad Kollnig
  */
 
 package net.kollnig.missioncontrol.dns;

--- a/app/src/main/res/layout/about.xml
+++ b/app/src/main/res/layout/about.xml
@@ -75,6 +75,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:id="@+id/tvCopyright"
                 android:text="@string/app_copyright"
                 android:textAppearance="@style/TextSmall" />
 

--- a/app/src/main/res/layout/android.xml
+++ b/app/src/main/res/layout/android.xml
@@ -44,6 +44,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:id="@+id/tvCopyright"
                 android:text="@string/app_copyright"
                 android:textAppearance="@style/TextSmall" />
 

--- a/app/src/main/res/layout/forward.xml
+++ b/app/src/main/res/layout/forward.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2020 Konrad Kollnig
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/forwardadd.xml
+++ b/app/src/main/res/layout/forwardadd.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2026 Konrad Kollnig
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/forwardapproval.xml
+++ b/app/src/main/res/layout/forwardapproval.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2026 Konrad Kollnig
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/forwarding.xml
+++ b/app/src/main/res/layout/forwarding.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2020 Konrad Kollnig
   -->
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"

--- a/app/src/main/res/layout/xposed.xml
+++ b/app/src/main/res/layout/xposed.xml
@@ -44,6 +44,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:id="@+id/tvCopyright"
                 android:text="@string/app_copyright"
                 android:textAppearance="@style/TextSmall" />
 

--- a/app/src/main/res/menu/forward.xml
+++ b/app/src/main/res/menu/forward.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2020 Konrad Kollnig
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">

--- a/app/src/main/res/menu/forwarding.xml
+++ b/app/src/main/res/menu/forwarding.xml
@@ -13,7 +13,7 @@
   ~ You should have received a copy of the GNU General Public License
   ~ along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
   ~
-  ~ Copyright © 2019–2020 Konrad Kollnig (University of Oxford)
+  ~ Copyright © 2019–2020 Konrad Kollnig
   -->
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"

--- a/scripts/refresh_copyright_headers.py
+++ b/scripts/refresh_copyright_headers.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""Refresh Konrad Kollnig copyright ranges from each tracked file's Git history.
+
+Only existing notices that name Konrad are changed.  NetGuard's Marcel Bokhorst
+notice, as well as all unrelated third-party notices, are deliberately left alone.
+Header-only revisions are ignored when determining a file's last substantive year.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+KONRAD_HEADER = re.compile(
+    r"(?P<intro>Copyright © )(?P<start>20\d{2})(?:(?P<separator>[–-])20\d{2})? Konrad Kollnig"
+    r"(?: \(University of Oxford\))?"
+)
+KONRAD_RESOURCE = re.compile(
+    r"(?P<prefix>\\u00A9 (?P<start>20\d{2})[–-])20\d{2} Konrad Kollnig"
+)
+SHARED_NETGUARD_HEADER = re.compile(
+    r"(?P<indent>\s*\* )Copyright © 2015[–-]2020 by Marcel Bokhorst \(M66B\), Konrad\n"
+    r"\s*\* Kollnig \(University of Oxford\)"
+)
+
+
+def git(*args: str) -> str:
+    return subprocess.check_output(("git", *args), cwd=ROOT, text=True).strip()
+
+
+def git_show(revision: str, path: str) -> str | None:
+    result = subprocess.run(
+        ("git", "show", f"{revision}:{path}"),
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout if result.returncode == 0 else None
+
+
+def is_notice_only_revision(revision: str, path: str) -> bool:
+    diff = subprocess.check_output(
+        ("git", "diff", "--unified=0", f"{revision}^", revision, "--", path),
+        cwd=ROOT,
+        text=True,
+    )
+    for line in diff.splitlines():
+        if line.startswith(("+++", "---")) or not line.startswith(("+", "-")):
+            continue
+        changed = line[1:].strip()
+        if changed and "Copyright" not in changed and "Kollnig (University of Oxford)" not in changed:
+            return False
+    return True
+
+
+def last_updated_year(path: str) -> str:
+    revisions = git("log", "--format=%H", "--", path).splitlines()
+    for revision in revisions:
+        before = git_show(f"{revision}^", path)
+        after = git_show(revision, path)
+        if before is None or after is None or not is_notice_only_revision(revision, path):
+            return git("show", "-s", "--format=%ad", "--date=format:%Y", revision)
+    raise RuntimeError(f"No revision found for {path}")
+
+
+def refresh(text: str, year: str) -> str:
+    text = SHARED_NETGUARD_HEADER.sub(
+        lambda match: (
+            f"{match.group('indent')}Copyright © 2015–2020 Marcel Bokhorst (M66B)\n"
+            f"{match.group('indent').lstrip(chr(10))}Copyright © 2019–{year} Konrad Kollnig"
+        ),
+        text,
+    )
+    text = KONRAD_HEADER.sub(
+        lambda match: (
+            f"{match.group('intro')}{match.group('start')} Konrad Kollnig"
+            if match.group("start") == year
+            else (
+                f"{match.group('intro')}{match.group('start')}"
+                f"{match.group('separator') or '–'}{year} Konrad Kollnig"
+            )
+        ),
+        text,
+    )
+    return KONRAD_RESOURCE.sub(
+        lambda match: f"{match.group('prefix')}{year} Konrad Kollnig", text
+    )
+
+
+def has_recognized_notice(text: str) -> bool:
+    return any(
+        pattern.search(text)
+        for pattern in (SHARED_NETGUARD_HEADER, KONRAD_HEADER, KONRAD_RESOURCE)
+    )
+
+
+def tracked_konrad_files() -> list[str]:
+    # Several inherited NetGuard headers split "Konrad Kollnig" over two lines.
+    files = git("grep", "-I", "-l", "-e", "Konrad").splitlines()
+    return [
+        path
+        for path in files
+        if path and not path.startswith("app/src/main/res/values")
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--write", action="store_true", help="apply the refresh")
+    parser.add_argument("paths", nargs="*", help="tracked files to refresh")
+    args = parser.parse_args()
+
+    paths = args.paths or tracked_konrad_files()
+    changed: list[str] = []
+    ignored: list[str] = []
+    for path in paths:
+        file = ROOT / path
+        original = file.read_text()
+        if not has_recognized_notice(original):
+            ignored.append(path)
+            continue
+        updated = refresh(original, last_updated_year(path))
+        if updated == original:
+            continue
+        changed.append(path)
+        if args.write:
+            file.write_text(updated)
+
+    for path in changed:
+        print(path)
+    if ignored:
+        print(f"Ignored {len(ignored)} file(s) without a recognized Konrad notice.", file=sys.stderr)
+    if changed and not args.write:
+        print("Run with --write to apply these changes.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- refresh Konrad Kollnig source copyright ranges from each file Git history
- remove the University of Oxford affiliation from owned notices
- preserve Marcel Bokhorst NetGuard attribution separately
- render the in-app copyright end year dynamically without changing localized strings

## Validation
- `uv run --script scripts/refresh_copyright_headers.py`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`