### PR TITLE
Polish Data Rights and Countries details

### DIFF
--- a/app/src/androidTest/java/net/kollnig/missioncontrol/ui/compose/DataRightsScreenTest.kt
+++ b/app/src/androidTest/java/net/kollnig/missioncontrol/ui/compose/DataRightsScreenTest.kt
@@ -25,18 +25,19 @@ class DataRightsScreenTest {
     @Test
     fun rendersOptionalSectionAndForwardsActions() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
-        var selectedAction = 0
+        val selectedActions = mutableListOf<Int>()
 
         composeRule.setContent {
             TrackerControlTheme {
-                DataRightsScreen(showAdSettings = true) { selectedAction = it }
+                DataRightsScreen(showAdSettings = true) { selectedActions += it }
             }
         }
 
         composeRule.onNodeWithText(context.getString(R.string.personalised_ads)).assertExists()
         composeRule.onNodeWithText(context.getString(R.string.request_data)).performClick()
+        composeRule.onNodeWithText(context.getString(R.string.request_deletion)).performClick()
         composeRule.runOnIdle {
-            assertEquals(R.id.btnReqData, selectedAction)
+            assertEquals(listOf(R.id.btnReqData, R.id.btnReqDeletion), selectedActions)
         }
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
@@ -88,7 +88,7 @@ internal fun DataRightsScreen(
                 text = stringResource(R.string.request_data),
                 onClick = { onAction(R.id.btnReqData) }
             )
-            DetailsSecondaryAction(
+            DetailsPrimaryAction(
                 text = stringResource(R.string.request_deletion),
                 onClick = { onAction(R.id.btnReqDeletion) }
             )
@@ -105,11 +105,11 @@ internal fun DataRightsScreen(
                 text = stringResource(R.string.contact_developer),
                 onClick = { onAction(R.id.btnContactDev) }
             )
-            DetailsSecondaryAction(
+            DetailsPrimaryAction(
                 text = stringResource(R.string.contact_playstore),
                 onClick = { onAction(R.id.btnContactGoogle) }
             )
-            DetailsSecondaryAction(
+            DetailsPrimaryAction(
                 text = stringResource(R.string.contact_officials),
                 onClick = { onAction(R.id.btnContactOfficials) }
             )

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
@@ -84,7 +85,7 @@ internal fun DataRightsScreen(
             description = stringResource(R.string.data_management_description),
             illustration = R.drawable.ic_email
         ) {
-            DetailsTextAction(
+            DetailsPrimaryAction(
                 text = stringResource(R.string.request_data),
                 onClick = { onAction(R.id.btnReqData) }
             )
@@ -101,7 +102,7 @@ internal fun DataRightsScreen(
             description = stringResource(R.string.contacts_description),
             illustration = R.drawable.ic_megaphone
         ) {
-            DetailsTextAction(
+            DetailsPrimaryAction(
                 text = stringResource(R.string.contact_developer),
                 onClick = { onAction(R.id.btnContactDev) }
             )
@@ -122,7 +123,7 @@ internal fun DataRightsScreen(
                 description = stringResource(R.string.personalised_ads_description),
                 illustration = R.drawable.ic_advertising
             ) {
-                DetailsTextAction(
+                DetailsPrimaryAction(
                     text = stringResource(R.string.ad_settings),
                     onClick = { onAction(R.id.btnAdSettings) }
                 )
@@ -168,7 +169,8 @@ private fun DataRightsSection(
                 painter = painterResource(illustration),
                 contentDescription = null,
                 modifier = Modifier.size(dimensionResource(R.dimen.card_img)),
-                contentScale = ContentScale.Fit
+                contentScale = ContentScale.Fit,
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
             )
         }
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
@@ -88,7 +88,7 @@ internal fun DataRightsScreen(
                 text = stringResource(R.string.request_data),
                 onClick = { onAction(R.id.btnReqData) }
             )
-            DetailsTextAction(
+            DetailsSecondaryAction(
                 text = stringResource(R.string.request_deletion),
                 onClick = { onAction(R.id.btnReqDeletion) }
             )
@@ -105,11 +105,11 @@ internal fun DataRightsScreen(
                 text = stringResource(R.string.contact_developer),
                 onClick = { onAction(R.id.btnContactDev) }
             )
-            DetailsTextAction(
+            DetailsSecondaryAction(
                 text = stringResource(R.string.contact_playstore),
                 onClick = { onAction(R.id.btnContactGoogle) }
             )
-            DetailsTextAction(
+            DetailsSecondaryAction(
                 text = stringResource(R.string.contact_officials),
                 onClick = { onAction(R.id.btnContactOfficials) }
             )

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/ActionsScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
@@ -169,8 +168,7 @@ private fun DataRightsSection(
                 painter = painterResource(illustration),
                 contentDescription = null,
                 modifier = Modifier.size(dimensionResource(R.dimen.card_img)),
-                contentScale = ContentScale.Fit,
-                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.primary)
+                contentScale = ContentScale.Fit
             )
         }
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/CountriesScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/CountriesScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -86,24 +88,27 @@ internal fun CountriesScreenContent(state: CountriesMapState) {
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            contentAlignment = Alignment.Center
-        ) {
-            when (state) {
-                CountriesMapState.Loading -> CircularProgressIndicator()
-                CountriesMapState.Failed -> Text(
-                    text = stringResource(R.string.countries_loading_failed),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp),
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontStyle = FontStyle.Italic,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-                is CountriesMapState.Loaded -> CountryMap(state)
+        when (state) {
+            CountriesMapState.Loading -> Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+            CountriesMapState.Failed -> Text(
+                text = stringResource(R.string.countries_loading_failed),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 16.dp),
+                style = MaterialTheme.typography.bodyMedium,
+                fontStyle = FontStyle.Italic,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            is CountriesMapState.Loaded -> {
+                Spacer(modifier = Modifier.height(8.dp))
+                CountryMap(state, Modifier.weight(1f).fillMaxWidth())
             }
         }
     }
@@ -118,15 +123,17 @@ private fun CountriesScreenPreview() {
 }
 
 @Composable
-private fun CountryMap(state: CountriesMapState.Loaded) {
+private fun CountryMap(
+    state: CountriesMapState.Loaded,
+    modifier: Modifier = Modifier
+) {
     val description = if (state.countryCodes.isEmpty()) {
         stringResource(R.string.countries_map_none)
     } else {
         stringResource(R.string.countries_map_highlighted, state.countryCodes)
     }
     Box(
-        modifier = Modifier
-            .fillMaxSize()
+        modifier = modifier
             .semantics { contentDescription = description }
     ) {
         AndroidView(

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -19,9 +19,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -85,7 +84,7 @@ fun DetailsTextAction(
     }
 }
 
-/** A left-aligned tonal action for the primary operation in a detail section. */
+/** A left-aligned filled action for an operation in a detail section. */
 @Composable
 fun DetailsPrimaryAction(
     text: String,
@@ -93,27 +92,7 @@ fun DetailsPrimaryAction(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
-    FilledTonalButton(
-        onClick = onClick,
-        enabled = enabled,
-        shape = MaterialTheme.shapes.medium,
-        modifier = modifier
-            .padding(horizontal = 16.dp, vertical = 4.dp)
-            .heightIn(min = 48.dp)
-    ) {
-        Text(text = text)
-    }
-}
-
-/** A left-aligned outlined action for secondary operations in a detail section. */
-@Composable
-fun DetailsSecondaryAction(
-    text: String,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-    enabled: Boolean = true
-) {
-    OutlinedButton(
+    Button(
         onClick = onClick,
         enabled = enabled,
         shape = MaterialTheme.shapes.medium,

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -19,7 +19,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -84,7 +84,7 @@ fun DetailsTextAction(
     }
 }
 
-/** A left-aligned, filled action for the primary operation in a detail section. */
+/** A left-aligned tonal action for the primary operation in a detail section. */
 @Composable
 fun DetailsPrimaryAction(
     text: String,
@@ -92,9 +92,10 @@ fun DetailsPrimaryAction(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
-    Button(
+    FilledTonalButton(
         onClick = onClick,
         enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
         modifier = modifier
             .padding(horizontal = 16.dp)
             .heightIn(min = 48.dp)

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -97,7 +98,27 @@ fun DetailsPrimaryAction(
         enabled = enabled,
         shape = MaterialTheme.shapes.medium,
         modifier = modifier
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .heightIn(min = 48.dp)
+    ) {
+        Text(text = text)
+    }
+}
+
+/** A left-aligned outlined action for secondary operations in a detail section. */
+@Composable
+fun DetailsSecondaryAction(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    OutlinedButton(
+        onClick = onClick,
+        enabled = enabled,
+        shape = MaterialTheme.shapes.medium,
+        modifier = modifier
+            .padding(horizontal = 16.dp, vertical = 4.dp)
             .heightIn(min = 48.dp)
     ) {
         Text(text = text)

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -80,5 +81,24 @@ fun DetailsTextAction(
             modifier = Modifier.fillMaxWidth(),
             textAlign = TextAlign.Start
         )
+    }
+}
+
+/** A left-aligned, filled action for the primary operation in a detail section. */
+@Composable
+fun DetailsPrimaryAction(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
+) {
+    Button(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier
+            .padding(horizontal = 16.dp)
+            .heightIn(min = 48.dp)
+    ) {
+        Text(text = text)
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/DetailsComponents.kt
@@ -19,8 +19,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -84,7 +84,7 @@ fun DetailsTextAction(
     }
 }
 
-/** A left-aligned filled action for an operation in a detail section. */
+/** A left-aligned light action for an operation in a detail section. */
 @Composable
 fun DetailsPrimaryAction(
     text: String,
@@ -92,7 +92,7 @@ fun DetailsPrimaryAction(
     modifier: Modifier = Modifier,
     enabled: Boolean = true
 ) {
-    Button(
+    OutlinedButton(
         onClick = onClick,
         enabled = enabled,
         shape = MaterialTheme.shapes.medium,


### PR DESCRIPTION
## Summary\n- give the primary Data Rights actions clear Material button affordances\n- tint illustrations with the Material colour scheme\n- tighten the Countries introduction and map spacing\n- retain secondary actions as lower-emphasis text controls\n\n## Verification\n- \n- \n- \n- \n\n## Stack\nDepends on #867. Device testing is intentionally deferred.