### PR TITLE
Add WireGuard profiles via QR code

### DIFF
--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -46,6 +46,8 @@ wgbridge-rs/                 Rust crate embedding gotatun (Mullvad WireGuard)
   - `wg/` (Kotlin) — WireGuard config/egress: `WgConfig.kt` (wg-quick → UAPI),
     `WgEgress.kt` (lifecycle, hostname re-resolution), `WgConnectivityMonitor.kt`
     (the 1 s stats poll — battery-relevant).
+  - `wg/QrDecoder.java`, `ActivityScanQr.java` — reading a WireGuard config off a
+    QR code (ZXing decode on CameraX frames; nothing leaves the device).
   - `wgbridge/` — hand-written JNI bindings to the Rust crate: `Wgbridge`,
     `Tunnel`, `Protector`, `Logger`, `DnsRecorder`. Mirror of `wgbridge-rs`.
 - **Native C packet engine** — `app/src/main/jni/netguard/`: `netguard.c`,

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -251,6 +251,14 @@ dependencies {
     // OkHttp for DNS-over-HTTPS
     implementation 'com.squareup.okhttp3:okhttp:5.5.0'
     implementation 'dnsjava:dnsjava:3.6.5'
+
+    // QR scanning of WireGuard configs: CameraX for the preview/frames,
+    // ZXing's pure-Java core for the decode (no Play Services dependency).
+    def camerax_version = '1.6.2'
+    implementation "androidx.camera:camera-camera2:$camerax_version"
+    implementation "androidx.camera:camera-lifecycle:$camerax_version"
+    implementation "androidx.camera:camera-view:$camerax_version"
+    implementation 'com.google.zxing:core:3.5.4'
 }
 
 // Fix lint error on release builds

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,8 +28,19 @@
         and no frame ever leaves the device.
     -->
     <uses-permission android:name="android.permission.CAMERA" />
+    <!--
+        Declaring CAMERA makes Play infer android.hardware.camera and
+        .autofocus as required, which would hide the app from camera-less
+        devices; scanning is optional, so mark all three optional.
+    -->
     <uses-feature
         android:name="android.hardware.camera.any"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera.autofocus"
         android:required="false" />
 
     <!-- https://developer.android.com/preview/privacy/package-visibility -->

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,6 +22,16 @@
     -->
     <uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />
 
+    <!--
+        Only used by net.kollnig.missioncontrol.ActivityScanQr to read a
+        WireGuard configuration off a QR code; nothing else opens the camera,
+        and no frame ever leaves the device.
+    -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature
+        android:name="android.hardware.camera.any"
+        android:required="false" />
+
     <!-- https://developer.android.com/preview/privacy/package-visibility -->
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
@@ -190,6 +200,17 @@
                 android:value="eu.faircode.netguard.ActivitySettings" />
         </activity>
 
