### PR TITLE
Request local network access from Troubleshooting

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -165,6 +165,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
     private int privateDnsWarningState = ServiceSinkhole.PRIVATE_DNS_WARNING_NONE;
     private int privateDnsWarningQueryGeneration;
+    private Boolean lastLocalNetworkGrant;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -616,6 +617,14 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         if (tvLocalNetwork != null)
             tvLocalNetwork.setVisibility(
                     LocalNetworkAccess.isMissing(this) ? View.VISIBLE : View.GONE);
+        boolean localNetworkGranted = LocalNetworkAccess.isGranted(this);
+        if (lastLocalNetworkGrant != null && !lastLocalNetworkGrant && localNetworkGranted)
+            ServiceSinkhole.reload("permission granted", this, false);
+        lastLocalNetworkGrant = localNetworkGranted;
+        if (dialogTroubleshooting != null && dialogTroubleshooting.isShowing() &&
+                dialogTroubleshooting.getWindow() != null)
+            renderLocalNetworkAccess(dialogTroubleshooting.getWindow().getDecorView(),
+                    LocalNetworkAccess.isEnforced(), localNetworkGranted);
 
         // Only while we are actually filtering: with the VPN off, port 853 is
         // not blocked and a pinned resolver works fine.
@@ -914,12 +923,16 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         } else if (requestCode == REQUEST_LOCAL_NETWORK) {
             boolean granted = (grantResults.length > 0 &&
                     grantResults[0] == PackageManager.PERMISSION_GRANTED);
+            lastLocalNetworkGrant = LocalNetworkAccess.isGranted(this);
             TextView tvLocalNetwork = findViewById(R.id.tvLocalNetwork);
             if (tvLocalNetwork != null)
                 // Derived, not inferred from the grant result: the row is about
                 // the configuration needing access, which onResume decides too.
                 tvLocalNetwork.setVisibility(
                         LocalNetworkAccess.isMissing(this) ? View.VISIBLE : View.GONE);
+            if (dialogTroubleshooting != null && dialogTroubleshooting.isShowing())
+                renderLocalNetworkAccess(dialogTroubleshooting.getWindow().getDecorView(),
+                        LocalNetworkAccess.isEnforced(), LocalNetworkAccess.isGranted(this));
             if (granted)
                 // The tunnel keeps its sockets across a reload, but the native
                 // engine reopens them, so LAN destinations become reachable.
@@ -1450,6 +1463,15 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             view.findViewById(R.id.tvDataSaverStatus).setVisibility(View.VISIBLE);
         }
 
+        renderLocalNetworkAccess(view, LocalNetworkAccess.isEnforced(),
+                LocalNetworkAccess.isGranted(this));
+        view.findViewById(R.id.btnLocalNetworkAccess).setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                requestPermissions(new String[] { LocalNetworkAccess.PERMISSION }, REQUEST_LOCAL_NETWORK);
+            }
+        });
+
         // VPN settings button
         view.findViewById(R.id.btnVpnSettings).setOnClickListener(new View.OnClickListener() {
             @Override
@@ -1474,6 +1496,17 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 })
                 .create();
         dialogTroubleshooting.show();
