### PR TITLE
Migrate Countries details to Compose

### DIFF
--- a/app/src/androidTest/java/net/kollnig/missioncontrol/ui/compose/CountriesScreenTest.kt
+++ b/app/src/androidTest/java/net/kollnig/missioncontrol/ui/compose/CountriesScreenTest.kt
@@ -1,0 +1,35 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package net.kollnig.missioncontrol.ui.compose
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import net.kollnig.missioncontrol.R
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CountriesScreenTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun rendersSharedHeadingAndFailureState() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        composeRule.setContent {
+            TrackerControlTheme {
+                CountriesScreenContent(CountriesMapState.Failed)
+            }
+        }
+
+        composeRule.onNodeWithText(context.getString(R.string.countries)).assertExists()
+        composeRule.onNodeWithText(context.getString(R.string.countries_loading_failed)).assertExists()
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
@@ -22,18 +22,17 @@ import static net.kollnig.missioncontrol.data.TrackerList.findTracker;
 import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Picture;
-import android.graphics.drawable.PictureDrawable;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
-import android.widget.ProgressBar;
-import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.collection.ArrayMap;
+import androidx.compose.ui.platform.ComposeView;
 import androidx.fragment.app.Fragment;
 
 import com.caverock.androidsvg.RenderOptions;
@@ -46,10 +45,14 @@ import com.maxmind.geoip2.model.CountryResponse;
 import com.maxmind.geoip2.record.Country;
 
 import net.kollnig.missioncontrol.R;
+import net.kollnig.missioncontrol.ui.compose.CountriesScreen;
+import net.kollnig.missioncontrol.ui.compose.CountriesScreenController;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Map;
 
 import eu.faircode.netguard.DatabaseHelper;
