### PR TITLE
Unify Material colours and headings

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/Common.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/Common.kt
@@ -24,7 +24,7 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.net.Uri
 import android.view.View
-import androidx.core.content.ContextCompat
+import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import eu.faircode.netguard.Util
 import java.io.BufferedReader
@@ -217,7 +217,9 @@ object Common {
             msg,
             Snackbar.LENGTH_LONG
         )
-        s.setActionTextColor(ContextCompat.getColor(activity, R.color.colorPrimary))
+        s.setActionTextColor(
+            MaterialColors.getColor(s.view, com.google.android.material.R.attr.colorPrimaryInverse)
+        )
         return s
     }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TimelineScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TimelineScreen.kt
@@ -273,7 +273,7 @@ internal fun TimelineScreenContent(
         model.rows.forEachIndexed { index, row ->
             item(key = row.key) {
                 when (row) {
-                    is TimelineRow.Section -> TimelineSectionHeading(row.title)
+                    is TimelineRow.Section -> DetailsSectionHeading(text = row.title)
                     is TimelineRow.App -> {
                         val next = model.rows.getOrNull(index + 1)
                         val showDivider = next is TimelineRow.App &&
@@ -604,19 +604,6 @@ private fun TimelineHintContent(callbacks: TimelineScreenCallbacks) {
 }
 
 @Composable
-private fun TimelineSectionHeading(title: String) {
-    Text(
-        text = title,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp)
-            .semantics { heading() },
-        style = MaterialTheme.typography.labelLarge,
-        color = MaterialTheme.colorScheme.primary
-    )
-}
-
-@Composable
 private fun TimelineAppRow(
     row: TimelineRow.App,
     showDivider: Boolean,
@@ -782,9 +769,17 @@ private fun timelineRows(entries: List<TimelineEntry>, context: Context): List<T
             blockedCount > 0 && allowedCount > 0 ->
                 context.getString(R.string.timeline_summary_mixed, blockedCount, allowedCount)
             blockedCount > 0 ->
-                context.getString(R.string.timeline_summary_all_blocked, blockedCount)
+                context.resources.getQuantityString(
+                    R.plurals.timeline_trackers_blocked,
+                    blockedCount,
+                    blockedCount
+                )
             else ->
-                context.getString(R.string.timeline_summary_none_blocked, allowedCount)
+                context.resources.getQuantityString(
+                    R.plurals.timeline_trackers_allowed,
+                    allowedCount,
+                    allowedCount
+                )
         }
         val contacts = entry.trackers.take(3).map { tracker ->
             val statusLabel = context.getString(

--- a/app/src/main/res/color/bottom_nav_item_color.xml
+++ b/app/src/main/res/color/bottom_nav_item_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorRedOn" android:state_checked="true" />
+    <item android:color="?attr/colorOnSurfaceVariant" />
+</selector>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -233,5 +233,10 @@
         android:id="@+id/bottomNav"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:background="@color/bottom_nav_background"
+        app:backgroundTint="@color/bottom_nav_background"
+        app:itemActiveIndicatorStyle="@style/TrackerControlBottomNavActiveIndicator"
+        app:itemIconTint="@color/bottom_nav_item_color"
+        app:itemTextColor="@color/bottom_nav_item_color"
         app:menu="@menu/bottom_nav" />
 </LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -48,6 +48,12 @@
     <string name="timeline_tracker_allowed">Permitido</string>
     <string name="timeline_summary_all_blocked">%d rastreadores bloqueados</string>
     <string name="timeline_summary_none_blocked">%d rastreadores permitidos</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d rastreadores bloqueados</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">%d rastreadores permitidos</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d bloqueado · %2$d permitido</string>
     <string name="troubleshooting_title">Solución de problemas</string>
     <string name="troubleshooting_battery_title">Optimización de batería</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -34,6 +34,12 @@
     <string name="timeline_tracker_allowed">Lubatud</string>
     <string name="timeline_summary_all_blocked">%d jälitajat on blokeeritud</string>
     <string name="timeline_summary_none_blocked">%d jälitajat on lubatud</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d jälitajat on blokeeritud</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">%d jälitajat on lubatud</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d blokeeritud · %2$d lubatud</string>
     <string name="troubleshooting_title">Veaotsing</string>
     <string name="troubleshooting_battery_title">Akukasutuse optimeerimine</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -49,6 +49,12 @@
     <string name="timeline_tracker_allowed">Autorisé</string>
     <string name="timeline_summary_all_blocked">%d traqueurs bloqués</string>
     <string name="timeline_summary_none_blocked">%d traqueurs autorisés</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d traqueurs bloqués</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">%d traqueurs autorisés</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d bloqués · %2$d autorisés</string>
     <string name="troubleshooting_title">Diagnostic des anomalies</string>
     <string name="troubleshooting_battery_title">Optimisation de batterie</string>

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -23,4 +23,11 @@
     <color name="trackerFeedBackground">#000000</color>
     <color name="trackerFeedSectionBackground">#242424</color>
     <color name="trackerFeedDivider">#424242</color>
+
+    <color name="bottom_nav_background">#000000</color>
+    <color name="bottom_nav_active_indicator">#5B1B1B</color>
+
+    <style name="TrackerControlBottomNavActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+        <item name="android:color">@color/bottom_nav_active_indicator</item>
+    </style>
 </resources>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -50,6 +50,12 @@
     <string name="timeline_tracker_allowed">Toegestaan</string>
     <string name="timeline_summary_all_blocked">%d trackers geblokkeerd</string>
     <string name="timeline_summary_none_blocked">%d trackers toegestaan</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d trackers geblokkeerd</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">%d trackers toegestaan</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d geblokkeerd · %2$d toegestaan</string>
     <string name="troubleshooting_title">Problemen oplossen</string>
     <string name="troubleshooting_battery_title">Batterijoptimalisatie</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -42,6 +42,12 @@
     <string name="timeline_tracker_allowed">Permitidos</string>
     <string name="timeline_summary_all_blocked">%d rastreadores bloqueados</string>
     <string name="timeline_summary_none_blocked">%d rastreadores permitidos</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d rastreadores bloqueados</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">%d rastreadores permitidos</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d bloqueado · %2$d permitido</string>
     <string name="troubleshooting_title">Soluções</string>
     <string name="troubleshooting_battery_title">Otimização de bateria</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -42,6 +42,12 @@
     <string name="timeline_tracker_allowed">Разрешено</string>
     <string name="timeline_summary_all_blocked">%d трекеров заблокировано</string>
     <string name="timeline_summary_none_blocked"> %d трекеров разрешено</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">%d трекеров заблокировано</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other"> %d трекеров разрешено</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d заблокировано ·  %2$d разрешено</string>
     <string name="troubleshooting_title">Устранение неполадок</string>
     <string name="troubleshooting_battery_title">Оптимизация батареи</string>

--- a/app/src/main/res/values-sl-rSI/strings.xml
+++ b/app/src/main/res/values-sl-rSI/strings.xml
@@ -50,6 +50,12 @@
     <string name="timeline_tracker_allowed">Dovoljeno</string>
     <string name="timeline_summary_all_blocked">Blokiranih sledilcev: %d</string>
     <string name="timeline_summary_none_blocked">Dovoljenih sledilcev: %d</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">Blokiranih sledilcev: %d</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">Dovoljenih sledilcev: %d</item>
+    </plurals>
     <string name="timeline_summary_mixed">Blokirano: %1$d · Dovoljeno: %2$d</string>
     <string name="troubleshooting_title">Odpravljaje težav</string>
     <string name="troubleshooting_battery_title">Optimizacija baterije</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -50,6 +50,12 @@
     <string name="timeline_tracker_allowed">Дозволено</string>
     <string name="timeline_summary_all_blocked">Заблоковано %d трекерів</string>
     <string name="timeline_summary_none_blocked">Дозволено %d трекерів</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">Заблоковано %d трекерів</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">Дозволено %d трекерів</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d заблоковано · %2$d дозволено</string>
     <string name="troubleshooting_title">Усунення несправностей</string>
     <string name="troubleshooting_battery_title">Оптимізація роботи батареї</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -50,6 +50,12 @@
     <string name="timeline_tracker_allowed">已放行</string>
     <string name="timeline_summary_all_blocked">拦截了 %d 个跟踪器</string>
     <string name="timeline_summary_none_blocked">放行了 %d 个跟踪器</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="other">拦截了 %d 个跟踪器</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="other">放行了 %d 个跟踪器</item>
+    </plurals>
     <string name="timeline_summary_mixed">%1$d 已拦截 · %2$d 已放行</string>
     <string name="troubleshooting_title">故障排除</string>
     <string name="troubleshooting_battery_title">电池优化</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -35,4 +35,11 @@
     <color name="trackerFeedBackground">#FFFFFF</color>
     <color name="trackerFeedSectionBackground">#F5F5F5</color>
     <color name="trackerFeedDivider">#E0E0E0</color>
+
+    <color name="bottom_nav_background">#FFFFFF</color>
+    <color name="bottom_nav_active_indicator">#FFCDD2</color>
+
+    <style name="TrackerControlBottomNavActiveIndicator" parent="Widget.Material3.BottomNavigationView.ActiveIndicator">
+        <item name="android:color">@color/bottom_nav_active_indicator</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,14 @@
     <string name="timeline_summary_all_blocked">%d trackers blocked</string>
     <string name="timeline_summary_none_blocked">%d trackers allowed</string>
     <string name="timeline_summary_mixed">%1$d blocked · %2$d allowed</string>
+    <plurals name="timeline_trackers_blocked">
+        <item quantity="one">%d tracker blocked</item>
+        <item quantity="other">%d trackers blocked</item>
+    </plurals>
+    <plurals name="timeline_trackers_allowed">
+        <item quantity="one">%d tracker allowed</item>
+        <item quantity="other">%d trackers allowed</item>
+    </plurals>
 
     <string name="troubleshooting_title">Troubleshooting</string>
 
@@ -564,11 +572,11 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <!-- Actions -->
     <string name="block_tracking">Block trackers</string>
     <string name="block_tracking_description">Many apps send data to third-parties, so-called trackers. TrackerControl allows to block these network transmissions selectively. Yet, use this wisely, since app developers rely on these services, notably advertising.</string>
-    <string name="personalised_ads">Limit Personalisation</string>
+    <string name="personalised_ads">Limit personalisation</string>
     <string name="personalised_ads_description">Android offers to limit apps\' access to the Google Advertising ID of your device. However, apps can potentially ignore this setting, and still use this ID. They can also continue to collect this ID for analytics purposes, according to Google\'s policies. You need trust in Google and the data-collecting company.</string>
-    <string name="data_managment">Manage Data</string>
+    <string name="data_managment">Manage data</string>
     <string name="data_management_description">The EU General Data Protection Regulation (GDPR) allows users from the EU to manage any data related to them. This app provides email templates to reach out to the developer. The developer has to answer within one month.</string>
-    <string name="contacts">Contact </string>
+    <string name="contacts">Contact</string>
     <string name="contacts_description">If you think an application violates data protection principles, you may want to contact the responsible entities directly.</string>
     <string name="play_services_required">This is a setting of the Google Play Services, which were not found on your device.</string>
     <string name="no_mail_service">Please install an email client.</string>
@@ -578,7 +586,7 @@ Your internet traffic is not being sent to a remote VPN server.</string>
     <string name="request_deletion">Request deletion</string>
     <string name="contact_developer">Developer</string>
     <string name="contact_playstore">Google</string>
-    <string name="contact_officials">EU Officials</string>
+    <string name="contact_officials">EU officials</string>
     <string name="google_dpo_mail">data-protection-office@google.com</string>
     <string name="dpas_overview_url">https://edpb.europa.eu/about-edpb/board/members</string>
     <string name="subject_request_data">GDPR Subject Access Request</string>
@@ -629,7 +637,7 @@ Sincerely,\n\n]]></string>
 
     <string name="launch_app">Launch &amp; Find trackers</string>
     <string name="launch_app_failed">This app can\'t be launched</string>
-    <string name="countries">Destination Countries</string>
+    <string name="countries">Destination countries</string>
     <string name="countries_explanation">Find out where your phone sends tracking data.\n\nInformation is based on DNS lookups and IP information, and might be inaccurate.</string>
     <string name="countries_loading_failed">Oops.. The country map failed to load. Please tell tc@kollnig.net how this happened.</string>
     <string name="countries_map_highlighted">Tracking destinations highlighted: %1$s</string>
@@ -690,7 +698,7 @@ Sincerely,\n\n]]></string>
     <string name="app_route_unavailable_partial_routes">Your remote VPN does not carry all traffic (its AllowedIPs is not a full tunnel). Per-app routing needs a full tunnel, because routes are shared by every app.</string>
 
     <!-- Per-app protection state -->
-    <string name="app_state_heading">Protection</string>
+    <string name="app_state_heading">Blocking mode</string>
     <string name="app_state_title_minimal">Minimal blocking</string>
     <string name="app_state_title_standard">Standard blocking</string>
     <string name="app_state_title_strict">Strict blocking</string>
@@ -874,17 +882,21 @@ Sincerely,\n\n]]></string>
     <!-- Insights Screen -->
     <string name="menu_insights">Insights</string>
     <string name="insights_title">Your Privacy Insights</string>
