### PR TITLE
Re-register a deleted provider device instead of reusing its dead key

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -367,6 +367,7 @@ public class ServiceSinkhole extends VpnService {
     private static final int NOTIFY_LOCAL_NETWORK = 13;
     private static final int NOTIFY_PRIVATE_DNS = 14;
     private static final int NOTIFY_PRIVATE_DNS_BYPASS = 15;
+    private static final int NOTIFY_WG_IDENTITY = 16;
 
     static final int PRIVATE_DNS_WARNING_NONE = 0;
     static final int PRIVATE_DNS_WARNING_HOSTNAME = 1;
@@ -2201,7 +2202,20 @@ public class ServiceSinkhole extends VpnService {
         net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.setRecoveryCallbacks(
                 () -> ServiceSinkhole.reload("wireguard connectivity repair", ServiceSinkhole.this, false),
                 () -> showWireGuardErrorNotification(getString(R.string.msg_wg_recovery_failed)),
-                () -> net.kollnig.missioncontrol.wg.WgRelayFailover.attemptFailover(ServiceSinkhole.this));
+                () -> net.kollnig.missioncontrol.wg.WgRelayFailover.attemptFailover(ServiceSinkhole.this,
+                        new net.kollnig.missioncontrol.wg.WgRelayFailover.Listener() {
+                            @Override
+                            public void onIdentityRenewed(String providerLabel) {
+                                showWireGuardIdentityNotification(providerLabel);
+                            }
+
+                            @Override
+                            public void onProviderRejected(String providerLabel, String message) {
+                                showWireGuardErrorNotification(getString(
+                                        R.string.msg_wg_provider_rejected, providerLabel,
+                                        message == null ? "" : message));
+                            }
+                        }));
         jni_wireguard_required(prefs.getBoolean("wg_enabled", false)
                 && !TextUtils.isEmpty(prefs.getString("wg_config", "")));
         boolean wgOk = net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.startOrUpdate(
@@ -4465,6 +4479,38 @@ public class ServiceSinkhole extends VpnService {
         notification.bigText(detail);
 
         Util.notify(this, NOTIFY_WG_ERROR, notification.build());
+    }
+
+    /**
+     * The provider had forgotten this device, so the failover path registered a
+     * fresh one and rewrote the saved profiles. Worth saying out loud: the user
+     * otherwise only ever sees "tunnel unavailable" while their profiles change
+     * underneath them (#860).
+     */
+    private void showWireGuardIdentityNotification(String providerLabel) {
+        Intent main = new Intent(this, ActivitySettings.class);
+        PendingIntent pi = PendingIntentCompat.getActivity(this, NOTIFY_WG_IDENTITY, main,
+                PendingIntent.FLAG_UPDATE_CURRENT);
+
+        String detail = getString(R.string.msg_wg_identity_renewed,
+                providerLabel == null ? "" : providerLabel);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, "notify");
+        builder.setSmallIcon(R.drawable.ic_lock_outline_white_24dp)
+                .setContentTitle(getString(R.string.msg_wg_identity_renewed_title))
+                .setContentText(detail)
+                .setContentIntent(pi)
+                .setColor(getResources().getColor(R.color.colorTrackerControl))
+                .setAutoCancel(true);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+
+        NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
+        notification.bigText(detail);
+
+        Util.notify(this, NOTIFY_WG_IDENTITY, notification.build());
     }
 
     private void clearWireGuardErrorNotification() {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2211,9 +2211,16 @@ public class ServiceSinkhole extends VpnService {
 
                             @Override
                             public void onProviderRejected(String providerLabel, String message) {
-                                showWireGuardErrorNotification(getString(
-                                        R.string.msg_wg_provider_rejected, providerLabel,
-                                        message == null ? "" : message));
+                                String detail = getString(R.string.msg_wg_provider_rejected,
+                                        providerLabel, message == null ? "" : message);
+                                // Record it before notifying: the recovery check
+                                // fires 30s after the restart that triggered this
+                                // failover and reposts on the same notification id,
+                                // so without this it would replace the provider's
+                                // explanation with "tunnel unresponsive".
+                                net.kollnig.missioncontrol.wg.WgEgress.INSTANCE
+                                        .reportProviderFailure(detail);
+                                showWireGuardErrorNotification(detail);
                             }
                         }));
         jni_wireguard_required(prefs.getBoolean("wg_enabled", false)

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2211,16 +2211,18 @@ public class ServiceSinkhole extends VpnService {
 
                             @Override
                             public void onProviderRejected(String providerLabel, String message) {
-                                String detail = getString(R.string.msg_wg_provider_rejected,
-                                        providerLabel, message == null ? "" : message);
-                                // Record it before notifying: the recovery check
-                                // fires 30s after the restart that triggered this
-                                // failover and reposts on the same notification id,
-                                // so without this it would replace the provider's
-                                // explanation with "tunnel unresponsive".
+                                // Handing this to WgEgress rather than
+                                // notifying from here is deliberate: this runs
+                                // mid-failover, off-thread, and the tunnel it
+                                // describes may already have been replaced.
+                                // WgEgress publishes it against the tunnel it
+                                // belongs to, which notifies through the state
+                                // listener and outlives the generic recovery
+                                // check that would otherwise overwrite it.
                                 net.kollnig.missioncontrol.wg.WgEgress.INSTANCE
-                                        .reportProviderFailure(detail);
-                                showWireGuardErrorNotification(detail);
+                                        .reportProviderFailure(getString(
+                                                R.string.msg_wg_provider_rejected, providerLabel,
+                                                message == null ? "" : message));
                             }
                         }));
         jni_wireguard_required(prefs.getBoolean("wg_enabled", false)

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -246,6 +246,13 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
                     progress.dismiss();
                     try {
                         manager.saveMullvadAccount(generated.accountNumber);
+                        manager.saveMullvadDeviceId(generated.deviceId);
+                        if (generated.identityReplaced)
+                            // Stale profiles for this account still reference the
+                            // deleted device, so move them onto the new identity.
+                            manager.rewriteProviderInterface("mullvad",
+                                    generated.accountNumber, generated.privateKey,
+                                    generated.address);
                         manager.saveProfile(null, generated.name, generated.config,
                                 "mullvad", generated.accountNumber,
                                 generated.countryCode, generated.countryName);

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -247,12 +247,6 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
                     try {
                         manager.saveMullvadAccount(generated.accountNumber);
                         manager.saveMullvadDeviceId(generated.deviceId);
-                        if (generated.identityReplaced)
-                            // Stale profiles for this account still reference the
-                            // deleted device, so move them onto the new identity.
-                            manager.rewriteProviderInterface("mullvad",
-                                    generated.accountNumber, generated.privateKey,
-                                    generated.address);
                         manager.saveProfile(null, generated.name, generated.config,
                                 "mullvad", generated.accountNumber,
                                 generated.countryCode, generated.countryName);

--- a/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
@@ -490,6 +490,12 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
                     manager.findMullvadProfileForCountry(generated.countryCode);
             manager.saveMullvadAccount(generated.accountNumber);
             manager.saveMullvadDeviceId(generated.deviceId);
+            if (generated.identityReplaced)
+                // The account's other profiles still carry the identity Mullvad
+                // dropped; leaving them alone would keep them unable to hand
+                // shake, so move them onto the freshly registered device.
+                manager.rewriteProviderInterface("mullvad", generated.accountNumber,
+                        generated.privateKey, generated.address);
             manager.saveProfile(existing == null ? null : existing.id,
                     generated.name,
                     generated.config,
@@ -520,6 +526,12 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
                     manager.findIvpnProfileForCountry(generated.countryCode);
             manager.saveIvpnAccount(generated.accountNumber);
             manager.saveIvpnSession(generated.accountNumber, generated.session);
+            if (generated.identityReplaced)
+                // The account's other profiles still carry the key IVPN
+                // dropped; leaving them alone would keep them unable to hand
+                // shake, so move them onto the new session.
+                manager.rewriteProviderInterface("ivpn", generated.accountNumber,
+                        generated.session.privateKey, generated.address);
             manager.saveProfile(existing == null ? null : existing.id,
                     generated.name,
                     generated.config,

--- a/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
@@ -490,12 +490,6 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
                     manager.findMullvadProfileForCountry(generated.countryCode);
             manager.saveMullvadAccount(generated.accountNumber);
             manager.saveMullvadDeviceId(generated.deviceId);
-            if (generated.identityReplaced)
-                // The account's other profiles still carry the identity Mullvad
-                // dropped; leaving them alone would keep them unable to hand
-                // shake, so move them onto the freshly registered device.
-                manager.rewriteProviderInterface("mullvad", generated.accountNumber,
-                        generated.privateKey, generated.address);
             manager.saveProfile(existing == null ? null : existing.id,
                     generated.name,
                     generated.config,
@@ -526,12 +520,6 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
                     manager.findIvpnProfileForCountry(generated.countryCode);
             manager.saveIvpnAccount(generated.accountNumber);
             manager.saveIvpnSession(generated.accountNumber, generated.session);
-            if (generated.identityReplaced)
-                // The account's other profiles still carry the key IVPN
-                // dropped; leaving them alone would keep them unable to hand
-                // shake, so move them onto the new session.
-                manager.rewriteProviderInterface("ivpn", generated.accountNumber,
-                        generated.session.privateKey, generated.address);
             manager.saveProfile(existing == null ? null : existing.id,
                     generated.name,
                     generated.config,

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
@@ -51,10 +51,18 @@ public class IvpnProfileGenerator {
         public final String countryName;
         public final String relayHostname;
         public final WgProfileManager.IvpnSession session;
+        public final String address;
+        /**
+         * True when the saved session could not be reused and a fresh IVPN
+         * session was created. Callers must then rewrite the account's other
+         * profiles, which still carry the key IVPN no longer knows.
+         */
+        public final boolean identityReplaced;
 
         public GeneratedProfile(String name, String config, String accountNumber,
                                 String countryCode, String countryName, String relayHostname,
-                                WgProfileManager.IvpnSession session) {
+                                WgProfileManager.IvpnSession session, String address,
+                                boolean identityReplaced) {
             this.name = name;
             this.config = config;
             this.accountNumber = accountNumber;
@@ -62,6 +70,8 @@ public class IvpnProfileGenerator {
             this.countryName = countryName == null ? "" : countryName;
             this.relayHostname = relayHostname == null ? "" : relayHostname;
             this.session = session;
+            this.address = address == null ? "" : address;
+            this.identityReplaced = identityReplaced;
         }
     }
 
@@ -135,6 +145,15 @@ public class IvpnProfileGenerator {
 
         Relay relay = chooseRelay(fetchRelays(), requestedCountryCode, excludeHostname);
         WgProfileManager.IvpnSession session = reusableSession;
+        boolean identityReplaced = false;
+        // A saved session is only reusable while IVPN still knows it. Once it
+        // is gone — deleted in the account's device list, or logged out
+        // elsewhere — its key never completes a handshake, so start a new
+        // session rather than inheriting the dead identity.
+        if (session != null && session.isUsable() && !sessionIsRegistered(session.token)) {
+            session = null;
+            identityReplaced = true;
+        }
         if (session == null || !session.isUsable()) {
             String privateKey = newPrivateKey();
             String publicKey = derivePublicKey(privateKey);
@@ -143,7 +162,8 @@ public class IvpnProfileGenerator {
 
         String config = buildConfig(session.privateKey, session.address, relay);
         return new GeneratedProfile("IVPN - " + relay.countryName, config, account,
-                relay.countryCode, relay.countryName, relay.hostname, session);
+                relay.countryCode, relay.countryName, relay.hostname, session,
+                addressWithCidr(session.address), identityReplaced);
     }
 
     public WgProfileManager.IvpnSession rotateSessionKey(WgProfileManager.IvpnSession session,
@@ -179,6 +199,38 @@ public class IvpnProfileGenerator {
 
     String derivePublicKey(String privateKey) {
         return Wgbridge.publicKey(privateKey);
+    }
+
+    /**
+     * Asks IVPN whether the saved session token is still valid. Throws rather
+     * than guessing when the answer is inconclusive: creating a session
+     * consumes one of the account's device slots.
+     */
+    boolean sessionIsRegistered(String sessionToken) throws Exception {
+        if (TextUtils.isEmpty(sessionToken))
+            return false;
+
+        JSONObject body = new JSONObject();
+        body.put("session_token", sessionToken);
+        Request request = new Request.Builder()
+                .url(API + "/v4/session/status")
+                .post(RequestBody.create(body.toString(), JSON))
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            String text = responseText(response);
+            JSONObject json = TextUtils.isEmpty(text) ? new JSONObject() : new JSONObject(text);
+            int status = json.optInt("status", 0);
+            if (status == 200)
+                return true;
+            // 601 is IVPN's "session not found"; a 401 says the same thing at
+            // the HTTP layer. Anything else is not evidence that the session
+            // is gone.
+            if (status == 601 || response.code() == 401)
+                return false;
+            throw new IOException(errorMessage(json,
+                    "IVPN session status request failed: " + response.code()));
+        }
     }
 
     WgProfileManager.IvpnSession createSession(String account, String privateKey,

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
@@ -228,8 +228,10 @@ public class IvpnProfileGenerator {
             // is gone.
             if (status == 601 || response.code() == 401)
                 return false;
-            throw new IOException(errorMessage(json,
-                    "IVPN session status request failed: " + response.code()));
+            if (status != 0)
+                throw new ApiRejectedException(errorMessage(json,
+                        "IVPN session status request failed: " + response.code()));
+            throw new IOException("IVPN session status request failed: " + response.code());
         }
     }
 
@@ -254,15 +256,18 @@ public class IvpnProfileGenerator {
         if (status == 70001 || !TextUtils.isEmpty(captcha) || !TextUtils.isEmpty(nextCaptchaId))
             throw new CaptchaRequiredException(nextCaptchaId, captcha,
                     response.optString("message", ""));
+        // IVPN answers HTTP 200 with a status field for its own refusals — a
+        // session limit, an inactive account. Those are rejections the caller
+        // can act on and show the user, not transport failures.
         if (status != 200)
-            throw new IOException(errorMessage(response, "IVPN session request failed"));
+            throw new ApiRejectedException(errorMessage(response, "IVPN session request failed"));
 
         JSONObject wireGuard = response.optJSONObject("wireguard");
         if (wireGuard == null)
             throw new IOException("IVPN did not return WireGuard session data");
         int wgStatus = wireGuard.optInt("status", 0);
         if (wgStatus != 200)
-            throw new IOException(errorMessage(wireGuard, "IVPN WireGuard setup failed"));
+            throw new ApiRejectedException(errorMessage(wireGuard, "IVPN WireGuard setup failed"));
 
         String token = response.optString("token", "");
         String address = wireGuard.optString("ip_address", "");

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/IvpnProfileGenerator.java
@@ -126,18 +126,35 @@ public class IvpnProfileGenerator {
                                      WgProfileManager.IvpnSession reusableSession,
                                      String captchaId, String captchaValue)
             throws Exception {
-        return generate(accountNumber, requestedCountryCode, reusableSession, captchaId, captchaValue, null);
+        return generate(accountNumber, requestedCountryCode, reusableSession, captchaId,
+                captchaValue, null, false);
     }
 
-    /**
-     * @param excludeHostname a relay hostname to avoid re-picking when another
-     *                        candidate is available in the chosen pool, e.g. a
-     *                        relay a caller just failed over away from.
-     */
     public GeneratedProfile generate(String accountNumber, String requestedCountryCode,
                                      WgProfileManager.IvpnSession reusableSession,
                                      String captchaId, String captchaValue,
                                      String excludeHostname)
+            throws Exception {
+        return generate(accountNumber, requestedCountryCode, reusableSession, captchaId,
+                captchaValue, excludeHostname, false);
+    }
+
+    /**
+     * @param excludeHostname         a relay hostname to avoid re-picking when another
+     *                                candidate is available in the chosen pool, e.g. a
+     *                                relay a caller just failed over away from.
+     * @param verifyReusableSession   ask IVPN whether the saved session still exists
+     *                                before reusing it, and start a new one when it does
+     *                                not. Only for callers that already know the tunnel
+     *                                does not work: the handshake is the authoritative
+     *                                test, and it needs nothing but the relay endpoint,
+     *                                while this asks an API host that a working tunnel
+     *                                never has to reach.
+     */
+    public GeneratedProfile generate(String accountNumber, String requestedCountryCode,
+                                     WgProfileManager.IvpnSession reusableSession,
+                                     String captchaId, String captchaValue,
+                                     String excludeHostname, boolean verifyReusableSession)
             throws Exception {
         String account = accountNumber == null ? "" : accountNumber.trim();
         if (account.isEmpty())
@@ -146,11 +163,13 @@ public class IvpnProfileGenerator {
         Relay relay = chooseRelay(fetchRelays(), requestedCountryCode, excludeHostname);
         WgProfileManager.IvpnSession session = reusableSession;
         boolean identityReplaced = false;
-        // A saved session is only reusable while IVPN still knows it. Once it
-        // is gone — deleted in the account's device list, or logged out
-        // elsewhere — its key never completes a handshake, so start a new
-        // session rather than inheriting the dead identity.
-        if (session != null && session.isUsable() && !sessionIsRegistered(session.token)) {
+        // The caller has already established that this session does not work.
+        // A saved session is only usable while IVPN still knows it — once it is
+        // gone, deleted in the account's device list or logged out elsewhere,
+        // its key never completes a handshake — so ask, and start a new session
+        // rather than inheriting the dead identity.
+        if (verifyReusableSession && session != null && session.isUsable() &&
+                !sessionIsRegistered(session.token)) {
             session = null;
             identityReplaced = true;
         }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/MullvadProfileGenerator.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/MullvadProfileGenerator.java
@@ -123,16 +123,28 @@ public class MullvadProfileGenerator {
     }
 
     public GeneratedProfile generate(String accountNumber, String requestedCountryCode, String reusableConfig) throws Exception {
-        return generate(accountNumber, requestedCountryCode, reusableConfig, null);
+        return generate(accountNumber, requestedCountryCode, reusableConfig, null, false);
+    }
+
+    public GeneratedProfile generate(String accountNumber, String requestedCountryCode, String reusableConfig,
+                                     String excludeHostname) throws Exception {
+        return generate(accountNumber, requestedCountryCode, reusableConfig, excludeHostname, false);
     }
 
     /**
-     * @param excludeHostname a relay hostname to avoid re-picking when another
-     *                        candidate is available in the chosen pool, e.g. a
-     *                        relay a caller just failed over away from.
+     * @param excludeHostname          a relay hostname to avoid re-picking when another
+     *                                 candidate is available in the chosen pool, e.g. a
+     *                                 relay a caller just failed over away from.
+     * @param verifyReusableIdentity   ask Mullvad whether the saved identity is still
+     *                                 registered before reusing it, and register a fresh
+     *                                 device when it is not. Only for callers that already
+     *                                 know the tunnel does not work: the handshake is the
+     *                                 authoritative test, and it needs nothing but the
+     *                                 relay endpoint, while this asks an API host that a
+     *                                 working tunnel never has to reach.
      */
     public GeneratedProfile generate(String accountNumber, String requestedCountryCode, String reusableConfig,
-                                     String excludeHostname) throws Exception {
+                                     String excludeHostname, boolean verifyReusableIdentity) throws Exception {
         String account = accountNumber == null ? "" : accountNumber.trim();
         if (account.isEmpty())
             throw new IllegalArgumentException("Mullvad account number is required");
@@ -147,11 +159,15 @@ public class MullvadProfileGenerator {
             String publicKey = derivePublicKey(privateKey);
             String token = fetchWebToken(account);
             device = createDevice(token, publicKey);
+        } else if (!verifyReusableIdentity) {
+            privateKey = reusable.getPrivateKey();
+            device = deviceFromConfig(reusable);
         } else {
-            // A saved identity is only reusable while Mullvad still knows it.
-            // Once the device is deleted from the account, reusing its key
-            // yields a tunnel that never completes a handshake, so register a
-            // fresh device instead of inheriting the dead identity.
+            // The caller has already established that this identity does not
+            // work. A saved identity is only usable while Mullvad still knows
+            // it — once the device is deleted from the account, its key never
+            // completes a handshake — so ask, and register a fresh device
+            // rather than inheriting the dead identity.
             String token = fetchWebToken(account);
             JSONObject registered = findDevice(token, publicKeyOf(reusable.getPrivateKey()));
             if (registered == null) {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/MullvadProfileGenerator.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/MullvadProfileGenerator.java
@@ -56,10 +56,19 @@ public class MullvadProfileGenerator {
         public final String countryName;
         public final String relayHostname;
         public final String deviceId;
+        public final String privateKey;
+        public final String address;
+        /**
+         * True when the saved identity could not be reused and a fresh Mullvad
+         * device was registered. Callers must then rewrite the account's other
+         * profiles, which still carry the identity Mullvad no longer knows.
+         */
+        public final boolean identityReplaced;
 
         public GeneratedProfile(String name, String config, String accountNumber,
                                 String countryCode, String countryName, String relayHostname,
-                                String deviceId) {
+                                String deviceId, String privateKey, String address,
+                                boolean identityReplaced) {
             this.name = name;
             this.config = config;
             this.accountNumber = accountNumber;
@@ -67,6 +76,9 @@ public class MullvadProfileGenerator {
             this.countryName = countryName == null ? "" : countryName;
             this.relayHostname = relayHostname == null ? "" : relayHostname;
             this.deviceId = deviceId == null ? "" : deviceId;
+            this.privateKey = privateKey == null ? "" : privateKey;
+            this.address = address == null ? "" : address;
+            this.identityReplaced = identityReplaced;
         }
     }
 
@@ -129,18 +141,32 @@ public class MullvadProfileGenerator {
         Relay relay = chooseRelay(fetchRelays(), requestedCountryCode, excludeHostname);
         String privateKey;
         JSONObject device;
+        boolean identityReplaced = false;
         if (reusable == null) {
             privateKey = newPrivateKey();
             String publicKey = derivePublicKey(privateKey);
             String token = fetchWebToken(account);
             device = createDevice(token, publicKey);
         } else {
-            privateKey = reusable.getPrivateKey();
-            device = deviceFromConfig(reusable);
+            // A saved identity is only reusable while Mullvad still knows it.
+            // Once the device is deleted from the account, reusing its key
+            // yields a tunnel that never completes a handshake, so register a
+            // fresh device instead of inheriting the dead identity.
+            String token = fetchWebToken(account);
+            JSONObject registered = findDevice(token, publicKeyOf(reusable.getPrivateKey()));
+            if (registered == null) {
+                privateKey = newPrivateKey();
+                device = createDevice(token, derivePublicKey(privateKey));
+                identityReplaced = true;
+            } else {
+                privateKey = reusable.getPrivateKey();
+                device = deviceForReuse(registered, reusable);
+            }
         }
         String config = buildConfig(privateKey, device, relay);
         return new GeneratedProfile("Mullvad - " + relay.countryName, config, account,
-                relay.countryCode, relay.countryName, relay.hostname, device.optString("id", ""));
+                relay.countryCode, relay.countryName, relay.hostname, device.optString("id", ""),
+                privateKey, addressOf(device), identityReplaced);
     }
 
     public String findDeviceIdForPubkey(String accountNumber, String publicKey) throws Exception {
@@ -193,6 +219,42 @@ public class MullvadProfileGenerator {
         }
     }
 
+    private String publicKeyOf(String privateKey) {
+        if (TextUtils.isEmpty(privateKey))
+            return "";
+        try {
+            String publicKey = derivePublicKey(privateKey);
+            return publicKey == null ? "" : publicKey;
+        } catch (Throwable ignored) {
+            return "";
+        }
+    }
+
+    private JSONObject findDevice(String token, String publicKey) throws Exception {
+        if (TextUtils.isEmpty(publicKey))
+            return null;
+        for (JSONObject device : listDevices(token))
+            if (publicKey.equals(device.optString("pubkey")))
+                return device;
+        return null;
+    }
+
+    /**
+     * The account's device record is authoritative for the tunnel addresses;
+     * the saved config only fills in what the record does not carry.
+     */
+    private JSONObject deviceForReuse(JSONObject registered, WgConfig config) throws Exception {
+        if (TextUtils.isEmpty(registered.optString("ipv4_address")) &&
+                TextUtils.isEmpty(registered.optString("ipv6_address"))) {
+            JSONObject device = deviceFromConfig(config);
+            device.put("id", registered.optString("id", ""));
+            if (!TextUtils.isEmpty(registered.optString("name")))
+                device.put("name", registered.optString("name"));
+            return device;
+        }
+        return registered;
+    }
+
     private JSONObject deviceFromConfig(WgConfig config) throws Exception {
         JSONObject device = new JSONObject();
         for (String address : config.getAddress()) {
@@ -236,7 +298,8 @@ public class MullvadProfileGenerator {
         return postJson(API + "/accounts/v1/devices", token, body);
     }
 
-    private List<JSONObject> listDevices(String token) throws Exception {
+    // Package-private so tests can supply device data without making HTTP calls.
+    List<JSONObject> listDevices(String token) throws Exception {
         Request.Builder builder = new Request.Builder()
                 .url(API + "/accounts/v1/devices");
         if (!TextUtils.isEmpty(token))
@@ -350,9 +413,14 @@ public class MullvadProfileGenerator {
         return result;
     }
 
-    private String buildConfig(String privateKey, JSONObject device, Relay relay) {
+    private static String addressOf(JSONObject device) {
         String ipv4 = device.optString("ipv4_address");
         String ipv6 = device.optString("ipv6_address");
+        return TextUtils.isEmpty(ipv4) ? ipv6 :
+                TextUtils.isEmpty(ipv6) ? ipv4 : ipv4 + ", " + ipv6;
+    }
+
+    private String buildConfig(String privateKey, JSONObject device, Relay relay) {
         String deviceName = device.optString("name");
 
         StringBuilder sb = new StringBuilder();
@@ -360,9 +428,7 @@ public class MullvadProfileGenerator {
         if (!TextUtils.isEmpty(deviceName))
             sb.append("# Mullvad device = ").append(deviceName).append('\n');
         sb.append("PrivateKey = ").append(privateKey).append('\n');
-        String address = TextUtils.isEmpty(ipv4) ? ipv6 :
-                TextUtils.isEmpty(ipv6) ? ipv4 : ipv4 + ", " + ipv6;
-        sb.append("Address = ").append(address).append('\n');
+        sb.append("Address = ").append(addressOf(device)).append('\n');
         sb.append("DNS = ").append(DEFAULT_DNS).append("\n\n");
         sb.append("[Peer]\n");
         sb.append("# Mullvad relay = ").append(relay.hostname).append('\n');

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -133,6 +133,12 @@ object WgEgress {
     private val tunnelGeneration = java.util.concurrent.atomic.AtomicLong(0)
     private val tunnelLifecycleLock = Any()
     @Volatile private var lastError: String? = null
+    // A provider's own explanation for why the tunnel cannot come up — an
+    // exhausted device limit, a lapsed account. It outlives the failover
+    // attempt that learned it, because the generic recovery check runs
+    // afterwards and would otherwise overwrite it with "unresponsive". Cleared
+    // once a handshake proves the tunnel works, or when it is torn down.
+    @Volatile private var providerFailureReason: String? = null
     @Volatile private var verificationGeneration: Long = 0
     @Volatile private var currentConfig: String? = null
     private var currentTunFd: Int = -1
@@ -566,10 +572,11 @@ object WgEgress {
             val latest = latestHandshakeMillisOrNull() ?: 0L
             if (latest > 0 && now() - latest < HANDSHAKE_DEAD_AFTER_MS) {
                 lastError = null
+                providerFailureReason = null
                 notifyStateChanged()
                 return@postDelayed
             }
-            lastError = "WireGuard tunnel unresponsive"
+            lastError = providerFailureReason ?: "WireGuard tunnel unresponsive"
             notifyStateChanged()
             notifyBrokenCb?.run()
         }, RECOVERY_NOTIFY_AFTER_MS)
@@ -661,6 +668,15 @@ object WgEgress {
     fun isRunning(): Boolean = tunnel != null
 
     fun getLastError(): String? = lastError
+
+    /**
+     * Records why the provider refused to bring this tunnel up, so the blocked
+     * state names the actual problem instead of the generic "unresponsive"
+     * message the recovery check would otherwise post over it.
+     */
+    fun reportProviderFailure(reason: String?) {
+        providerFailureReason = reason?.takeIf { it.isNotBlank() }
+    }
 
     fun latestHandshakeMillisOrNull(): Long? =
         try { tunnel?.latestHandshakeMillis() } catch (_: Throwable) { null }
@@ -804,6 +820,7 @@ object WgEgress {
         // without ever producing a tunnel still reports — so leaving it set
         // here kept a stopped tunnel reporting its final error forever.
         lastError = null
+        providerFailureReason = null
         if (t != null) {
             try {
                 t.stop()
@@ -853,6 +870,7 @@ object WgEgress {
     private fun clearRecoveryState() {
         verificationGeneration++
         recoveryNotificationGeneration++
+        providerFailureReason = null
         forceRestartPending = false
         pendingRestartTunnel = null
         pendingRestartTunnelGeneration = -1
@@ -880,6 +898,7 @@ object WgEgress {
             if (gen != verificationGeneration) return@postDelayed
             if (fresh) {
                 lastError = null
+                providerFailureReason = null
                 recoveryNotificationGeneration++
                 notifyStateChanged()
             }

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -139,6 +139,9 @@ object WgEgress {
     // afterwards and would otherwise overwrite it with "unresponsive". Cleared
     // once a handshake proves the tunnel works, or when it is torn down.
     @Volatile private var providerFailureReason: String? = null
+    // What the in-flight failover has learned so far, not yet applied. See
+    // [reportProviderFailure].
+    @Volatile private var pendingProviderFailure: String? = null
     @Volatile private var verificationGeneration: Long = 0
     @Volatile private var currentConfig: String? = null
     private var currentTunFd: Int = -1
@@ -526,9 +529,11 @@ object WgEgress {
             return
         }
         val resolved = java.util.concurrent.atomic.AtomicBoolean(false)
+        pendingProviderFailure = null
         val timeoutRunnable = Runnable {
             if (resolved.compareAndSet(false, true)) {
                 failoverInFlight.set(false)
+                pendingProviderFailure = null
                 if (isCurrent(expected)) {
                     Log.w(TAG, "relay failover timed out after ${FAILOVER_TIMEOUT_MS}ms; falling back to backoff")
                     scheduleRestart(attempt)
@@ -547,8 +552,18 @@ object WgEgress {
                     failoverInFlight.set(false)
                 }
                 verifyHandler.removeCallbacks(timeoutRunnable)
+                val refusal = pendingProviderFailure
+                pendingProviderFailure = null
                 if (!resolved.compareAndSet(false, true)) return@execute
                 if (!isCurrent(expected)) return@execute
+                if (refusal != null) {
+                    // The provider explained why this tunnel cannot come up.
+                    // Publishing it here, on the tunnel it belongs to, both
+                    // notifies now and outlives the generic recovery check.
+                    providerFailureReason = refusal
+                    lastError = refusal
+                    notifyStateChanged()
+                }
                 if (switched) {
                     Log.w(TAG, "relay failover: switched the active profile to a different server")
                     restartAttempts = 0
@@ -560,6 +575,7 @@ object WgEgress {
         } catch (e: java.util.concurrent.RejectedExecutionException) {
             verifyHandler.removeCallbacks(timeoutRunnable)
             failoverInFlight.set(false)
+            pendingProviderFailure = null
             if (resolved.compareAndSet(false, true)) scheduleRestart(attempt)
         }
     }
@@ -675,7 +691,13 @@ object WgEgress {
      * message the recovery check would otherwise post over it.
      */
     fun reportProviderFailure(reason: String?) {
-        providerFailureReason = reason?.takeIf { it.isNotBlank() }
+        // Staged rather than applied: the failover that learned this runs
+        // off-thread and can finish after its tunnel was replaced — the user
+        // switched profiles, or turned WireGuard off. [tryRelayFailover]
+        // commits it only while that tunnel is still current, so a refusal
+        // from an abandoned attempt cannot surface against the profile the
+        // user moved to.
+        pendingProviderFailure = reason?.takeIf { it.isNotBlank() }
     }
 
     fun latestHandshakeMillisOrNull(): Long? =
@@ -821,6 +843,7 @@ object WgEgress {
         // here kept a stopped tunnel reporting its final error forever.
         lastError = null
         providerFailureReason = null
+        pendingProviderFailure = null
         if (t != null) {
             try {
                 t.stop()
@@ -871,6 +894,7 @@ object WgEgress {
         verificationGeneration++
         recoveryNotificationGeneration++
         providerFailureReason = null
+        pendingProviderFailure = null
         forceRestartPending = false
         pendingRestartTunnel = null
         pendingRestartTunnelGeneration = -1

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgRelayFailover.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgRelayFailover.java
@@ -31,6 +31,22 @@ public class WgRelayFailover {
     private static final Pattern IVPN_RELAY_PATTERN =
             Pattern.compile("(?m)^#\\s*IVPN relay\\s*=\\s*(\\S+)");
 
+    /**
+     * Receives what a failover attempt learned about the provider account, so
+     * the service can tell the user instead of leaving them with the generic
+     * "tunnel unresponsive" notification.
+     */
+    public interface Listener {
+        /**
+         * The saved device/session was gone from the provider account and a
+         * fresh one was registered; the account's profiles now use it.
+         */
+        void onIdentityRenewed(String providerLabel);
+
+        /** The provider refused the request, e.g. an exhausted device limit. */
+        void onProviderRejected(String providerLabel, String message);
+    }
+
     private WgRelayFailover() {
     }
 
@@ -40,6 +56,10 @@ public class WgRelayFailover {
      * rewritten to a different server.
      */
     public static boolean attemptFailover(Context context) {
+        return attemptFailover(context, null);
+    }
+
+    public static boolean attemptFailover(Context context, Listener listener) {
         WgProfileManager manager = new WgProfileManager(context);
         WgProfileManager.Profile active = manager.getActiveProfile();
         if (active == null || TextUtils.isEmpty(active.provider) || TextUtils.isEmpty(active.config)) {
@@ -55,6 +75,17 @@ public class WgRelayFailover {
                 String excludeHostname = currentRelayHostname(active.config, MULLVAD_RELAY_PATTERN);
                 MullvadProfileGenerator.GeneratedProfile generated = new MullvadProfileGenerator()
                         .generate(active.account, active.countryCode, active.config, excludeHostname);
+                // generate() registers a fresh device when the saved one is
+                // gone from the account; persist that identity regardless of
+                // whether the relay switch below goes through, or the device
+                // this config now authenticates as is lost, and the account's
+                // other profiles keep a key Mullvad no longer knows.
+                if (generated.identityReplaced) {
+                    manager.saveMullvadDeviceId(generated.deviceId);
+                    manager.rewriteProviderInterface("mullvad", active.account,
+                            generated.privateKey, generated.address);
+                    notifyIdentityRenewed(listener, "Mullvad");
+                }
                 newConfig = generated.config;
                 newCountryCode = generated.countryCode;
             } else if ("ivpn".equals(active.provider)) {
@@ -68,6 +99,11 @@ public class WgRelayFailover {
                 // this config now authenticates as is lost and never saved.
                 if (generated.session != null)
                     manager.saveIvpnSession(active.account, generated.session);
+                if (generated.identityReplaced && generated.session != null) {
+                    manager.rewriteProviderInterface("ivpn", active.account,
+                            generated.session.privateKey, generated.address);
+                    notifyIdentityRenewed(listener, "IVPN");
+                }
                 newConfig = generated.config;
                 newCountryCode = generated.countryCode;
             } else {
@@ -99,6 +135,11 @@ public class WgRelayFailover {
         } catch (MullvadProfileGenerator.ApiRejectedException | IvpnProfileGenerator.ApiRejectedException ex) {
             Log.w(TAG, "Relay failover for " + active.provider + " was rejected by the provider API: "
                     + ex.getMessage());
+            // Worth telling the user about: an exhausted device limit or a
+            // lapsed account keeps the tunnel down until they act, and the
+            // generic "tunnel unresponsive" notification says none of that.
+            if (listener != null)
+                listener.onProviderRejected(providerLabel(active.provider), ex.getMessage());
             return false;
         } catch (IvpnProfileGenerator.CaptchaRequiredException ex) {
             Log.w(TAG, "Relay failover for " + active.provider
@@ -108,6 +149,17 @@ public class WgRelayFailover {
             Log.w(TAG, "Relay failover for " + active.provider + " failed: " + ex.getMessage());
             return false;
         }
+    }
+
+    private static void notifyIdentityRenewed(Listener listener, String providerLabel) {
+        Log.w(TAG, providerLabel + " no longer knew this device; registered a fresh one "
+                + "and moved the account's profiles onto it");
+        if (listener != null)
+            listener.onIdentityRenewed(providerLabel);
+    }
+
+    private static String providerLabel(String provider) {
+        return "ivpn".equals(provider) ? "IVPN" : "Mullvad";
     }
 
     private static String currentRelayHostname(String config, Pattern pattern) {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgRelayFailover.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgRelayFailover.java
@@ -74,7 +74,11 @@ public class WgRelayFailover {
             if ("mullvad".equals(active.provider)) {
                 String excludeHostname = currentRelayHostname(active.config, MULLVAD_RELAY_PATTERN);
                 MullvadProfileGenerator.GeneratedProfile generated = new MullvadProfileGenerator()
-                        .generate(active.account, active.countryCode, active.config, excludeHostname);
+                        // verify=true: the tunnel is already known broken, so
+                        // this is the fallback where asking Mullvad about the
+                        // identity is worth a round trip.
+                        .generate(active.account, active.countryCode, active.config,
+                                excludeHostname, true);
                 // generate() registers a fresh device when the saved one is
                 // gone from the account; persist that identity regardless of
                 // whether the relay switch below goes through, or the device
@@ -92,7 +96,8 @@ public class WgRelayFailover {
                 String excludeHostname = currentRelayHostname(active.config, IVPN_RELAY_PATTERN);
                 WgProfileManager.IvpnSession session = manager.getIvpnSession(active.account);
                 IvpnProfileGenerator.GeneratedProfile generated = new IvpnProfileGenerator()
-                        .generate(active.account, active.countryCode, session, "", "", excludeHostname);
+                        .generate(active.account, active.countryCode, session, "", "",
+                                excludeHostname, true);
                 // generate() may have had to mint a fresh session (no reusable
                 // one, or the reusable one was stale); persist it regardless of
                 // whether the switch below goes through, or the device/session

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -324,6 +324,9 @@
     <string name="msg_wg_blocked_title">WireGuard tunnel unavailable</string>
     <string name="msg_wg_blocked">Internet access is blocked until WireGuard starts or the WireGuard setting is disabled.</string>
     <string name="msg_wg_blocked_detail">Internet access is blocked until WireGuard starts or the WireGuard setting is disabled. %s</string>
+    <string name="msg_wg_identity_renewed_title">VPN device re-registered</string>
+    <string name="msg_wg_identity_renewed">%1$s no longer knew this device, so TrackerControl registered a new one and updated the %1$s profiles on this device.</string>
+    <string name="msg_wg_provider_rejected">%1$s refused to set up this device: %2$s</string>
     <string name="msg_wg_recovery_failed">WireGuard stopped responding. TrackerControl is trying to reconnect, and internet access may remain blocked until WireGuard recovers.</string>
     <string name="summary_watchdog">Periodically check if TrackerControl is still running (enter zero to disable this option). This might result in extra battery usage.</string>
     <string name="summary_log_logcat">Research mode: identified trackers are logged to ADB and SNI extraction is enabled for better hostname detection. Retrieve logs with adb logcat using tag \'TC-Log\'.</string>

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/ProfileGeneratorTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/ProfileGeneratorTest.java
@@ -64,7 +64,7 @@ public class ProfileGeneratorTest {
         TestMullvadGenerator generator = new TestMullvadGenerator(null);
         generator.registerDevice(PUBLIC_KEY, "", IPV6);
 
-        String config = generator.generate(ACCOUNT, "de", reusableConfig(IPV6)).config;
+        String config = generator.generate(ACCOUNT, "de", reusableConfig(IPV6), null, true).config;
 
         assertTrue(config.contains("Address = " + IPV6));
         assertFalse(config.contains("Address = ,"));
@@ -76,7 +76,7 @@ public class ProfileGeneratorTest {
         generator.registerDevice(PUBLIC_KEY, IPV4, IPV6);
 
         String config = generator.generate(ACCOUNT, "de",
-                reusableConfig(IPV4 + ", " + IPV6)).config;
+                reusableConfig(IPV4 + ", " + IPV6), null, true).config;
 
         assertTrue(config.contains("Address = " + IPV4 + ", " + IPV6));
     }
@@ -87,7 +87,7 @@ public class ProfileGeneratorTest {
         generator.registerDevice(PUBLIC_KEY, IPV4, IPV6);
 
         MullvadProfileGenerator.GeneratedProfile generated =
-                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6));
+                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6), null, true);
 
         assertFalse(generated.identityReplaced);
         assertEquals(0, generator.createDeviceCalls);
@@ -105,7 +105,7 @@ public class ProfileGeneratorTest {
         generator.registerDevice(key(7), IPV4, IPV6);
 
         MullvadProfileGenerator.GeneratedProfile generated =
-                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6));
+                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6), null, true);
 
         assertTrue(generated.identityReplaced);
         assertEquals(1, generator.createDeviceCalls);
@@ -116,13 +116,45 @@ public class ProfileGeneratorTest {
     }
 
     @Test
+    public void mullvadReuseDoesNotAskProviderByDefault() throws Exception {
+        // The handshake is the authoritative test of a saved identity, and it
+        // only needs the relay endpoint. Reusing must not depend on reaching
+        // the API host, or a profile that would have worked fails to generate.
+        TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.deviceListFailure = new IOException("API unreachable");
+
+        MullvadProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6));
+
+        assertFalse(generated.identityReplaced);
+        assertEquals(0, generator.fetchWebTokenCalls);
+        assertEquals(0, generator.createDeviceCalls);
+        assertTrue(generated.config.contains("PrivateKey = " + PRIVATE_KEY));
+    }
+
+    @Test
+    public void ivpnReuseDoesNotAskProviderByDefault() throws Exception {
+        TestIvpnGenerator generator = new TestIvpnGenerator(null);
+        generator.sessionStatusFailure = new IOException("API unreachable");
+        WgProfileManager.IvpnSession session = new WgProfileManager.IvpnSession(
+                "token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
+
+        IvpnProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", session);
+
+        assertFalse(generated.identityReplaced);
+        assertEquals(0, generator.createSessionCalls);
+        assertTrue(generated.config.contains("Address = 10.64.0.9/32"));
+    }
+
+    @Test
     public void mullvadDeviceListFailureDoesNotCreateDevice() throws Exception {
         IOException failure = new IOException("device list failed");
         TestMullvadGenerator generator = new TestMullvadGenerator(null);
         generator.deviceListFailure = failure;
 
         try {
-            generator.generate(ACCOUNT, "de", reusableConfig(IPV4));
+            generator.generate(ACCOUNT, "de", reusableConfig(IPV4), null, true);
             fail("Expected device list failure");
         } catch (IOException ex) {
             assertSame(failure, ex);
@@ -139,7 +171,7 @@ public class ProfileGeneratorTest {
                 "stale-token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
 
         IvpnProfileGenerator.GeneratedProfile generated =
-                generator.generate(ACCOUNT, "de", stale);
+                generator.generate(ACCOUNT, "de", stale, "", "", null, true);
 
         assertTrue(generated.identityReplaced);
         assertEquals(1, generator.createSessionCalls);
@@ -154,7 +186,7 @@ public class ProfileGeneratorTest {
                 "token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
 
         IvpnProfileGenerator.GeneratedProfile generated =
-                generator.generate(ACCOUNT, "de", session);
+                generator.generate(ACCOUNT, "de", session, "", "", null, true);
 
         assertFalse(generated.identityReplaced);
         assertEquals(0, generator.createSessionCalls);
@@ -170,7 +202,7 @@ public class ProfileGeneratorTest {
                 "token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
 
         try {
-            generator.generate(ACCOUNT, "de", session);
+            generator.generate(ACCOUNT, "de", session, "", "", null, true);
             fail("Expected session status failure");
         } catch (IOException ex) {
             assertSame(failure, ex);

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/ProfileGeneratorTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/ProfileGeneratorTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class ProfileGeneratorTest {
     private static final String ACCOUNT = "test-account";
     private static final String PRIVATE_KEY = key(0);
+    private static final String OTHER_PRIVATE_KEY = key(2);
     private static final String PUBLIC_KEY = key(1);
     private static final String PEER_KEY = key(9);
     private static final String IPV6 = "fc00:bbbb:bbbb:bb01::2/128";
@@ -61,6 +62,7 @@ public class ProfileGeneratorTest {
     @Test
     public void mullvadIpv6OnlyReusableConfigHasNoLeadingAddressComma() throws Exception {
         TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.registerDevice(PUBLIC_KEY, "", IPV6);
 
         String config = generator.generate(ACCOUNT, "de", reusableConfig(IPV6)).config;
 
@@ -71,11 +73,110 @@ public class ProfileGeneratorTest {
     @Test
     public void mullvadReusableConfigKeepsBothAddresses() throws Exception {
         TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.registerDevice(PUBLIC_KEY, IPV4, IPV6);
 
         String config = generator.generate(ACCOUNT, "de",
                 reusableConfig(IPV4 + ", " + IPV6)).config;
 
         assertTrue(config.contains("Address = " + IPV4 + ", " + IPV6));
+    }
+
+    @Test
+    public void mullvadRegisteredReusableConfigKeepsIdentity() throws Exception {
+        TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.registerDevice(PUBLIC_KEY, IPV4, IPV6);
+
+        MullvadProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6));
+
+        assertFalse(generated.identityReplaced);
+        assertEquals(0, generator.createDeviceCalls);
+        assertEquals(PRIVATE_KEY, generated.privateKey);
+        assertEquals("device", generated.deviceId);
+        assertTrue(generated.config.contains("PrivateKey = " + PRIVATE_KEY));
+    }
+
+    @Test
+    public void mullvadDeletedDeviceRegistersFreshIdentity() throws Exception {
+        TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.newPrivateKey = OTHER_PRIVATE_KEY;
+        // The account lists a device, but not the one the saved profile uses:
+        // this is the state left behind by deleting the device at Mullvad.
+        generator.registerDevice(key(7), IPV4, IPV6);
+
+        MullvadProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", reusableConfig(IPV4 + ", " + IPV6));
+
+        assertTrue(generated.identityReplaced);
+        assertEquals(1, generator.createDeviceCalls);
+        assertEquals(OTHER_PRIVATE_KEY, generated.privateKey);
+        assertEquals("device", generated.deviceId);
+        assertEquals(IPV4 + ", " + IPV6, generated.address);
+        assertTrue(generated.config.contains("PrivateKey = " + OTHER_PRIVATE_KEY));
+    }
+
+    @Test
+    public void mullvadDeviceListFailureDoesNotCreateDevice() throws Exception {
+        IOException failure = new IOException("device list failed");
+        TestMullvadGenerator generator = new TestMullvadGenerator(null);
+        generator.deviceListFailure = failure;
+
+        try {
+            generator.generate(ACCOUNT, "de", reusableConfig(IPV4));
+            fail("Expected device list failure");
+        } catch (IOException ex) {
+            assertSame(failure, ex);
+        }
+
+        assertEquals(0, generator.createDeviceCalls);
+    }
+
+    @Test
+    public void ivpnDeletedSessionCreatesFreshSession() throws Exception {
+        TestIvpnGenerator generator = new TestIvpnGenerator(null);
+        generator.sessionRegistered = false;
+        WgProfileManager.IvpnSession stale = new WgProfileManager.IvpnSession(
+                "stale-token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
+
+        IvpnProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", stale);
+
+        assertTrue(generated.identityReplaced);
+        assertEquals(1, generator.createSessionCalls);
+        assertEquals("10.64.0.2/32", generated.address);
+        assertTrue(generated.config.contains("Address = 10.64.0.2/32"));
+    }
+
+    @Test
+    public void ivpnRegisteredSessionIsReused() throws Exception {
+        TestIvpnGenerator generator = new TestIvpnGenerator(null);
+        WgProfileManager.IvpnSession session = new WgProfileManager.IvpnSession(
+                "token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
+
+        IvpnProfileGenerator.GeneratedProfile generated =
+                generator.generate(ACCOUNT, "de", session);
+
+        assertFalse(generated.identityReplaced);
+        assertEquals(0, generator.createSessionCalls);
+        assertTrue(generated.config.contains("Address = 10.64.0.9/32"));
+    }
+
+    @Test
+    public void ivpnSessionStatusFailureDoesNotCreateSession() throws Exception {
+        IOException failure = new IOException("session status failed");
+        TestIvpnGenerator generator = new TestIvpnGenerator(null);
+        generator.sessionStatusFailure = failure;
+        WgProfileManager.IvpnSession session = new WgProfileManager.IvpnSession(
+                "token", PRIVATE_KEY, PUBLIC_KEY, "10.64.0.9");
+
+        try {
+            generator.generate(ACCOUNT, "de", session);
+            fail("Expected session status failure");
+        } catch (IOException ex) {
+            assertSame(failure, ex);
+        }
+
+        assertEquals(0, generator.createSessionCalls);
     }
 
     @Test
@@ -129,11 +230,30 @@ public class ProfileGeneratorTest {
 
     private static class TestMullvadGenerator extends MullvadProfileGenerator {
         private final IOException relayFailure;
+        private final List<JSONObject> devices = new java.util.ArrayList<>();
+        IOException deviceListFailure;
+        String newPrivateKey = PRIVATE_KEY;
         int fetchWebTokenCalls;
         int createDeviceCalls;
 
         TestMullvadGenerator(IOException relayFailure) {
             this.relayFailure = relayFailure;
+        }
+
+        void registerDevice(String publicKey, String ipv4, String ipv6) throws Exception {
+            devices.add(new JSONObject()
+                    .put("id", "device")
+                    .put("name", "registered")
+                    .put("pubkey", publicKey)
+                    .put("ipv4_address", ipv4)
+                    .put("ipv6_address", ipv6));
+        }
+
+        @Override
+        List<JSONObject> listDevices(String token) throws Exception {
+            if (deviceListFailure != null)
+                throw deviceListFailure;
+            return devices;
         }
 
         @Override
@@ -161,21 +281,30 @@ public class ProfileGeneratorTest {
 
         @Override
         String newPrivateKey() {
-            return PRIVATE_KEY;
+            return newPrivateKey;
         }
 
         @Override
         String derivePublicKey(String privateKey) {
-            return PUBLIC_KEY;
+            return PRIVATE_KEY.equals(privateKey) ? PUBLIC_KEY : key(3);
         }
     }
 
     private static class TestIvpnGenerator extends IvpnProfileGenerator {
         private final IOException relayFailure;
+        IOException sessionStatusFailure;
+        boolean sessionRegistered = true;
         int createSessionCalls;
 
         TestIvpnGenerator(IOException relayFailure) {
             this.relayFailure = relayFailure;
+        }
+
+        @Override
+        boolean sessionIsRegistered(String sessionToken) throws Exception {
+            if (sessionStatusFailure != null)
+                throw sessionStatusFailure;
+            return sessionRegistered;
         }
 
         @Override


### PR DESCRIPTION
Fixes #860.

## The bug

`getReusableMullvadConfig(account)` hands `MullvadProfileGenerator.generate(…)` a saved config, and the generator reused its private key and tunnel addresses with nothing able to notice that Mullvad had forgotten the device. Delete the device from the account, enter the same account number again, and every profile — the old ones and each newly generated country — carries the same dead identity: all stuck in “Handshaking”, then blocked, with DNS failing closed. The debug key-rotation path could not repair it, because it only rotates a device that still matches the saved public key.

IVPN has the same shape: a saved `IvpnSession` is reused whenever `isUsable()` is true, which only checks that the fields are non-empty — a session revoked at IVPN looks identical.

## The fix

The handshake is the authoritative test of a saved identity, and it needs nothing but the relay endpoint. Asking the provider's API is a fallback for when that test has already failed — not a precondition for reuse, which would put an API host on the path of an operation that does not need one and refuse to generate profiles that would have worked.

So reuse stays optimistic, and `generate(…)` takes a `verify` flag that only `WgRelayFailover` sets — the path that runs after `WgEgress` has given up on the tunnel. With it set:

- **Mullvad** looks the saved public key up in `GET /accounts/v1/devices`. Found → reuse, taking the addresses and device id from the account's own record. Not found → register a fresh device and flag `identityReplaced`.
- **IVPN** asks `POST /v4/session/status` about the token. Status 200 → reuse. Status 601 (or HTTP 401) → the session is gone; start a new one and flag `identityReplaced`.

Neither guesses when the answer is inconclusive: an unexpected status throws rather than silently burning one of the account's device slots.

When the identity was replaced, `WgRelayFailover` calls `rewriteProviderInterface(provider, account, privateKey, address)`, moving the account's *other* profiles onto the new identity instead of leaving them behind unusable — so the confirmed workaround in the issue (delete the stale profiles by hand first) is no longer needed.

Trade-off worth naming: the failover path fires on the third restart attempt (`RELAY_FAILOVER_AFTER_ATTEMPTS`), so the reported scenario self-heals after roughly a minute of blocked traffic rather than never occurring.

## Notification

The issue notes there was no good notification — just that WireGuard couldn't connect. `WgRelayFailover` runs on exactly that path, so it now reports what it found through a small `Listener` that `ServiceSinkhole` implements:

- identity renewed → its own dismissible notification, because the user's saved profiles just changed underneath them;
- provider rejected the request (exhausted device limit, lapsed account) → the WireGuard error notification carries the provider's own message instead of the generic “WireGuard tunnel unresponsive”.

Two things were needed to make that second one actually reach the user:

- IVPN answers HTTP 200 with a `status` field for its own refusals, so `createSession()` threw a plain `IOException` for exactly those cases and they fell past the `ApiRejectedException` catch into the generic branch. They are rejections now.
- `requestFullRestart()` schedules the recovery check *before* handing off to failover, so 30s later it set `lastError` to the generic message and reposted on the same notification id, overwriting the explanation. `WgEgress` now keeps a `providerFailureReason` that the recovery check prefers, cleared once a handshake proves the tunnel works or the tunnel is torn down.

## Verification

- `./gradlew :app:compileGithubDebugJavaWithJavac` — passes
- `./gradlew :app:testGithubDebugUnitTest` — passes (full suite)
- `./gradlew :app:lintGithubDebug` — passes

New tests in `ProfileGeneratorTest` cover both providers: reuse succeeds with the provider API stubbed to fail (proving the default path never depends on reaching it), a registered identity verifies and is reused with no device/session created, a deleted one produces a fresh identity with `identityReplaced` set, and a failed lookup throws without creating anything. No device work — the container has no device or emulator.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqaT1jw8rGAcoj7sWU8AET)_