### PR TITLE
Close the details screen when the intent names no app

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -29,6 +29,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -120,14 +121,25 @@ public class DetailsActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        // Receive about details
+        Intent intent = getIntent();
+        appPackageName = intent.getStringExtra(INTENT_EXTRA_APP_PACKAGENAME);
+
+        // The whole screen is about one app, and every tab needs its package
+        // name. This activity is exported, so an intent without one can arrive
+        // from anywhere; without this the Trackers tab crashes on a null
+        // WorkManager tag. There is nothing to show, so close instead.
+        if (TextUtils.isEmpty(appPackageName)) {
+            finish();
+            return;
+        }
+
         // Edge-to-edge is enabled globally by ApplicationEx via EdgeToEdge.enable()
         setContentView(R.layout.activity_details);
 
         running = true;
 
-        // Receive about details
-        Intent intent = getIntent();
-        appPackageName = intent.getStringExtra(INTENT_EXTRA_APP_PACKAGENAME);
         appUid = intent.getIntExtra(INTENT_EXTRA_APP_UID, -1);
         String appName = intent.getStringExtra(INTENT_EXTRA_APP_NAME);
         // Opening Details means the user has found where to adjust protection.


### PR DESCRIPTION
`DetailsActivity` is `android:exported="true"`, so an intent without `INTENT_APP_PACKAGENAME` can arrive from any app on the device. The null package name was carried through until the Trackers tab started its library analysis, where WorkManager rejects the null tag and the app crashes:

```
java.lang.NullPointerException: Parameter specified as non-null is null:
    method androidx.work.WorkRequest$Builder.addTag, parameter tag
    at TrackerAnalysisManager.startAnalysis(TrackerAnalysisManager.java:101)
    at TrackersFragment.setupAnalysisObserver(TrackersFragment.java:111)
```

Every tab on this screen is about one app, so there is nothing to show without that extra — `finish()` before any of it is built.

Verified on a Pixel 8 (GitHub debug build): `am start -n .../DetailsActivity` with no extras now closes silently instead of crashing, and a normal launch with the extras still opens the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)