@@ -58,6 +61,9 @@ public class CountriesFragment extends Fragment {
     private static final String ARG_APP_UID = "app-uid";
     private final String TAG = CountriesFragment.class.getSimpleName();
     private int mAppUid;
+    private CountriesScreenController screenController;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private int viewGeneration;
 
     public CountriesFragment() {
         // Required empty public constructor
@@ -88,13 +94,16 @@ public class CountriesFragment extends Fragment {
      * @return A list of seen trackers
      */
     public synchronized Map<String, Integer> getHostCountriesCount(int uid) {
-        Map<String, Integer> countryToCount = new ArrayMap<>();
-
         Context context = getContext();
         if (context == null)
-            return countryToCount;
+            return new ArrayMap<>();
+        return getHostCountriesCount(context, uid);
+    }
 
-        DatabaseHelper dh = DatabaseHelper.getInstance(getContext());
+    private synchronized Map<String, Integer> getHostCountriesCount(Context context, int uid) {
+        Map<String, Integer> countryToCount = new ArrayMap<>();
+
+        DatabaseHelper dh = DatabaseHelper.getInstance(context);
         try (Cursor cursor = dh.getHosts(uid)) {
             InputStream database = context.getAssets().open("GeoLite2-Country.mmdb");
             try (DatabaseReader reader = new DatabaseReader.Builder(database).withCache(new CHMCache()).build()) {
@@ -136,28 +145,22 @@ public class CountriesFragment extends Fragment {
         assert arguments != null;
         mAppUid = arguments.getInt(ARG_APP_UID);
 
-        ProgressBar pbLoading = v.findViewById(R.id.pbLoading);
-
-        ImageView mv = v.findViewById(R.id.svgView);
-        TextView txtFailure = v.findViewById(R.id.txtFailure);
-
-        new Thread(() -> {
-            showCountriesMap(pbLoading, mv, txtFailure);
-        }).start();
+        ComposeView composeCountries = v.findViewById(R.id.composeCountries);
+        screenController = CountriesScreen.install(composeCountries);
+        int generation = ++viewGeneration;
+        Context context = requireContext().getApplicationContext();
+        int uid = mAppUid;
+        new Thread(() -> loadCountriesMap(context, uid, generation)).start();
     }
 
     /**
-     * Show a country map of the tracking destinations
-     *
-     * @param pbLoading  A progress bar to show progress
-     * @param mv         An image view to render the resulting country map
-     * @param txtFailure A text view to show a message in case of failure
+     * Load the country map while Compose owns only the presentation state.
      */
-    private void showCountriesMap(ProgressBar pbLoading, ImageView mv, TextView txtFailure) {
+    private void loadCountriesMap(Context context, int uid, int generation) {
         try {
-            SVG svg = SVG.getFromAsset(requireContext().getAssets(), "world.svg");
+            SVG svg = SVG.getFromAsset(context.getAssets(), "world.svg");
 
-            Map<String, Integer> hostCountriesCount = getHostCountriesCount(mAppUid);
+            Map<String, Integer> hostCountriesCount = getHostCountriesCount(context, uid);
 
             final RenderOptions renderOptions = new RenderOptions();
             String countries = TextUtils.join(",#", hostCountriesCount.keySet());
@@ -168,19 +171,33 @@ public class CountriesFragment extends Fragment {
             // malformed-CSS exception is caught by the outer try below rather
             // than crashing the UI thread.
             final Picture picture = svg.renderToPicture(renderOptions);
-
-            mv.post(() -> {
-                mv.setImageDrawable(new PictureDrawable(picture));
-                pbLoading.setVisibility(View.GONE);
-            });
+            ArrayList<String> countryCodes = new ArrayList<>(hostCountriesCount.keySet());
+            Collections.sort(countryCodes);
+            postMap(picture, TextUtils.join(", ", countryCodes), generation);
         } catch (IllegalStateException | IOException | SVGParseException e) {
             e.printStackTrace();
-
-            mv.post(() -> {
-                mv.setVisibility(View.GONE);
-                txtFailure.setVisibility(View.VISIBLE);
-                pbLoading.setVisibility(View.GONE);
-            });
+            postFailure(generation);
         }
+    }
+
+    private void postMap(Picture picture, String countryCodes, int generation) {
+        mainHandler.post(() -> {
+            if (generation == viewGeneration && screenController != null)
+                screenController.showMap(picture, countryCodes);
+        });
+    }
+
+    private void postFailure(int generation) {
+        mainHandler.post(() -> {
+            if (generation == viewGeneration && screenController != null)
+                screenController.showFailure();
+        });
+    }
+
+    @Override
+    public void onDestroyView() {
+        viewGeneration++;
+        screenController = null;
+        super.onDestroyView();
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/CountriesScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/CountriesScreen.kt
@@ -1,0 +1,145 @@
+/*
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+package net.kollnig.missioncontrol.ui.compose
+
+import android.graphics.Picture
+import android.graphics.drawable.PictureDrawable
+import android.view.View
+import android.widget.ImageView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import net.kollnig.missioncontrol.R
+
+internal sealed interface CountriesMapState {
+    data object Loading : CountriesMapState
+    data class Loaded(val picture: Picture, val countryCodes: String) : CountriesMapState
+    data object Failed : CountriesMapState
+}
+
+class CountriesScreenController internal constructor(
+    private val state: MutableState<CountriesMapState>
+) {
+    fun showMap(picture: Picture, countryCodes: String) {
+        state.value = CountriesMapState.Loaded(picture, countryCodes)
+    }
+
+    fun showFailure() {
+        state.value = CountriesMapState.Failed
+    }
+}
+
+/** Java-facing entry point for the incrementally migrated Countries tab. */
+object CountriesScreen {
+    @JvmStatic
+    fun install(composeView: ComposeView): CountriesScreenController {
+        val state = mutableStateOf<CountriesMapState>(CountriesMapState.Loading)
+        composeView.setViewCompositionStrategy(
+            ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed
+        )
+        composeView.setContent {
+            TrackerControlTheme {
+                CountriesScreenContent(state.value)
+            }
+        }
+        return CountriesScreenController(state)
+    }
+}
+
+@Composable
+internal fun CountriesScreenContent(state: CountriesMapState) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        DetailsSectionHeading(text = stringResource(R.string.countries))
+        Text(
+            text = stringResource(R.string.countries_explanation),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            when (state) {
+                CountriesMapState.Loading -> CircularProgressIndicator()
+                CountriesMapState.Failed -> Text(
+                    text = stringResource(R.string.countries_loading_failed),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontStyle = FontStyle.Italic,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                is CountriesMapState.Loaded -> CountryMap(state)
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CountriesScreenPreview() {
+    TrackerControlTheme {
+        CountriesScreenContent(CountriesMapState.Failed)
+    }
+}
+
+@Composable
+private fun CountryMap(state: CountriesMapState.Loaded) {
+    val description = if (state.countryCodes.isEmpty()) {
+        stringResource(R.string.countries_map_none)
+    } else {
+        stringResource(R.string.countries_map_highlighted, state.countryCodes)
+    }
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics { contentDescription = description }
+    ) {
+        AndroidView(
+            factory = { context ->
+                ImageView(context).apply {
+                    importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+                    scaleType = ImageView.ScaleType.FIT_CENTER
+                }
+            },
+            update = { imageView ->
+                imageView.setImageDrawable(PictureDrawable(state.picture))
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+    }
+}

--- a/app/src/main/res/layout/fragment_countries.xml
+++ b/app/src/main/res/layout/fragment_countries.xml
@@ -1,78 +1,9 @@
-<LinearLayout
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.compose.ui.platform.ComposeView
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/composeCountries"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:mContext=".details.CountriesFragment"
-    android:orientation="vertical">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="16dp">
-
-        <TextView
-            android:id="@+id/textView4"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:gravity="bottom"
-            android:minHeight="24dp"
-            android:text="@string/countries"
-            android:textColor="?android:textColorPrimary"
-            android:textSize="24sp"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/description"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/textView4">
-
-            <TextView
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/countries_explanation"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-    <ProgressBar
-        android:id="@+id/pbLoading"
-        style="?android:attr/progressBarStyle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:indeterminate="true"/>
-
-    <ImageView
-        android:id="@+id/svgView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        tools:ignore="ContentDescription" />
-
-    <TextView
-        android:id="@+id/txtFailure"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingStart="16dp"
-        android:paddingEnd="8dp"
-        android:text="@string/countries_loading_failed"
-        android:textStyle="italic"
-        android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-</LinearLayout>
+    android:background="@color/trackerFeedBackground"
+    tools:mContext=".details.CountriesFragment" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -627,6 +627,8 @@ Sincerely,\n\n]]></string>
     <string name="countries">Destination Countries</string>
     <string name="countries_explanation">Find out where your phone sends tracking data.\n\nInformation is based on DNS lookups and IP information, and might be inaccurate.</string>
     <string name="countries_loading_failed">Oops.. The country map failed to load. Please tell tc@kollnig.net how this happened.</string>
+    <string name="countries_map_highlighted">Tracking destinations highlighted: %1$s</string>
+    <string name="countries_map_none">No tracking destinations are highlighted.</string>
 
     <string name="tracker_advertising">Advertising</string>
     <string name="tracker_analytics">Analytics</string>


### PR DESCRIPTION
Concern: migrate Countries to the shared details design with lifecycle-safe background delivery. Evidence: Compose preview, Pixel Compose UI test, and screenshot comparison. Exclusions: no GeoLite data, SVG rendering, or country calculation changes.