### PR TITLE
Unify screens on Material surface roles

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackerControlTheme.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackerControlTheme.kt
@@ -16,6 +16,8 @@ package net.kollnig.missioncontrol.ui.compose
 
 import android.content.Context
 import android.content.res.Configuration
+import android.util.TypedValue
+import androidx.annotation.AttrRes
 import androidx.annotation.ColorRes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Typography
@@ -32,10 +34,10 @@ import net.kollnig.missioncontrol.R
  * Material theme for Compose content embedded in TrackerControl's existing
  * view hierarchy.
  *
- * Colours are resolved from Android resources so the existing values-night
- * palette remains the source of truth. Dynamic colour is intentionally not
- * used: the app's red/teal identity and neutral detail surfaces must match
- * the surrounding View-based screens.
+ * DECISION: Hybrid Compose/View screens resolve semantic surface roles from the
+ * surrounding Material 3 View theme so their tonal backgrounds remain
+ * identical. Dynamic colour remains intentionally disabled to preserve
+ * TrackerControl's red/teal identity.
  */
 @Composable
 fun TrackerControlTheme(content: @Composable () -> Unit) {
@@ -59,7 +61,7 @@ fun TrackerControlTheme(content: @Composable () -> Unit) {
 
 private val TrackerControlTypography = Typography()
 
-private fun trackerControlLightColours(context: Context) = lightColorScheme(
+internal fun trackerControlLightColours(context: Context) = lightColorScheme(
     primary = context.colour(R.color.colorRedOn),
     onPrimary = Color.White,
     primaryContainer = context.colour(R.color.colorPrimaryLight),
@@ -68,21 +70,21 @@ private fun trackerControlLightColours(context: Context) = lightColorScheme(
     onSecondary = Color.White,
     secondaryContainer = context.colour(R.color.colorAccent),
     onSecondaryContainer = Color.White,
-    background = context.colour(R.color.trackerFeedBackground),
-    onBackground = Color.Black,
-    surface = context.colour(R.color.trackerFeedBackground),
-    onSurface = Color.Black,
-    surfaceVariant = context.colour(R.color.trackerFeedSectionBackground),
-    onSurfaceVariant = Color(0xFF424242),
-    outline = context.colour(R.color.trackerFeedDivider),
-    outlineVariant = context.colour(R.color.trackerFeedDivider),
+    background = context.themeColour(android.R.attr.colorBackground),
+    onBackground = context.themeColour(com.google.android.material.R.attr.colorOnBackground),
+    surface = context.themeColour(com.google.android.material.R.attr.colorSurface),
+    onSurface = context.themeColour(com.google.android.material.R.attr.colorOnSurface),
+    surfaceVariant = context.themeColour(com.google.android.material.R.attr.colorSurfaceContainer),
+    onSurfaceVariant = context.themeColour(com.google.android.material.R.attr.colorOnSurfaceVariant),
+    outline = context.themeColour(com.google.android.material.R.attr.colorOutline),
+    outlineVariant = context.themeColour(com.google.android.material.R.attr.colorOutlineVariant),
     error = context.colour(R.color.colorRedOn),
     onError = Color.White
 )
 
-private fun trackerControlDarkColours(context: Context) = darkColorScheme(
+internal fun trackerControlDarkColours(context: Context) = darkColorScheme(
     // colorRedOn is deliberately brighter in values-night so small actions and
-    // status labels retain contrast on the black detail-screen background.
+    // status labels retain contrast on the theme-derived dark surface.
     primary = context.colour(R.color.colorRedOn),
     onPrimary = Color.Black,
     primaryContainer = context.colour(R.color.colorPrimaryDark),
@@ -91,17 +93,31 @@ private fun trackerControlDarkColours(context: Context) = darkColorScheme(
     onSecondary = Color.Black,
     secondaryContainer = context.colour(R.color.colorAccent),
     onSecondaryContainer = Color.Black,
-    background = context.colour(R.color.trackerFeedBackground),
-    onBackground = Color.White,
-    surface = context.colour(R.color.trackerFeedBackground),
-    onSurface = Color.White,
-    surfaceVariant = context.colour(R.color.trackerFeedSectionBackground),
-    onSurfaceVariant = Color(0xFFE0E0E0),
-    outline = context.colour(R.color.trackerFeedDivider),
-    outlineVariant = context.colour(R.color.trackerFeedDivider),
+    background = context.themeColour(android.R.attr.colorBackground),
+    onBackground = context.themeColour(com.google.android.material.R.attr.colorOnBackground),
+    surface = context.themeColour(com.google.android.material.R.attr.colorSurface),
+    onSurface = context.themeColour(com.google.android.material.R.attr.colorOnSurface),
+    surfaceVariant = context.themeColour(com.google.android.material.R.attr.colorSurfaceContainer),
+    onSurfaceVariant = context.themeColour(com.google.android.material.R.attr.colorOnSurfaceVariant),
+    outline = context.themeColour(com.google.android.material.R.attr.colorOutline),
+    outlineVariant = context.themeColour(com.google.android.material.R.attr.colorOutlineVariant),
     error = context.colour(R.color.colorRedOn),
     onError = Color.Black
 )
+
+private fun Context.themeColour(@AttrRes attribute: Int): Color {
+    val value = TypedValue()
+    check(theme.resolveAttribute(attribute, value, true)) {
+        "Required theme colour attribute $attribute is missing"
+    }
+
+    return when {
+        value.resourceId != 0 -> Color(ContextCompat.getColor(this, value.resourceId))
+        value.type in TypedValue.TYPE_FIRST_COLOR_INT..TypedValue.TYPE_LAST_COLOR_INT ->
+            Color(value.data)
+        else -> error("Required theme colour attribute $attribute is not a colour")
+    }
+}
 
 private fun Context.colour(@ColorRes resource: Int): Color =
     Color(ContextCompat.getColor(this, resource))

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackersScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TrackersScreen.kt
@@ -308,7 +308,7 @@ private fun TrackerSummaryRow(
 private fun HeaderDivider() {
     HorizontalDivider(
         modifier = Modifier.padding(horizontal = 16.dp),
-        color = colorResource(R.color.trackerFeedDivider),
+        color = MaterialTheme.colorScheme.outlineVariant,
         thickness = 1.dp
     )
 }
@@ -328,7 +328,7 @@ private fun TrackerSectionRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(colorResource(R.color.trackerFeedSectionBackground))
+            .background(MaterialTheme.colorScheme.surfaceVariant)
             .heightIn(min = 48.dp)
             .padding(horizontal = 16.dp, vertical = 8.dp),
         verticalAlignment = Alignment.CenterVertically
@@ -480,7 +480,7 @@ private fun TrackerCompanyRow(
         if (row.showDivider) {
             HorizontalDivider(
                 modifier = Modifier.padding(top = 8.dp),
-                color = colorResource(R.color.trackerFeedDivider),
+                color = MaterialTheme.colorScheme.outlineVariant,
                 thickness = 1.dp
             )
         }

--- a/app/src/main/res/layout/activity_protection.xml
+++ b/app/src/main/res/layout/activity_protection.xml
@@ -5,7 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/trackerFeedBackground"
+    android:background="?android:attr/colorBackground"
     tools:context="net.kollnig.missioncontrol.details.ProtectionActivity">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -32,7 +32,7 @@
         android:id="@+id/composeProtection"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/trackerFeedBackground"
+        android:background="?android:attr/colorBackground"
         android:clipToPadding="false"
         android:paddingBottom="24dp"
         app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/app/src/main/res/layout/fragment_actions.xml
+++ b/app/src/main/res/layout/fragment_actions.xml
@@ -5,5 +5,5 @@
     android:id="@+id/composeActions"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/trackerFeedBackground"
+    android:background="?android:attr/colorBackground"
     tools:context=".details.ActionsFragment" />

--- a/app/src/main/res/layout/fragment_countries.xml
+++ b/app/src/main/res/layout/fragment_countries.xml
@@ -5,5 +5,5 @@
     android:id="@+id/composeCountries"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/trackerFeedBackground"
+    android:background="?android:attr/colorBackground"
     tools:mContext=".details.CountriesFragment" />

--- a/app/src/main/res/layout/fragment_trackers.xml
+++ b/app/src/main/res/layout/fragment_trackers.xml
@@ -3,6 +3,6 @@
     android:id="@+id/composeTrackers"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/trackerFeedBackground"
+    android:background="?android:attr/colorBackground"
     xmlns:android="http://schemas.android.com/apk/res/android"
     tools:mContext=".details.TrackersFragment" />

--- a/app/src/main/res/layout/item_tracker_feed_company.xml
+++ b/app/src/main/res/layout/item_tracker_feed_company.xml
@@ -121,6 +121,6 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginTop="8dp"
-        android:background="@color/trackerFeedDivider"
+        android:background="?attr/colorOutlineVariant"
         android:importantForAccessibility="no" />
 </LinearLayout>

--- a/app/src/main/res/layout/item_tracker_feed_section.xml
+++ b/app/src/main/res/layout/item_tracker_feed_section.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@color/trackerFeedSectionBackground"
+    android:background="?attr/colorSurfaceContainer"
     android:minHeight="48dp"
     android:gravity="center_vertical"
     android:orientation="horizontal"

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -20,10 +20,6 @@
          link. See issue #560. -->
     <color name="colorFooterLink">#80cbc4</color>
 
-    <color name="trackerFeedBackground">#000000</color>
-    <color name="trackerFeedSectionBackground">#242424</color>
-    <color name="trackerFeedDivider">#424242</color>
-
     <color name="bottom_nav_background">#000000</color>
     <color name="bottom_nav_active_indicator">#5B1B1B</color>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -30,12 +30,6 @@
     <color name="timeline_blocked">#C62828</color>
     <color name="timeline_allowed">#2E7D32</color>
 
-    <!-- Material3's derived colorBackground is brand-tinted; these Manage
-         App/feed surfaces are deliberately neutral. -->
-    <color name="trackerFeedBackground">#FFFFFF</color>
-    <color name="trackerFeedSectionBackground">#F5F5F5</color>
-    <color name="trackerFeedDivider">#E0E0E0</color>
-
     <color name="bottom_nav_background">#FFFFFF</color>
     <color name="bottom_nav_active_indicator">#FFCDD2</color>
 

--- a/app/src/test/java/net/kollnig/missioncontrol/ui/compose/TrackerControlThemeTest.kt
+++ b/app/src/test/java/net/kollnig/missioncontrol/ui/compose/TrackerControlThemeTest.kt
@@ -1,0 +1,79 @@
+package net.kollnig.missioncontrol.ui.compose
+
+import android.content.Context
+import android.view.ContextThemeWrapper
+import androidx.compose.ui.graphics.toArgb
+import net.kollnig.missioncontrol.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class TrackerControlThemeTest {
+    @Test
+    @Config(qualifiers = "notnight")
+    fun lightColourSchemeMatchesMaterialThemeAttributes() {
+        val context = themedContext()
+
+        assertSchemeMatchesTheme(context, trackerControlLightColours(context))
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun darkColourSchemeMatchesMaterialThemeAttributes() {
+        val context = themedContext()
+
+        assertSchemeMatchesTheme(context, trackerControlDarkColours(context))
+    }
+
+    private fun themedContext(): Context {
+        val application = RuntimeEnvironment.getApplication()
+        return ContextThemeWrapper(application, R.style.AppThemeRed)
+    }
+
+    private fun assertSchemeMatchesTheme(
+        context: Context,
+        scheme: androidx.compose.material3.ColorScheme
+    ) {
+        assertEquals(themeColour(context, android.R.attr.colorBackground), scheme.background.toArgb())
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorOnBackground),
+            scheme.onBackground.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorSurface),
+            scheme.surface.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorOnSurface),
+            scheme.onSurface.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorSurfaceContainer),
+            scheme.surfaceVariant.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorOnSurfaceVariant),
+            scheme.onSurfaceVariant.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorOutline),
+            scheme.outline.toArgb()
+        )
+        assertEquals(
+            themeColour(context, com.google.android.material.R.attr.colorOutlineVariant),
+            scheme.outlineVariant.toArgb()
+        )
+    }
+
+    private fun themeColour(context: Context, attribute: Int): Int {
+        val value = android.util.TypedValue()
+        assertTrue("Theme attribute $attribute must be resource-backed", context.theme.resolveAttribute(attribute, value, true))
+        assertTrue("Theme attribute $attribute must resolve to a colour resource", value.resourceId != 0)
+        return androidx.core.content.ContextCompat.getColor(context, value.resourceId)
+    }
+}


### PR DESCRIPTION
## Summary\n- replace temporary white, grey, and divider aliases with Material 3 semantic theme roles\n- make Compose background, surface, section containers, content colours, and outlines match their View hosts\n- migrate remaining XML detail hosts to background, surfaceContainer, and outlineVariant attributes\n- keep TrackerControl red and teal roles and dynamic-colour policy unchanged\n- verify light and dark theme-role parity with Robolectric\n\n## Verification\n- ./gradlew :app:testGithubDebugUnitTest -q\n- ./gradlew :app:compileGithubDebugJavaWithJavac -q\n- ./gradlew :app:compileGithubDebugAndroidTestKotlin -q\n- ./gradlew :app:processGithubDebugResources -q\n- ./gradlew :app:lintGithubDebug -q\n- git diff --check\n\n## Stack\nDepends on #869. No dependency changes, experimental APIs, or device commands.