+    }
+
+    static void renderLocalNetworkAccess(View popupRoot, boolean enforced, boolean granted) {
+        View section = popupRoot.findViewById(R.id.localNetworkAccessSection);
+        View action = popupRoot.findViewById(R.id.btnLocalNetworkAccess);
+        View status = popupRoot.findViewById(R.id.tvLocalNetworkAccessStatus);
+
+        boolean showSection = enforced;
+        section.setVisibility(showSection ? View.VISIBLE : View.GONE);
+        action.setVisibility(showSection && !granted ? View.VISIBLE : View.GONE);
+        status.setVisibility(showSection && granted ? View.VISIBLE : View.GONE);
     }
 
     private void menu_legend() {

--- a/app/src/main/res/layout/troubleshooting.xml
+++ b/app/src/main/res/layout/troubleshooting.xml
@@ -104,6 +104,48 @@
                 android:textStyle="italic"
                 android:visibility="gone" />
 
+            <!-- Local Network Access -->
+            <LinearLayout
+                android:id="@+id/localNetworkAccessSection"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/troubleshooting_local_network_title"
+                    android:textAppearance="@style/TextMedium"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/troubleshooting_local_network_desc"
+                    android:textAppearance="@style/TextSmall" />
+
+                <Button
+                    android:id="@+id/btnLocalNetworkAccess"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/troubleshooting_local_network_action"
+                    android:visibility="gone" />
+
+                <TextView
+                    android:id="@+id/tvLocalNetworkAccessStatus"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/troubleshooting_local_network_ok"
+                    android:textAppearance="@style/TextSmall"
+                    android:textStyle="italic"
+                    android:visibility="gone" />
+            </LinearLayout>
+
             <!-- App breakage -->
             <TextView
                 android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,11 @@
     <string name="troubleshooting_datasaver_action">Allow unrestricted data</string>
     <string name="troubleshooting_datasaver_ok">Data saver is not restricting TrackerControl.</string>
 
+    <string name="troubleshooting_local_network_title">Local network access</string>
+    <string name="troubleshooting_local_network_desc">Permission is needed for local DNS servers, WireGuard peers, and proxies.</string>
+    <string name="troubleshooting_local_network_action">Allow local network access</string>
+    <string name="troubleshooting_local_network_ok">Local network access is allowed.</string>
+
     <string name="troubleshooting_app_breakage_title">An app stopped working</string>
     <string name="troubleshooting_app_breakage_desc">Tap the app in the main list, then tap Protection. Try "Minimal blocking only" first. If the app still has problems, choose "Trackers allowed". Use "Bypass TrackerControl" only as a last resort.</string>
 

--- a/app/src/test/java/eu/faircode/netguard/ActivityMainTroubleshootingTest.java
+++ b/app/src/test/java/eu/faircode/netguard/ActivityMainTroubleshootingTest.java
@@ -1,0 +1,52 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+
+import android.view.LayoutInflater;
+import android.view.View;
+
+import net.kollnig.missioncontrol.R;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+@RunWith(RobolectricTestRunner.class)
+public class ActivityMainTroubleshootingTest {
+    private View inflateTroubleshooting() {
+        return LayoutInflater.from(RuntimeEnvironment.getApplication())
+                .inflate(R.layout.troubleshooting, null, false);
+    }
+
+    @Test
+    public void localNetworkAccessIsHiddenBelowEnforcement() {
+        View root = inflateTroubleshooting();
+
+        ActivityMain.renderLocalNetworkAccess(root, false, false);
+
+        assertEquals(View.GONE, root.findViewById(R.id.localNetworkAccessSection).getVisibility());
+    }
+
+    @Test
+    public void localNetworkAccessShowsActionWhenPermissionIsMissing() {
+        View root = inflateTroubleshooting();
+
+        ActivityMain.renderLocalNetworkAccess(root, true, false);
+
+        assertEquals(View.VISIBLE, root.findViewById(R.id.localNetworkAccessSection).getVisibility());
+        assertEquals(View.VISIBLE, root.findViewById(R.id.btnLocalNetworkAccess).getVisibility());
+        assertEquals(View.GONE, root.findViewById(R.id.tvLocalNetworkAccessStatus).getVisibility());
+    }
+
+    @Test
+    public void localNetworkAccessShowsStatusWhenPermissionIsGranted() {
+        View root = inflateTroubleshooting();
+
+        ActivityMain.renderLocalNetworkAccess(root, true, true);
+
+        assertEquals(View.VISIBLE, root.findViewById(R.id.localNetworkAccessSection).getVisibility());
+        assertEquals(View.GONE, root.findViewById(R.id.btnLocalNetworkAccess).getVisibility());
+        assertEquals(View.VISIBLE, root.findViewById(R.id.tvLocalNetworkAccessStatus).getVisibility());
+    }
+}


### PR DESCRIPTION
## Summary\n- add a Local network access section to Troubleshooting on Android 17+\n- request ACCESS_LOCAL_NETWORK through the existing permission flow\n- show a granted status after success while preserving reload and permanent-denial handling\n- cover hidden, requestable, and granted rendering states\n\n## Verification\n- ./gradlew :app:testGithubDebugUnitTest --tests eu.faircode.netguard.ActivityMainTroubleshootingTest -q\n- ./gradlew :app:testGithubDebugUnitTest -q\n- ./gradlew :app:compileGithubDebugJavaWithJavac -q\n- ./gradlew :app:lintGithubDebug -q\n- git diff --check\n\n## Stack\nDepends on #868. No device commands were run.