### PR TITLE
Reintroduce the tracker explanation at the top of the Trackers tab

### DIFF
--- a/app/src/main/res/layout/list_item_trackers_header.xml
+++ b/app/src/main/res/layout/list_item_trackers_header.xml
@@ -50,6 +50,30 @@
     </com.google.android.material.card.MaterialCardView>
 
     <!--
+      Plain intro text in the same shape as the Countries tab's lead-in: a
+      24sp heading and a paragraph, no card. Horizontal insets come from the
+      RecyclerView's own 16dp padding, so this adds none of its own.
+    -->
+    <TextView
+        android:id="@+id/tvTrackersIntroTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:accessibilityHeading="true"
+        android:gravity="bottom"
+        android:minHeight="24dp"
+        android:text="@string/block_tracking"
+        android:textColor="?android:textColorPrimary"
+        android:textSize="24sp" />
+
+    <TextView
+        android:id="@+id/tvTrackersIntroText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/block_tracking_description" />
+
+    <!--
       Two summary rows only. Protection and remote-VPN routing share one row
       because both describe how this app's traffic is handled; the tracker
       library report gets its own row because it comes from the app's code


### PR DESCRIPTION
The "Block trackers" card dropped in #835 was the only place that said what a tracker is and why blocking is a judgement call. The Trackers tab now opens with its heading and paragraph, above the two summary rows.

Shape follows the Countries tab's lead-in rather than the old card: a 24sp heading and a paragraph, no card, with the horizontal inset coming from the list's own 16dp padding instead of adding a second one on top of it. It stays put rather than being a dismissible hint, since it is the tab's framing and not a tip.

Layout-only change — both strings are the existing, already-translated `block_tracking` and `block_tracking_description`.

Verified on a Pixel 8 (GitHub debug build): renders at the top of the tab, aligned with the Countries lead-in and with the cards below, and scrolls with the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)