### PR TITLE
Add stable Compose foundation for app details

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Prefetch Gradle dependencies
         run: |
           ./gradlew :app:dependencies :app:prefetchAndroidLintDependencies \
+            :app:prefetchOfflineBuildClasspaths \
             --no-daemon --no-configuration-cache
           # AGP resolves its platform-specific AAPT2 binary lazily while
           # generating the locale config; cache it before the offline build.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
 def ccacheLauncher = file("$projectDir/gradle/ccache-launcher.sh").absolutePath
 
@@ -29,6 +30,9 @@ tasks.register('prefetchOfflineBuildClasspaths') {
         ['fdroidDebugUnitTestRuntimeClasspath',
          'fdroidReleaseCompileClasspath',
          'fdroidReleaseRuntimeClasspath',
+         // The Compose compiler resolves this only during release packaging;
+         // :app:dependencies and compilation do not cache its artifact.
+         'composeMappingProducerClasspath',
          'coreLibraryDesugaring'].each { name ->
             configurations.named(name).get().resolve()
         }
@@ -164,6 +168,7 @@ android {
     namespace = 'net.kollnig.missioncontrol'
     buildFeatures {
         buildConfig = true
+        compose = true
     }
 
     androidResources {
@@ -181,11 +186,22 @@ androidComponents {
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.19.0'
+    implementation platform('androidx.compose:compose-bom:2026.08.00')
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.16.1'
     testImplementation 'com.squareup.okhttp3:mockwebserver3:5.5.0'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test:runner:1.7.0'
+    // Compose UI test 1.12.0 still requests Espresso 3.5.0 transitively.
+    // Use the stable release that supports current Android input injection.
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    androidTestImplementation platform('androidx.compose:compose-bom:2026.08.00')
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -63,6 +63,11 @@
 -keep class androidx.appcompat.app.AppCompatViewInflater { <init>(...); }
 -keepclassmembers class * implements android.os.Parcelable { static ** CREATOR; }
 
+# Compose transitively references optional OEM-provided Window extension and
+# sidecar APIs; they may be absent from the device and are not packaged here.
+-dontwarn androidx.window.extensions.**
+-dontwarn androidx.window.sidecar.**
+
 #Glide
 -keep public class * implements com.bumptech.glide.module.GlideModule
 -keep public class * extends com.bumptech.glide.module.AppGlideModule

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -1,0 +1,84 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.kollnig.missioncontrol.ui.compose
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+// DECISION: these are content-only primitives; Java/View hosts retain navigation
+// and window-inset ownership while the details screens migrate incrementally.
+
+/** A full-width, neutral section heading for detail-screen content. */
+@Composable
+fun DetailsSectionHeading(
+    text: String,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        tonalElevation = 0.dp
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 48.dp)
+                .semantics { heading() }
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            Text(
+                text = text,
+                style = MaterialTheme.typography.titleMedium
+            )
+        }
+    }
+}
+
+/** A full-width, left-aligned text action with a Material button role. */
+@Composable
+fun DetailsTextAction(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    TextButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 48.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Text(
+            text = text,
+            modifier = Modifier.fillMaxWidth(),
+            textAlign = TextAlign.Start
+        )
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackerControlTheme.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackerControlTheme.kt
@@ -1,0 +1,107 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * TrackerControl is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with TrackerControl. If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.kollnig.missioncontrol.ui.compose
+
+import android.content.Context
+import android.content.res.Configuration
+import androidx.annotation.ColorRes
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Typography
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import net.kollnig.missioncontrol.R
+
+/**
+ * Material theme for Compose content embedded in TrackerControl's existing
+ * view hierarchy.
+ *
+ * Colours are resolved from Android resources so the existing values-night
+ * palette remains the source of truth. Dynamic colour is intentionally not
+ * used: the app's red/teal identity and neutral detail surfaces must match
+ * the surrounding View-based screens.
+ */
+@Composable
+fun TrackerControlTheme(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val isDarkTheme = (context.resources.configuration.uiMode and
+        Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    val colourScheme = remember(context, isDarkTheme) {
+        if (isDarkTheme) {
+            trackerControlDarkColours(context)
+        } else {
+            trackerControlLightColours(context)
+        }
+    }
+
+    MaterialTheme(
+        colorScheme = colourScheme,
+        typography = TrackerControlTypography,
+        content = content
+    )
+}
+
+private val TrackerControlTypography = Typography()
+
+private fun trackerControlLightColours(context: Context) = lightColorScheme(
+    primary = context.colour(R.color.colorRedOn),
+    onPrimary = Color.White,
+    primaryContainer = context.colour(R.color.colorPrimaryLight),
+    onPrimaryContainer = Color.Black,
+    secondary = context.colour(R.color.colorAccent),
+    onSecondary = Color.White,
+    secondaryContainer = context.colour(R.color.colorAccent),
+    onSecondaryContainer = Color.White,
+    background = context.colour(R.color.trackerFeedBackground),
+    onBackground = Color.Black,
+    surface = context.colour(R.color.trackerFeedBackground),
+    onSurface = Color.Black,
+    surfaceVariant = context.colour(R.color.trackerFeedSectionBackground),
+    onSurfaceVariant = Color(0xFF424242),
+    outline = context.colour(R.color.trackerFeedDivider),
+    outlineVariant = context.colour(R.color.trackerFeedDivider),
+    error = context.colour(R.color.colorRedOn),
+    onError = Color.White
+)
+
+private fun trackerControlDarkColours(context: Context) = darkColorScheme(
+    // colorRedOn is deliberately brighter in values-night so small actions and
+    // status labels retain contrast on the black detail-screen background.
+    primary = context.colour(R.color.colorRedOn),
+    onPrimary = Color.Black,
+    primaryContainer = context.colour(R.color.colorPrimaryDark),
+    onPrimaryContainer = Color.White,
+    secondary = context.colour(R.color.colorAccent),
+    onSecondary = Color.Black,
+    secondaryContainer = context.colour(R.color.colorAccent),
+    onSecondaryContainer = Color.Black,
+    background = context.colour(R.color.trackerFeedBackground),
+    onBackground = Color.White,
+    surface = context.colour(R.color.trackerFeedBackground),
+    onSurface = Color.White,
+    surfaceVariant = context.colour(R.color.trackerFeedSectionBackground),
+    onSurfaceVariant = Color(0xFFE0E0E0),
+    outline = context.colour(R.color.trackerFeedDivider),
+    outlineVariant = context.colour(R.color.trackerFeedDivider),
+    error = context.colour(R.color.colorRedOn),
+    onError = Color.Black
+)
+
+private fun Context.colour(@ColorRes resource: Int): Color =
+    Color(ContextCompat.getColor(this, resource))

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -17,7 +17,8 @@
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
             android:background="@color/colorPrimary"
             app:theme="@style/ThemeOverlay.Material3.Dark.ActionBar"
             app:popupTheme="@style/ThemeOverlay.Material3.Light"
@@ -32,7 +33,8 @@
             android:background="@color/colorPrimary"
             app:tabTextColor="@color/colorPrimaryLight"
             app:tabSelectedTextColor="@android:color/white"
-            app:tabIndicatorColor="@android:color/white" />
+            app:tabIndicatorColor="@android:color/white"
+            app:tabMode="auto" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.viewpager2.widget.ViewPager2

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         // https://developer.android.com/studio
         classpath 'com.android.tools.build:gradle:9.3.1'
+        classpath 'org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:2.3.21'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Concern: add the stable Compose foundation shared by the details migrations. Evidence: GitHub, F-Droid and Play compilation; JVM tests; lint; offline F-Droid release assembly. Exclusions: no screen migration, alpha dependency, experimental Expressive API, or dynamic colour.