-    <string name="insights_subtitle_7days">Last 7 Days</string>
-    <string name="insights_tracking_attempts">Tracker Hosts Contacted</string>
+    <string name="insights_subtitle_7days">Last 7 days</string>
+    <string name="insights_tracking_attempts">Tracker hosts contacted</string>
     <string name="insights_blocked">Blocked</string>
     <string name="insights_allowed">Allowed Through</string>
-    <string name="insights_tracker_companies">Tracking Companies</string>
-    <string name="insights_apps_with_trackers">Apps with Trackers</string>
+    <string name="insights_tracker_companies">Tracking companies</string>
+    <string name="insights_apps_with_trackers">Apps with trackers</string>
     <string name="insights_top_tracking_apps">Worst Offending Apps</string>
     <string name="insights_top_companies">Most Active Tracking Companies</string>
-    <string name="insights_pervasive_trackers">Most Pervasive Trackers</string>
-    <string name="insights_top_domains">Top Tracker Domains</string>
+    <string name="insights_pervasive_trackers">Most pervasive trackers</string>
+    <string name="insights_top_domains">Top tracker domains</string>
     <string name="insights_in_apps">in %d apps</string>
+    <plurals name="insights_apps_count">
+        <item quantity="one">in %d app</item>
+        <item quantity="other">in %d apps</item>
+    </plurals>
     <string name="insights_no_data">No tracking data yet. Use your apps and check back!</string>
     <string name="insights_shocking_fact">Your apps contacted %1$d tracking companies via %2$d tracker hosts this week!</string>
     <string name="insights_shocking_fact_playstore">Your apps contacted %1$d tracking companies this week!</string>


### PR DESCRIPTION
## Summary\n- theme the main bottom navigation with the app's red and neutral Material palette\n- align Timeline and shared detail headings, including sentence casing\n- fix singular tracker summaries and snackbar action contrast\n\n## Verification\n- \n- \n- \n- \n\n## Scope\nNo dependency changes. Device testing is intentionally deferred.