### PR TITLE
Cut avoidable main-thread work in the Compose details screens

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
@@ -74,6 +74,13 @@ public class TrackersFragment extends Fragment {
     private final Map<String, Tracker> trackersByKey = new HashMap<>();
     @Nullable
     private WorkInfo analysisWork;
+    /**
+     * Cached result of the "can this app open a browser?" check used for the
+     * warning banner. Depends only on mAppId and the install type, both fixed
+     * for the fragment's lifetime, so it is computed once and reused.
+     */
+    @Nullable
+    private Boolean browserWarning;
 
     private boolean running = false;
     /** True while the async tracker query runs; drives the loading spinner. */
@@ -327,6 +334,14 @@ public class TrackersFragment extends Fragment {
             hintAccent = false;
         }
 
+        // Category blocked state is looked up once per category per render (not
+        // memoised across renders, since toggles change it), rather than being
+        // re-queried per row that references the same category.
+        Map<String, Boolean> categoryBlockedByName = new HashMap<>();
+        for (TrackerCategory category : categories)
+            categoryBlockedByName.put(category.getCategoryName(),
+                    blocklist.blocked(mAppUid, category.getCategoryName()));
+
         List<TrackersRow> rows = new ArrayList<>();
         List<Object> feedRows = TrackerFeedLogic.buildRows(
                 categories, expandedCompanyKeys, expandedSections);
@@ -334,16 +349,18 @@ public class TrackersFragment extends Fragment {
             Object feedRow = feedRows.get(index);
             if (feedRow instanceof TrackerFeedLogic.SectionRow) {
                 TrackerCategory category = ((TrackerFeedLogic.SectionRow) feedRow).getCategory();
-                rows.add(buildSectionRow(context, blocklist, state,
-                        trackerProtectionEnabled, minimal, category));
+                boolean categoryBlocked = categoryBlockedByName.get(category.getCategoryName());
+                rows.add(buildSectionRow(context, state,
+                        trackerProtectionEnabled, minimal, category, categoryBlocked));
             } else if (feedRow instanceof TrackerFeedLogic.CompanyRow) {
                 TrackerFeedLogic.CompanyRow company = (TrackerFeedLogic.CompanyRow) feedRow;
                 Object nextRow = index + 1 < feedRows.size() ? feedRows.get(index + 1) : null;
                 boolean showDivider = nextRow instanceof TrackerFeedLogic.CompanyRow
                         || nextRow instanceof TrackerFeedLogic.ShowMoreRow;
+                boolean categoryBlocked = categoryBlockedByName.get(company.getCategoryName());
                 rows.add(buildCompanyRow(context, blocklist, state,
                         trackerProtectionEnabled, minimal, strict, internetBlocked,
-                        company, showDivider));
+                        company, showDivider, categoryBlocked));
             } else if (feedRow instanceof TrackerFeedLogic.ShowMoreRow) {
                 TrackerFeedLogic.ShowMoreRow showMore = (TrackerFeedLogic.ShowMoreRow) feedRow;
                 rows.add(new TrackersRow.ShowMore(
@@ -355,9 +372,11 @@ public class TrackersFragment extends Fragment {
             }
         }
 
-        Intent urlIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.wikipedia.org/"));
-        urlIntent.setPackage(mAppId);
-        boolean browserWarning = Common.isCallable(context, urlIntent) && !Util.isPlayStoreInstall();
+        if (browserWarning == null) {
+            Intent urlIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://www.wikipedia.org/"));
+            urlIntent.setPackage(mAppId);
+            browserWarning = Common.isCallable(context, urlIntent) && !Util.isPlayStoreInstall();
+        }
         return new TrackersScreenModel(
                 browserWarning,
                 context.getString(state == AppProtectionState.PROTECTED
@@ -371,15 +390,14 @@ public class TrackersFragment extends Fragment {
     }
 
     private TrackersRow.Section buildSectionRow(Context context,
-            TrackerBlocklist blocklist,
             AppProtectionState state,
             boolean trackerProtectionEnabled,
             boolean minimal,
-            TrackerCategory category) {
+            TrackerCategory category,
+            boolean categoryBlocked) {
         final String categoryName = category.getCategoryName();
         final String displayName = category.getDisplayName(context);
         boolean readOnlyMinimal = minimal || state == AppProtectionState.MINIMAL_ONLY;
-        boolean categoryBlocked = blocklist.blocked(mAppUid, categoryName);
         boolean categoryMinimallyBlocked = false;
         if (readOnlyMinimal) {
             for (Tracker tracker : category.getChildren()) {
@@ -425,11 +443,11 @@ public class TrackersFragment extends Fragment {
             boolean strict,
             boolean internetBlocked,
             TrackerFeedLogic.CompanyRow row,
-            boolean showDivider) {
+            boolean showDivider,
+            boolean categoryBlocked) {
         Tracker tracker = row.getTracker();
         String categoryName = row.getCategoryName();
         String blockingKey = TrackerBlocklist.getBlockingKey(tracker);
-        boolean categoryBlocked = blocklist.blocked(mAppUid, categoryName);
         boolean companyKeyBlocked = blocklist.blocked(mAppUid, blockingKey);
         TrackerStatusLogic.Result status = TrackerStatusLogic.resolve(
                 trackerProtectionEnabled,

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
@@ -76,8 +76,9 @@ public class TrackersFragment extends Fragment {
     private WorkInfo analysisWork;
     /**
      * Cached result of the "can this app open a browser?" check used for the
-     * warning banner. Depends only on mAppId and the install type, both fixed
-     * for the fragment's lifetime, so it is computed once and reused.
+     * warning banner. It can only change through package state the user alters
+     * outside this screen, so it is invalidated on resume rather than paying
+     * the PackageManager IPC on every render.
      */
     @Nullable
     private Boolean browserWarning;
@@ -218,6 +219,7 @@ public class TrackersFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
+        browserWarning = null;
         updateTrackerList();
     }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TimelineScreen.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/ui/compose/TimelineScreen.kt
@@ -74,7 +74,6 @@ import net.kollnig.missioncontrol.R
 import net.kollnig.missioncontrol.data.InsightsData
 import net.kollnig.missioncontrol.data.TimelineEntry
 import java.text.NumberFormat
-import java.util.UUID
 
 /** The four reasons an empty Timeline can be shown. */
 enum class TimelineEmptyState {
@@ -845,7 +844,7 @@ private fun timelineRows(entries: List<TimelineEntry>, context: Context): List<T
         }
         if (sectionTitle != currentSection) {
             currentSection = sectionTitle
-            currentSectionKey = stableKey("section:$sectionTitle")
+            currentSectionKey = "section:$sectionTitle"
             rows += TimelineRow.Section(currentSectionKey!!, sectionTitle)
         }
 
@@ -873,7 +872,7 @@ private fun timelineRows(entries: List<TimelineEntry>, context: Context): List<T
                 else R.string.timeline_tracker_allowed
             )
             TimelineTrackerContact(
-                key = stableKey("contact:${entry.uid}:${tracker.companyName}:${tracker.blocked}"),
+                key = "contact:${entry.uid}:${tracker.companyName}:${tracker.blocked}",
                 companyName = tracker.companyName,
                 category = tracker.category,
                 blocked = tracker.blocked,
@@ -887,7 +886,7 @@ private fun timelineRows(entries: List<TimelineEntry>, context: Context): List<T
             DateUtils.FORMAT_ABBREV_RELATIVE
         ).toString()
         rows += TimelineRow.App(
-            key = stableKey("entry:${entry.uid}"),
+            key = "entry:${entry.uid}",
             sectionKey = currentSectionKey!!,
             uid = entry.uid,
             appName = entry.appName,
@@ -912,9 +911,6 @@ private fun startOfDay(daysAgo: Int): Long {
     calendar.set(java.util.Calendar.MILLISECOND, 0)
     return calendar.timeInMillis
 }
-
-private fun stableKey(identity: String): String =
-    UUID.nameUUIDFromBytes(identity.toByteArray(Charsets.UTF_8)).toString()
 
 @Preview(showBackground = true)
 @Composable


### PR DESCRIPTION
Fixes #872 with the targeted, no-restructure wins — the full-rebuild render design stays, per the issue's caution against speculative restructuring:

- **`TrackersFragment.buildScreenModel()`** ran a `PackageManager.queryIntentActivities` IPC (the browser-warning check) on every toggle, expand and refresh tick. The result depends only on the app id and install type, so it is now computed lazily once per fragment lifetime.
- **Category blocked state** was queried from `TrackerBlocklist` once per section row *and* once per company row sharing the same category — O(rows) synchronized lookups per render. It is now looked up once per category per render and threaded into the row builders; the per-company blocking-key lookup is unchanged, and the map is rebuilt every render so toggles are reflected immediately.
- **`TimelineScreen`** no longer MD5-hashes (`UUID.nameUUIDFromBytes`) its `LazyColumn` key strings on every 30-second rebuild: the prefixed identity strings (`section:`, `entry:`, `contact:`) are already unique and stable.

Behaviour is unchanged — the same booleans reach `TrackerStatusLogic.resolve` and the row constructors, and key identity semantics are preserved.

Verified: `:app:compileGithubDebugJavaWithJavac`, `:app:testGithubDebugUnitTest`, `:app:lintGithubDebug` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)