+
+        <activity
+            android:name="net.kollnig.missioncontrol.ActivityScanQr"
+            android:configChanges="orientation|screenSize"
+            android:exported="false"
+            android:label="@string/setting_wg_profile_scan"
+            android:parentActivityName="net.kollnig.missioncontrol.ActivityWireGuardProfiles">
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value="net.kollnig.missioncontrol.ActivityWireGuardProfiles" />
+        </activity>
 
         <activity
             android:name="net.kollnig.missioncontrol.DetailsActivity"

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityScanQr.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityScanQr.java
@@ -1,0 +1,190 @@
+package net.kollnig.missioncontrol;
+
+import android.Manifest;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import android.util.Log;
+import android.util.Size;
+import android.view.MenuItem;
+import android.widget.Toast;
+
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.camera.core.CameraSelector;
+import androidx.camera.core.ImageAnalysis;
+import androidx.camera.core.ImageProxy;
+import androidx.camera.core.Preview;
+import androidx.camera.core.resolutionselector.ResolutionSelector;
+import androidx.camera.core.resolutionselector.ResolutionStrategy;
+import androidx.camera.lifecycle.ProcessCameraProvider;
+import androidx.camera.view.PreviewView;
+import androidx.core.content.ContextCompat;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import net.kollnig.missioncontrol.wg.QrDecoder;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import eu.faircode.netguard.Util;
+
+/**
+ * Scans a QR code with the camera and hands its text back to the caller.
+ *
+ * WireGuard providers commonly show a configuration as a QR code, which spares
+ * users retyping or emailing a config to the phone. Everything stays on the
+ * device: frames are decoded in-process by {@link QrDecoder} and never stored.
+ */
+public class ActivityScanQr extends AppCompatActivity {
+    private static final String TAG = "TrackerControl.ScanQr";
+
+    /** Result extra holding the decoded QR text. */
+    public static final String EXTRA_RESULT = "qr_text";
+
+    private final ExecutorService analysisExecutor = Executors.newSingleThreadExecutor();
+    private final QrDecoder decoder = new QrDecoder();
+    // The analyzer keeps running for a frame or two after the first hit, and
+    // finishing twice would deliver the result to a dead activity.
+    private final AtomicBoolean delivered = new AtomicBoolean(false);
+
+    private ActivityResultLauncher<String> permissionLauncher;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        Util.setTheme(this);
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_scan_qr);
+
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setTitle(R.string.setting_wg_profile_scan);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
+
+        permissionLauncher = registerForActivityResult(
+                new ActivityResultContracts.RequestPermission(), granted -> {
+                    if (granted) {
+                        startCamera();
+                    } else {
+                        Toast.makeText(this, R.string.msg_wg_profile_scan_no_camera_permission,
+                                Toast.LENGTH_LONG).show();
+                        finish();
+                    }
+                });
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+                == PackageManager.PERMISSION_GRANTED)
+            startCamera();
+        else
+            permissionLauncher.launch(Manifest.permission.CAMERA);
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        analysisExecutor.shutdown();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            finish();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
+    }
+
+    private void startCamera() {
+        PreviewView previewView = findViewById(R.id.scan_preview);
+        ListenableFuture<ProcessCameraProvider> future = ProcessCameraProvider.getInstance(this);
+        future.addListener(() -> {
+            try {
+                ProcessCameraProvider provider = future.get();
+
+                Preview preview = new Preview.Builder().build();
+                preview.setSurfaceProvider(previewView.getSurfaceProvider());
+
+                ImageAnalysis analysis = new ImageAnalysis.Builder()
+                        // A dense config QR needs more than preview resolution,
+                        // but a full-size frame only slows the decoder down.
+                        .setResolutionSelector(new ResolutionSelector.Builder()
+                                .setResolutionStrategy(new ResolutionStrategy(
+                                        new Size(1280, 720),
+                                        ResolutionStrategy.FALLBACK_RULE_CLOSEST_HIGHER_THEN_LOWER))
+                                .build())
+                        .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                        .build();
+                analysis.setAnalyzer(analysisExecutor, this::analyze);
+
+                provider.unbindAll();
+                provider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA,
+                        preview, analysis);
+            } catch (Throwable ex) {
+                Log.e(TAG, "Cannot start camera", ex);
+                Toast.makeText(this, getString(R.string.msg_wg_profile_scan_failed,
+                        ex.getMessage()), Toast.LENGTH_LONG).show();
+                finish();
+            }
+        }, ContextCompat.getMainExecutor(this));
+    }
+
+    private void analyze(ImageProxy image) {
+        try {
+            if (delivered.get())
+                return;
+            String text = decoder.decode(luminance(image), image.getWidth(), image.getHeight());
+            if (text != null && !text.isEmpty() && delivered.compareAndSet(false, true))
+                runOnUiThread(() -> deliver(text));
+        } catch (Throwable ex) {
+            Log.w(TAG, "QR decoding failed", ex);
+        } finally {
+            image.close();
+        }
+    }
+
+    /**
+     * Copies the Y plane of a YUV_420_888 frame into a tightly packed
+     * greyscale array, dropping the row and pixel padding some devices add.
+     */
+    private static byte[] luminance(ImageProxy image) {
+        ImageProxy.PlaneProxy plane = image.getPlanes()[0];
+        ByteBuffer buffer = plane.getBuffer();
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int rowStride = plane.getRowStride();
+        int pixelStride = plane.getPixelStride();
+
+        byte[] out = new byte[width * height];
+        if (pixelStride == 1 && rowStride == width && buffer.remaining() >= out.length) {
+            buffer.get(out, 0, out.length);
+            return out;
+        }
+
+        byte[] row = new byte[rowStride];
+        for (int y = 0; y < height; y++) {
+            int offset = y * rowStride;
+            // The last row is often shorter than a full stride.
+            if (offset >= buffer.limit())
+                break;
+            buffer.position(offset);
+            int available = Math.min(rowStride, buffer.remaining());
+            buffer.get(row, 0, available);
+            for (int x = 0; x < width; x++) {
+                int index = x * pixelStride;
+                if (index >= available)
+                    break;
+                out[y * width + x] = row[index];
+            }
+        }
+        return out;
+    }
+
+    private void deliver(String text) {
+        setResult(RESULT_OK, new Intent().putExtra(EXTRA_RESULT, text));
+        finish();
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityScanQr.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityScanQr.java
@@ -12,6 +12,7 @@ import android.widget.Toast;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.camera.core.CameraInfoUnavailableException;
 import androidx.camera.core.CameraSelector;
 import androidx.camera.core.ImageAnalysis;
 import androidx.camera.core.ImageProxy;
@@ -120,9 +121,16 @@ public class ActivityScanQr extends AppCompatActivity {
                         .build();
                 analysis.setAnalyzer(analysisExecutor, this::analyze);
 
+                CameraSelector selector = selectCamera(provider);
+                if (selector == null) {
+                    Toast.makeText(this, R.string.msg_wg_profile_scan_no_camera,
+                            Toast.LENGTH_LONG).show();
+                    finish();
+                    return;
+                }
+
                 provider.unbindAll();
-                provider.bindToLifecycle(this, CameraSelector.DEFAULT_BACK_CAMERA,
-                        preview, analysis);
+                provider.bindToLifecycle(this, selector, preview, analysis);
             } catch (Throwable ex) {
                 Log.e(TAG, "Cannot start camera", ex);
                 Toast.makeText(this, getString(R.string.msg_wg_profile_scan_failed,
@@ -130,6 +138,20 @@ public class ActivityScanQr extends AppCompatActivity {
                 finish();
             }
         }, ContextCompat.getMainExecutor(this));
+    }
+
+    /**
+     * Prefers the back camera, but front-camera-only devices (some tablets and
+     * Chromebooks) must still be able to scan. Analysis frames are not mirrored
+     * even when the front preview is, so decoding works either way.
+     */
+    private static CameraSelector selectCamera(ProcessCameraProvider provider)
+            throws CameraInfoUnavailableException {
+        if (provider.hasCamera(CameraSelector.DEFAULT_BACK_CAMERA))
+            return CameraSelector.DEFAULT_BACK_CAMERA;
+        if (provider.hasCamera(CameraSelector.DEFAULT_FRONT_CAMERA))
+            return CameraSelector.DEFAULT_FRONT_CAMERA;
+        return null;
     }
 
     private void analyze(ImageProxy image) {

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -5,6 +5,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.content.pm.PackageManager;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -16,6 +17,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.compose.ui.platform.ComposeView;
@@ -52,6 +55,7 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
 
     private WgProfileManager manager;
     private WireGuardProfilesScreenController screenController;
+    private ActivityResultLauncher<Intent> scanLauncher;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
@@ -71,6 +75,13 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
 
         manager = new WgProfileManager(this);
         manager.migrateIfNeeded();
+
+        scanLauncher = registerForActivityResult(
+                new ActivityResultContracts.StartActivityForResult(), result -> {
+                    if (result.getResultCode() != RESULT_OK || result.getData() == null)
+                        return;
+                    onQrScanned(result.getData().getStringExtra(ActivityScanQr.EXTRA_RESULT));
+                });
 
         screenController = WireGuardProfilesScreen.install(
                 composeView,
@@ -152,12 +163,15 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
         new MaterialAlertDialogBuilder(this)
                 .setItems(new CharSequence[]{
                         getString(R.string.setting_wg_profile_import),
+                        getString(R.string.setting_wg_profile_scan),
                         getString(R.string.setting_wg_mullvad_setup),
                         getString(R.string.setting_wg_proton_setup)
                 }, (dialog, which) -> {
                     if (which == 0)
                         showProfileDialog(null);
                     else if (which == 1)
+                        startScan();
+                    else if (which == 2)
                         showMullvadDialog();
                     else
                         showProtonDialog();
@@ -298,7 +312,36 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
         });
     }
 
+    // WireGuard providers routinely publish a config as a QR code; scanning it
+    // saves users from moving a config file onto the phone by hand.
+    private void startScan() {
+        if (!getPackageManager().hasSystemFeature(PackageManager.FEATURE_CAMERA_ANY)) {
+            Toast.makeText(this, R.string.msg_wg_profile_scan_no_camera, Toast.LENGTH_LONG).show();
+            return;
+        }
+        scanLauncher.launch(new Intent(this, ActivityScanQr.class));
+    }
+
+    private void onQrScanned(String text) {
+        if (TextUtils.isEmpty(text))
+            return;
+        try {
+            WgConfigParser.INSTANCE.parse(text);
+        } catch (Throwable ex) {
+            // Any QR code will scan, so tell the user when it was not a config
+            // rather than dropping them into an import dialog full of noise.
+            Toast.makeText(this, getString(R.string.msg_wg_profile_scan_not_config,
+                    ex.getMessage()), Toast.LENGTH_LONG).show();
+            return;
+        }
+        showProfileDialog(null, text);
+    }
+
     private void showProfileDialog(WgProfileManager.Profile item) {
+        showProfileDialog(item, null);
+    }
+
+    private void showProfileDialog(WgProfileManager.Profile item, String prefillConfig) {
         LinearLayout form = new LinearLayout(this);
         form.setOrientation(LinearLayout.VERTICAL);
         int pad = (int) (20 * getResources().getDisplayMetrics().density);
@@ -322,6 +365,8 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
                 InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
         if (item != null)
             config.setText(item.config);
+        else if (prefillConfig != null)
+            config.setText(prefillConfig);
         form.addView(config, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT));

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/QrDecoder.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/QrDecoder.java
@@ -1,0 +1,65 @@
+package net.kollnig.missioncontrol.wg;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.BinaryBitmap;
+import com.google.zxing.DecodeHintType;
+import com.google.zxing.LuminanceSource;
+import com.google.zxing.MultiFormatReader;
+import com.google.zxing.NotFoundException;
+import com.google.zxing.PlanarYUVLuminanceSource;
+import com.google.zxing.Result;
+import com.google.zxing.common.HybridBinarizer;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.Map;
+
+/**
+ * Decodes QR codes from raw camera luminance planes. Deliberately free of
+ * Android APIs so the decoding path can be unit-tested on the JVM; the camera
+ * plumbing lives in {@link net.kollnig.missioncontrol.ActivityScanQr}.
+ */
+public class QrDecoder {
+    private final MultiFormatReader reader;
+
+    public QrDecoder() {
+        Map<DecodeHintType, Object> hints = new EnumMap<>(DecodeHintType.class);
+        hints.put(DecodeHintType.POSSIBLE_FORMATS, EnumSet.of(BarcodeFormat.QR_CODE));
+        // WireGuard configs are long, so the QR is dense: the extra scan passes
+        // are worth the cost on a frame that would otherwise be dropped.
+        hints.put(DecodeHintType.TRY_HARDER, Boolean.TRUE);
+        reader = new MultiFormatReader();
+        reader.setHints(hints);
+    }
+
+    /**
+     * @param luminance greyscale samples, row-major, {@code width * height} bytes
+     * @return the decoded text, or {@code null} when the frame holds no QR code
+     */
+    public String decode(byte[] luminance, int width, int height) {
+        if (luminance == null || width <= 0 || height <= 0
+                || luminance.length < width * height)
+            return null;
+
+        PlanarYUVLuminanceSource source = new PlanarYUVLuminanceSource(
+                luminance, width, height, 0, 0, width, height, false);
+
+        String text = decodeSource(source);
+        if (text == null)
+            // Some screens/printouts show light-on-dark codes, which ZXing only
+            // reads once the source is inverted.
+            text = decodeSource(source.invert());
+        return text;
+    }
+
+    private String decodeSource(LuminanceSource source) {
+        try {
+            Result result = reader.decodeWithState(new BinaryBitmap(new HybridBinarizer(source)));
+            return result == null ? null : result.getText();
+        } catch (NotFoundException ex) {
+            return null;
+        } finally {
+            reader.reset();
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_scan_qr.xml
+++ b/app/src/main/res/layout/activity_scan_qr.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/black"
+    tools:context="net.kollnig.missioncontrol.ActivityScanQr">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/scan_preview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/scan_hint"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:background="#99000000"
+        android:padding="16dp"
+        android:text="@string/msg_wg_profile_scan_hint"
+        android:textColor="@android:color/white" />
+
+</FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,7 @@
     <string name="setting_wg_profile">WireGuard profile</string>
     <string name="setting_wg_profile_manage">Custom WireGuard profiles</string>
     <string name="setting_wg_profile_import">Import WireGuard config</string>
+    <string name="setting_wg_profile_scan">Scan QR code</string>
     <string name="setting_wg_mullvad_setup">Set up Mullvad</string>
     <string name="setting_wg_proton_setup">Use a Proton VPN config</string>
     <string name="setting_wg_keepalive_when_screen_off">Keep WireGuard alive when screen is off</string>
@@ -269,6 +270,11 @@
     <string name="msg_wg_profile_set_active">Set active</string>
     <string name="msg_wg_profile_config_hint">[Interface]\nPrivateKey = ...\nAddress = ...\n\n[Peer]\nPublicKey = ...\nAllowedIPs = 0.0.0.0/0, ::/0\nEndpoint = ...</string>
     <string name="msg_wg_profile_delete_confirm">Delete this WireGuard profile?</string>
+    <string name="msg_wg_profile_scan_hint">Point the camera at the WireGuard QR code shown by your VPN provider. The scan happens on your device.</string>
+    <string name="msg_wg_profile_scan_no_camera">This device has no camera to scan with</string>
+    <string name="msg_wg_profile_scan_no_camera_permission">Camera permission is needed to scan a QR code</string>
+    <string name="msg_wg_profile_scan_failed">Could not start the camera: %1$s</string>
+    <string name="msg_wg_profile_scan_not_config">This QR code is not a WireGuard config: %1$s</string>
     <string name="msg_wg_mullvad_account">Mullvad account number</string>
     <string name="msg_wg_mullvad_recommended">Recommended location</string>
     <string name="msg_wg_mullvad_note">TrackerControl creates a Mullvad WireGuard profile. The account number is saved locally for future Mullvad profiles. Tokens are not stored, and deleting the profile here does not remove the device from Mullvad.</string>

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/QrDecoderTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/QrDecoderTest.java
@@ -1,0 +1,73 @@
+package net.kollnig.missioncontrol.wg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+
+import org.junit.Test;
+
+import java.util.EnumMap;
+import java.util.Map;
+
+public class QrDecoderTest {
+    private static final String CONFIG = ""
+            + "[Interface]\n"
+            + "PrivateKey = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n"
+            + "Address = 10.64.0.2/32\n"
+            + "DNS = 10.64.0.1\n"
+            + "\n"
+            + "[Peer]\n"
+            + "PublicKey = AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n"
+            + "AllowedIPs = 0.0.0.0/0, ::/0\n"
+            + "Endpoint = 192.0.2.1:51820\n";
+
+    @Test
+    public void decodesAWireGuardConfigQr() throws Exception {
+        String text = new QrDecoder().decode(render(CONFIG, 600), 600, 600);
+
+        assertEquals(CONFIG, text);
+        // The scanned text must be usable as-is by the profile import path.
+        WgConfigParser.INSTANCE.parse(text);
+    }
+
+    @Test
+    public void decodesALightOnDarkQr() throws Exception {
+        byte[] luminance = render(CONFIG, 600);
+        for (int i = 0; i < luminance.length; i++)
+            luminance[i] = (byte) (255 - (luminance[i] & 0xFF));
+
+        assertEquals(CONFIG, new QrDecoder().decode(luminance, 600, 600));
+    }
+
+    @Test
+    public void returnsNullOnAFrameWithoutAQr() {
+        assertEquals(null, new QrDecoder().decode(new byte[600 * 600], 600, 600));
+    }
+
+    @Test
+    public void rejectsUndersizedOrEmptyFrames() {
+        QrDecoder decoder = new QrDecoder();
+
+        assertNull(decoder.decode(null, 600, 600));
+        assertNull(decoder.decode(new byte[10], 600, 600));
+        assertNull(decoder.decode(new byte[0], 0, 0));
+    }
+
+    /** Renders {@code text} as a QR code into a greyscale luminance plane. */
+    private static byte[] render(String text, int size) throws Exception {
+        Map<EncodeHintType, Object> hints = new EnumMap<>(EncodeHintType.class);
+        hints.put(EncodeHintType.MARGIN, 2);
+        BitMatrix matrix = new QRCodeWriter().encode(
+                text, BarcodeFormat.QR_CODE, size, size, hints);
+
+        byte[] luminance = new byte[size * size];
+        for (int y = 0; y < size; y++)
+            for (int x = 0; x < size; x++)
+                luminance[y * size + x] = (byte) (matrix.get(x, y) ? 0x00 : 0xFF);
+        return luminance;
+    }
+}


### PR DESCRIPTION
Closes #859.

VPN providers routinely publish a WireGuard configuration as a QR code, so importing one into TrackerControl meant retyping it or getting the file onto the phone some other way.

## What changed

- **Custom WireGuard profiles → Add** now offers a fourth route, **Scan QR code**, next to the existing import/Mullvad/Proton ones.
- New `ActivityScanQr`: CameraX preview, camera permission requested on entry, frames decoded in-process. The first decoded code is validated with `WgConfigParser` and handed to the usual import dialog with the config prefilled, so the user names it and saves it as a regular custom profile. A QR code that is not a WireGuard config reports why rather than prefilling the dialog with noise.
- New `wg/QrDecoder`: the decode itself, deliberately free of Android APIs so it is unit-testable on the JVM. Tries the inverted luminance too, since light-on-dark codes are common on provider dashboards.
- Manifest: `CAMERA` permission (only this screen uses it) and `android.hardware.camera.any` as a non-required feature, so the app still installs on camera-less devices; the menu entry checks for a camera before launching.

## Dependencies

- `androidx.camera:camera-camera2` / `camera-lifecycle` / `camera-view` 1.6.2 — preview and frame delivery.
- `com.google.zxing:core` 3.5.4 — pure-Java decode, no Play Services, so the F-Droid flavour is unaffected.

Nothing about the scan touches the network: frames are decoded in the process and never stored.

## Testing

- `./gradlew :app:compileGithubDebugJavaWithJavac` — passes.
- `./gradlew :app:testGithubDebugUnitTest` — passes, including the new `QrDecoderTest` (dense config QR, inverted code, blank frame, undersized input).
- `./gradlew :app:lintGithubDebug` — passes, no new findings attributable to this change.
- Not exercised on a device: this was written in a container with no camera, so the CameraX plumbing (permission flow, YUV plane handling on real hardware) still wants a manual scan on a phone before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CzCvh1UxNEoEqefvUZdxR

---
_Generated by [Claude Code](https://claude.ai/code/session_019CzCvh1UxNEoEqefvUZdxR)_