### PR TITLE
Guard browser intents and preserve pending internet-block entries

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -33,7 +33,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up JDK 21
-        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v5
         with:
           java-version: '21'
           distribution: temurin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           # Robolectric SDK 36 (see app/src/test/resources/robolectric.properties)
           # ships jars compiled with Java 21 and refuses to run on Java 17.
@@ -117,7 +117,7 @@ jobs:
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
@@ -58,16 +58,27 @@ public class ActivityForwardApproval extends Activity {
         String addr = getIntent().getStringExtra("raddr");
         final int rport = getIntent().getIntExtra("rport", 0);
         final int ruid = getIntent().getIntExtra("ruid", 0);
-        final String raddr = (addr == null ? "127.0.0.1" : addr);
 
+        // Resolve and re-derive as the numeric address: this activity is
+        // exported, so raddr is attacker-controlled from any app, and the
+        // native side copies it into a fixed INET6_ADDRSTRLEN buffer.
+        String resolved = "127.0.0.1";
         try {
-            InetAddress iraddr = InetAddress.getByName(raddr);
+            // A blank address is malformed input, not a request to forward to
+            // localhost: InetAddress.getByName("") resolves to the loopback
+            // address, which would silently turn it into a working redirect.
+            if (addr != null && TextUtils.isEmpty(addr))
+                throw new IllegalArgumentException("Forwarding address is empty");
+
+            InetAddress iraddr = InetAddress.getByName(addr == null ? "127.0.0.1" : addr);
             if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                 throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");
+            resolved = iraddr.getHostAddress();
         } catch (Throwable ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             finish();
         }
+        final String raddr = resolved;
 
         String pname;
         if (protocol == 6)

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -195,13 +196,22 @@ public class ActivityForwarding extends AppCompatActivity {
                                     String[] values = getResources().getStringArray(R.array.protocolValues);
                                     final int protocol = Integer.valueOf(values[pos]);
                                     final int dport = Integer.parseInt(etDPort.getText().toString());
-                                    final String raddr = etRAddr.getText().toString();
                                     final int rport = Integer.parseInt(etRPort.getText().toString());
                                     final int ruid = ((Rule) spRuid.getSelectedItem()).uid;
 
-                                    InetAddress iraddr = InetAddress.getByName(raddr);
+                                    String raddrInput = etRAddr.getText().toString();
+                                    if (TextUtils.isEmpty(raddrInput))
+                                        throw new IllegalArgumentException("Forwarding address is required");
+
+                                    InetAddress iraddr = InetAddress.getByName(raddrInput);
                                     if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                                         throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");
+                                    // Store the resolved numeric address, not the raw
+                                    // (possibly hostname) text: the native side copies
+                                    // this into a fixed INET6_ADDRSTRLEN buffer, and a
+                                    // hostname is neither bounded in length nor
+                                    // resolvable from native code.
+                                    final String raddr = iraddr.getHostAddress();
 
                                     new AsyncTask<Object, Object, Throwable>() {
                                         @Override

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1738,10 +1738,20 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                 int rport = Integer.parseInt(attributes.getValue("rport"));
 
                 try {
+                    // Re-derive as the numeric address: the imported file is
+                    // untrusted input, and the native side copies raddr into a
+                    // fixed INET6_ADDRSTRLEN buffer. A blank address is left
+                    // alone: native treats it as "no redirect", and resolving
+                    // it would turn an inert exported rule into a live
+                    // redirect to loopback on re-import.
+                    if (!TextUtils.isEmpty(raddr))
+                        raddr = InetAddress.getByName(raddr).getHostAddress();
                     int uid = getUid(pkg);
                     DatabaseHelper.getInstance(context).addForward(protocol, dport, raddr, rport, uid);
                 } catch (PackageManager.NameNotFoundException ex) {
                     Log.w(TAG, "Package not found pkg=" + pkg);
+                } catch (java.io.IOException ex) {
+                    Log.w(TAG, "Invalid forward raddr=" + raddr + ": " + ex);
                 }
 
             } else

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -90,9 +90,15 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final int DB_VERSION = 23;
 
     private static boolean once = true;
-    private static List<LogChangedListener> logChangedListeners = new ArrayList<>();
-    private static List<AccessChangedListener> accessChangedListeners = new ArrayList<>();
-    private static List<ForwardChangedListener> forwardChangedListeners = new ArrayList<>();
+    // CopyOnWriteArrayList: listeners are added/removed from activity/fragment
+    // lifecycle methods on the main thread while handleChangedNotification()
+    // iterates them on the DB handler thread. A plain ArrayList let a
+    // same-tick removal throw ConcurrentModificationException out of that
+    // iteration, which is not covered by the per-listener try/catch below and
+    // kills the notification thread.
+    private static List<LogChangedListener> logChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private static List<AccessChangedListener> accessChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private static List<ForwardChangedListener> forwardChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     private static HandlerThread hthread = null;
     private static Handler handler = null;

--- a/app/src/main/java/eu/faircode/netguard/IdleStatePolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/IdleStatePolicy.java
@@ -1,0 +1,40 @@
+package eu.faircode.netguard;
+
+/**
+ * What happens when the device enters or leaves Doze.
+ *
+ * <p>Leaving Doze used to reload unconditionally. That was inherited from NetGuard and had
+ * no purpose here: nothing in rule building depends on idle state, while the reload's
+ * "Native restart" path calls {@code jni_clear}, which closes the socket of every live
+ * session. Every maintenance window therefore dropped all connections for all apps, and
+ * charged a wakelock, a rule rebuild and a full {@code access} table rescan for it.
+ *
+ * <p>What genuinely has to happen on the way out of Doze is the screen-state keepalive
+ * policy, which the WireGuard egress owns. The reload survives only as a recovery net for
+ * the case where the VPN really did die while the device was idle — protection enabled but
+ * no established tunnel — since nothing else would notice until the next network event.
+ */
+final class IdleStatePolicy {
+    interface Callbacks {
+        void onWireGuardInteractiveStateChanged(boolean interactive);
+
+        void onReload();
+    }
+
+    private IdleStatePolicy() {
+    }
+
+    /**
+     * @param recoveryCondition protection is enabled but no VPN is established, i.e. the
+     *                          only case in which leaving Doze should still reload
+     */
+    static void onDeviceIdleModeChanged(boolean deviceIdleMode, boolean recoveryCondition,
+                                        boolean interactive, Callbacks callbacks) {
+        if (deviceIdleMode)
+            return;
+
+        callbacks.onWireGuardInteractiveStateChanged(interactive);
+        if (recoveryCondition)
+            callbacks.onReload();
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -110,12 +110,18 @@ public class Rule {
     public boolean expanded = false;
 
     private static List<PackageInfo> cachePackageInfo = null;
-    private static Map<PackageInfo, String> cacheLabel = new HashMap<>();
-    private static Map<String, Boolean> cacheSystem = new HashMap<>();
+    // ConcurrentHashMap + computeIfAbsent: isSystem() is called from the
+    // packet path (ServiceSinkhole.isAddressAllowed) while clearCache() runs
+    // from package-change broadcasts on another thread. A plain HashMap with
+    // separate containsKey()/get() calls let a concurrent clear() land
+    // between them, auto-unboxing a null Boolean into an NPE inside a JNI
+    // callback; computeIfAbsent() makes the lookup-or-compute atomic instead.
+    private static Map<PackageInfo, String> cacheLabel = new java.util.concurrent.ConcurrentHashMap<>();
+    private static Map<String, Boolean> cacheSystem = new java.util.concurrent.ConcurrentHashMap<>();
     private static final Object predefinedLock = new Object();
     private static PredefinedRules cachePredefinedRules;
-    private static Map<String, Boolean> cacheInternet = new HashMap<>();
-    private static Map<PackageInfo, Boolean> cacheEnabled = new HashMap<>();
+    private static Map<String, Boolean> cacheInternet = new java.util.concurrent.ConcurrentHashMap<>();
+    private static Map<PackageInfo, Boolean> cacheEnabled = new java.util.concurrent.ConcurrentHashMap<>();
     private static Map<Integer, Long> trackerRecent = new HashMap<>();
 
     private static final class PredefinedRules {
@@ -139,20 +145,18 @@ public class Rule {
     }
 
     private static String getLabel(PackageInfo info, Context context) {
-        if (!cacheLabel.containsKey(info)) {
+        return cacheLabel.computeIfAbsent(info, i -> {
             PackageManager pm = context.getPackageManager();
-            cacheLabel.put(info, info.applicationInfo.loadLabel(pm).toString());
-        }
-        return cacheLabel.get(info);
+            return i.applicationInfo.loadLabel(pm).toString();
+        });
     }
 
     public static boolean isSystem(String packageName, Context context) {
-        if (!cacheSystem.containsKey(packageName)) {
-            boolean system = Util.isSystem(packageName, context);
-            Boolean predefined = getPredefinedRules(context).system.get(packageName);
-            cacheSystem.put(packageName, resolveSystemClassification(system, predefined));
-        }
-        return cacheSystem.get(packageName);
+        return cacheSystem.computeIfAbsent(packageName, pkg -> {
+            boolean system = Util.isSystem(pkg, context);
+            Boolean predefined = getPredefinedRules(context).system.get(pkg);
+            return resolveSystemClassification(system, predefined);
+        });
     }
 
     static boolean resolveSystemClassification(boolean system, Boolean predefined) {
@@ -255,15 +259,11 @@ public class Rule {
     }
 
     private static boolean hasInternet(String packageName, Context context) {
-        if (!cacheInternet.containsKey(packageName))
-            cacheInternet.put(packageName, Util.hasInternet(packageName, context));
-        return cacheInternet.get(packageName);
+        return cacheInternet.computeIfAbsent(packageName, pkg -> Util.hasInternet(pkg, context));
     }
 
     private static boolean isEnabled(PackageInfo info, Context context) {
-        if (!cacheEnabled.containsKey(info))
-            cacheEnabled.put(info, Util.isEnabled(info, context));
-        return cacheEnabled.get(info);
+        return cacheEnabled.computeIfAbsent(info, i -> Util.isEnabled(i, context));
     }
 
     public static void clearCache(Context context) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -498,7 +498,11 @@ public class ServiceSinkhole extends VpnService {
             String f = prefs.getString("pcap_file_size", null);
             if (TextUtils.isEmpty(f))
                 f = "2";
-            file_size = Integer.parseInt(f) * 1024 * 1024;
+            // jni_pcap takes a jint, so compute in long first: an in-int
+            // multiplication of a few thousand (MB) overflows to a negative
+            // file size, which native then truncates on every write.
+            long sizeBytes = Long.parseLong(f) * 1024 * 1024;
+            file_size = (int) Math.min(sizeBytes, Integer.MAX_VALUE);
         } catch (Throwable ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
         }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3319,13 +3319,28 @@ public class ServiceSinkhole extends VpnService {
             Util.logExtras(intent);
 
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            Log.i(TAG, "device idle=" + pm.isDeviceIdleMode());
+            boolean deviceIdleMode = pm.isDeviceIdleMode();
+            Log.i(TAG, "device idle=" + deviceIdleMode);
 
-            // Reload rules when coming from idle mode
-            if (!pm.isDeviceIdleMode()) {
-                reload("idle state changed", ServiceSinkhole.this, false);
-                updateWireGuardInteractiveState(Util.isInteractive(ServiceSinkhole.this));
-            }
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
+            IdleStatePolicy.onDeviceIdleModeChanged(
+                    deviceIdleMode,
+                    prefs.getBoolean("enabled", false) && vpn == null,
+                    Util.isInteractive(ServiceSinkhole.this),
+                    new IdleStatePolicy.Callbacks() {
+                        @Override
+                        public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                            updateWireGuardInteractiveState(interactive);
+                        }
+
+                        @Override
+                        public void onReload() {
+                            // Only reached when the VPN died while the device was idle. A
+                            // reload on every Doze exit closed every native session, so
+                            // apps reconnected after each maintenance window for nothing.
+                            reload("idle state changed", ServiceSinkhole.this, false);
+                        }
+                    });
         }
     };
 

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2293,9 +2293,21 @@ public class ServiceSinkhole extends VpnService {
             }
             tunnelThread = null;
 
-            jni_clear(jni_context);
-
             Log.i(TAG, "Stopped tunnel thread");
+        }
+
+        // Clear the session list even when there was no thread to join. When
+        // jni_run() returns on a native error the tunnel thread nulls
+        // tunnelThread itself, so the recovery restart arrives here with
+        // nothing to stop — but the context still holds every session that run
+        // built up. jni_start() keeps ctx->ng_session, and the new epoll
+        // instance registers only the pipe and tun, so those UDP/ICMP sockets
+        // would never be polled again while still holding their descriptors.
+        // Nothing can race this: either the thread was joined above, or it has
+        // already exited.
+        synchronized (jni_lock) {
+            if (jni_context != 0)
+                jni_clear(jni_context);
         }
 
         // NOTE: WireGuard is intentionally NOT torn down here. NetGuard's
@@ -4233,6 +4245,22 @@ public class ServiceSinkhole extends VpnService {
                     vpn = null;
                     unprepare();
                 }
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
+
+            // Final teardown of the egress side, mirroring CommandHandler.stop().
+            // Only that command path used to do this, so a destroy that did not
+            // come through it — a system revoke (onRevoke -> stopSelf), or
+            // stopService — left the Rust tunnel, its duplicated descriptors,
+            // the connectivity monitor and callbacks capturing this now-dead
+            // service alive until some later start replaced them. Both stops
+            // are idempotent, and both must precede jni_done() below.
+            try {
+                net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.stop(
+                        () -> { jni_wireguard_stop(); return kotlin.Unit.INSTANCE; });
+                jni_wireguard_required(false);
+                net.kollnig.missioncontrol.dns.DnsProxyServer.getInstance(ServiceSinkhole.this).stop();
             } catch (Throwable ex) {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -1,5 +1,6 @@
 package net.kollnig.missioncontrol;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -187,9 +188,14 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
                 .setTitle(R.string.setting_wg_proton_setup)
                 .setMessage(R.string.msg_wg_proton_note)
                 .setNegativeButton(android.R.string.cancel, null)
-                .setNeutralButton(R.string.msg_wg_proton_open_dashboard, (dialog, which) ->
+                .setNeutralButton(R.string.msg_wg_proton_open_dashboard, (dialog, which) -> {
+                    try {
                         startActivity(new Intent(Intent.ACTION_VIEW,
-                                Uri.parse(PROTON_DASHBOARD_URL))))
+                                Uri.parse(PROTON_DASHBOARD_URL)));
+                    } catch (ActivityNotFoundException ex) {
+                        Toast.makeText(this, R.string.msg_no_browser, Toast.LENGTH_LONG).show();
+                    }
+                })
                 .setPositiveButton(R.string.setting_wg_profile_import, (dialog, which) ->
                         showProfileDialog(null))
                 .show();

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -17,14 +17,11 @@
 
 package net.kollnig.missioncontrol;
 
-import static net.kollnig.missioncontrol.data.InternetBlocklist.SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY;
-import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
 import static net.kollnig.missioncontrol.data.TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY;
 
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
-import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -68,7 +65,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 
 import eu.faircode.netguard.DatabaseHelper;
 import eu.faircode.netguard.Util;
@@ -91,19 +87,15 @@ public class DetailsActivity extends AppCompatActivity {
      * @param c The context
      */
     public static void savePrefs(Context c) {
-        SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
-
         // Tracker settings
         TrackerBlocklist b = TrackerBlocklist.getInstance(c);
         b.saveSettings(c);
 
-        // Internet settings
-        SharedPreferences.Editor editor = prefs.edit();
-        InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(c);
-        Set<String> internetSet = Common.intToStringSet(internetBlocklist.getBlocklist());
-        editor.putStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, internetSet);
-
-        editor.apply();
+        // Internet settings. Goes through InternetBlocklist.saveSettings
+        // rather than reading getBlocklist() (resolved UIDs only), so
+        // entries for an app that is not installed yet stay in prefs
+        // instead of being dropped on every save.
+        InternetBlocklist.getInstance(c).saveSettings(c);
     }
 
     @Override

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -17,10 +17,6 @@
 
 package net.kollnig.missioncontrol;
 
-import static net.kollnig.missioncontrol.data.InternetBlocklist.SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY;
-import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
-import static net.kollnig.missioncontrol.data.TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY;
-
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -68,7 +64,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 
 import eu.faircode.netguard.DatabaseHelper;
 import eu.faircode.netguard.Util;
@@ -91,19 +86,15 @@ public class DetailsActivity extends AppCompatActivity {
      * @param c The context
      */
     public static void savePrefs(Context c) {
-        SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
-
         // Tracker settings
         TrackerBlocklist b = TrackerBlocklist.getInstance(c);
         b.saveSettings(c);
 
-        // Internet settings
-        SharedPreferences.Editor editor = prefs.edit();
-        InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(c);
-        Set<String> internetSet = Common.intToStringSet(internetBlocklist.getBlocklist());
-        editor.putStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, internetSet);
-
-        editor.apply();
+        // Internet settings. Routed through InternetBlocklist itself so that
+        // package names pending resolution (apps blocked while not yet
+        // installed) are persisted alongside the resolved UIDs, rather than
+        // being dropped by a numeric-only rewrite of the preference.
+        InternetBlocklist.getInstance(c).saveSettings(c);
     }
 
     @Override

--- a/app/src/main/java/net/kollnig/missioncontrol/details/ActionsFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/ActionsFragment.java
@@ -156,7 +156,13 @@ public class ActionsFragment extends Fragment {
             sendEmail(getString(R.string.google_dpo_mail), null, null);
         } else if (id == R.id.btnContactOfficials) {
             Intent browserIntent = Common.browse(getString(R.string.dpas_overview_url));
-            startActivity(browserIntent);
+            try {
+                startActivity(browserIntent);
+            } catch (android.content.ActivityNotFoundException ex) {
+                View v = getView();
+                if (v != null)
+                    Snackbar.make(v, R.string.msg_no_browser, Snackbar.LENGTH_LONG).show();
+            }
         }
     }
 

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -172,7 +172,17 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
             log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed during init");
     }
     atomic_store_explicit(&wg_required, 0, memory_order_release);
-    pcap_file = NULL;
+
+    // A prior instance in this process may have left a capture open (jni_done
+    // does not necessarily run before a fresh jni_init, e.g. process reuse);
+    // never just overwrite the pointer and leak the fd.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        pcap_close_locked();
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
 
     if (pthread_mutex_init(&ctx->lock, NULL))
         log_android(ANDROID_LOG_ERROR, "pthread_mutex_init failed");
@@ -309,24 +319,14 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
     pcap_record_size = (size_t) record_size;
     pcap_file_size = file_size;
 
-    //if (pthread_mutex_lock(&lock))
-    //    log_android(ANDROID_LOG_ERROR, "pthread_mutex_lock failed");
+    // Guards pcap_file (and the two settings above) against the packet
+    // threads, which check pcap_file and write through it via
+    // write_pcap_rec() without otherwise synchronizing with this function.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
 
     if (name_ == NULL) {
-        if (pcap_file != NULL) {
-            int flags = fcntl(fileno(pcap_file), F_GETFL, 0);
-            if (flags < 0 || fcntl(fileno(pcap_file), F_SETFL, flags & ~O_NONBLOCK) < 0)
-                log_android(ANDROID_LOG_ERROR, "PCAP fcntl ~O_NONBLOCK error %d: %s",
-                            errno, strerror(errno));
-
-            if (fsync(fileno(pcap_file)))
-                log_android(ANDROID_LOG_ERROR, "PCAP fsync error %d: %s", errno, strerror(errno));
-
-            if (fclose(pcap_file))
-                log_android(ANDROID_LOG_ERROR, "PCAP fclose error %d: %s", errno, strerror(errno));
-
-            pcap_file = NULL;
-        }
+        pcap_close_locked();
         log_android(ANDROID_LOG_WARN, "PCAP disabled");
     } else {
         const char *name = (*env)->GetStringUTFChars(env, name_, 0);
@@ -346,7 +346,7 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
             long size = ftell(pcap_file);
             if (size == 0) {
                 log_android(ANDROID_LOG_WARN, "PCAP initialize");
-                write_pcap_hdr();
+                write_pcap_hdr_locked();
             } else
                 log_android(ANDROID_LOG_WARN, "PCAP current size %ld", size);
         }
@@ -355,8 +355,8 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
         ng_delete_alloc(name, __FILE__, __LINE__);
     }
 
-    //if (pthread_mutex_unlock(&lock))
-    //    log_android(ANDROID_LOG_ERROR, "pthread_mutex_unlock failed");
+    if (pthread_mutex_unlock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
 }
 
 JNIEXPORT void JNICALL
@@ -522,6 +522,16 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1done(
     log_android(ANDROID_LOG_INFO, "Done");
 
     clear(ctx);
+
+    // Service teardown: any capture still enabled must be flushed and closed
+    // here, since nothing else closes it once this context goes away.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        pcap_close_locked();
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
 
     if (pthread_mutex_destroy(&ctx->lock))
         log_android(ANDROID_LOG_ERROR, "pthread_mutex_destroy failed");
@@ -959,7 +969,11 @@ struct allowed *is_address_allowed(const struct arguments *args, jobject jpacket
         else {
             const char *raddr = (*args->env)->GetStringUTFChars(args->env, jraddr, NULL);
             ng_add_alloc(raddr, "raddr");
-            strcpy(allowed.raddr, raddr);
+            // Defense in depth: allowed.raddr is a fixed INET6_ADDRSTRLEN
+            // buffer. The Java caller is expected to hand back a numeric
+            // address, but never trust that from native code.
+            strncpy(allowed.raddr, raddr, sizeof(allowed.raddr) - 1);
+            allowed.raddr[sizeof(allowed.raddr) - 1] = 0;
             (*args->env)->ReleaseStringUTFChars(args->env, jraddr, raddr);
             ng_delete_alloc(raddr, __FILE__, __LINE__);
         }

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -600,11 +600,14 @@ jobject create_packet(const struct arguments *args,
 void account_usage(const struct arguments *args, jint version, jint protocol,
                    const char *daddr, jint dport, jint uid, jlong sent, jlong received);
 
-void write_pcap_hdr();
+extern pthread_mutex_t pcap_lock;
+
+// Caller must hold pcap_lock; see pcap.c.
+void write_pcap_hdr_locked();
+
+void pcap_close_locked();
 
 void write_pcap_rec(const uint8_t *buffer, size_t len);
-
-void write_pcap(const void *ptr, size_t len);
 
 int compare_u32(uint32_t seq1, uint32_t seq2);
 

--- a/app/src/main/jni/netguard/pcap.c
+++ b/app/src/main/jni/netguard/pcap.c
@@ -23,40 +23,15 @@ FILE *pcap_file = NULL;
 size_t pcap_record_size = 64;
 long pcap_file_size = 2 * 1024 * 1024;
 
-void write_pcap_hdr() {
-    struct pcap_hdr_s pcap_hdr;
-    pcap_hdr.magic_number = 0xa1b2c3d4;
-    pcap_hdr.version_major = 2;
-    pcap_hdr.version_minor = 4;
-    pcap_hdr.thiszone = 0;
-    pcap_hdr.sigfigs = 0;
-    pcap_hdr.snaplen = pcap_record_size;
-    pcap_hdr.network = LINKTYPE_RAW;
-    write_pcap(&pcap_hdr, sizeof(struct pcap_hdr_s));
-}
+// Guards pcap_file (open/close/write) against concurrent access from the
+// packet threads (write_pcap_rec, from ip.c/tcp.c/udp.c/icmp.c) and whatever
+// thread toggles capture via jni_pcap()/jni_init()/jni_done(). Every function
+// below that touches pcap_file either takes this lock itself or is documented
+// as requiring the caller to already hold it.
+pthread_mutex_t pcap_lock = PTHREAD_MUTEX_INITIALIZER;
 
-void write_pcap_rec(const uint8_t *buffer, size_t length) {
-    struct timespec ts;
-    if (clock_gettime(CLOCK_REALTIME, &ts))
-        log_android(ANDROID_LOG_ERROR, "clock_gettime error %d: %s", errno, strerror(errno));
-
-    size_t plen = (length < pcap_record_size ? length : pcap_record_size);
-    size_t rlen = sizeof(struct pcaprec_hdr_s) + plen;
-    struct pcaprec_hdr_s *pcap_rec = ng_malloc(rlen, "pcap");
-
-    pcap_rec->ts_sec = (guint32_t) ts.tv_sec;
-    pcap_rec->ts_usec = (guint32_t) (ts.tv_nsec / 1000);
-    pcap_rec->incl_len = (guint32_t) plen;
-    pcap_rec->orig_len = (guint32_t) length;
-
-    memcpy(((uint8_t *) pcap_rec) + sizeof(struct pcaprec_hdr_s), buffer, plen);
-
-    write_pcap(pcap_rec, rlen);
-
-    ng_free(pcap_rec, __FILE__, __LINE__);
-}
-
-void write_pcap(const void *ptr, size_t len) {
+// Caller must hold pcap_lock and pcap_file must be non-NULL.
+static void write_pcap_locked(const void *ptr, size_t len) {
     if (fwrite(ptr, len, 1, pcap_file) < 1)
         log_android(ANDROID_LOG_ERROR, "PCAP fwrite error %d: %s", errno, strerror(errno));
     else {
@@ -78,4 +53,65 @@ void write_pcap(const void *ptr, size_t len) {
             }
         }
     }
+}
+
+// Caller must hold pcap_lock and pcap_file must be non-NULL (called from
+// jni_pcap() right after opening a fresh capture file, under the same lock).
+void write_pcap_hdr_locked() {
+    struct pcap_hdr_s pcap_hdr;
+    pcap_hdr.magic_number = 0xa1b2c3d4;
+    pcap_hdr.version_major = 2;
+    pcap_hdr.version_minor = 4;
+    pcap_hdr.thiszone = 0;
+    pcap_hdr.sigfigs = 0;
+    pcap_hdr.snaplen = pcap_record_size;
+    pcap_hdr.network = LINKTYPE_RAW;
+    write_pcap_locked(&pcap_hdr, sizeof(struct pcap_hdr_s));
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts))
+        log_android(ANDROID_LOG_ERROR, "clock_gettime error %d: %s", errno, strerror(errno));
+
+    size_t plen = (length < pcap_record_size ? length : pcap_record_size);
+    size_t rlen = sizeof(struct pcaprec_hdr_s) + plen;
+    struct pcaprec_hdr_s *pcap_rec = ng_malloc(rlen, "pcap");
+
+    pcap_rec->ts_sec = (guint32_t) ts.tv_sec;
+    pcap_rec->ts_usec = (guint32_t) (ts.tv_nsec / 1000);
+    pcap_rec->incl_len = (guint32_t) plen;
+    pcap_rec->orig_len = (guint32_t) length;
+
+    memcpy(((uint8_t *) pcap_rec) + sizeof(struct pcaprec_hdr_s), buffer, plen);
+
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        if (pcap_file != NULL)
+            write_pcap_locked(pcap_rec, rlen);
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
+
+    ng_free(pcap_rec, __FILE__, __LINE__);
+}
+
+// Closes pcap_file if open. Caller must hold pcap_lock.
+void pcap_close_locked() {
+    if (pcap_file == NULL)
+        return;
+
+    int flags = fcntl(fileno(pcap_file), F_GETFL, 0);
+    if (flags < 0 || fcntl(fileno(pcap_file), F_SETFL, flags & ~O_NONBLOCK) < 0)
+        log_android(ANDROID_LOG_ERROR, "PCAP fcntl ~O_NONBLOCK error %d: %s",
+                    errno, strerror(errno));
+
+    if (fsync(fileno(pcap_file)))
+        log_android(ANDROID_LOG_ERROR, "PCAP fsync error %d: %s", errno, strerror(errno));
+
+    if (fclose(pcap_file))
+        log_android(ANDROID_LOG_ERROR, "PCAP fclose error %d: %s", errno, strerror(errno));
+
+    pcap_file = NULL;
 }

--- a/app/src/main/jni/netguard/session.c
+++ b/app/src/main/jni/netguard/session.c
@@ -125,6 +125,12 @@ void *handle_events(void *a) {
         if (ms - last_check > EPOLL_MIN_CHECK) {
             last_check = ms;
 
+            // jni_get_stats() (netguard.c) walks ctx->ng_session under this
+            // same lock from the stats-reporting thread; take it here too so
+            // a session freed below can never be a session it is reading.
+            if (pthread_mutex_lock(&args->ctx->lock))
+                log_android(ANDROID_LOG_ERROR, "pthread_mutex_lock failed");
+
             time_t now = time(NULL);
             struct ng_session *sl = NULL;
             s = args->ctx->ng_session;
@@ -172,6 +178,9 @@ void *handle_events(void *a) {
                     s = s->next;
                 }
             }
+
+            if (pthread_mutex_unlock(&args->ctx->lock))
+                log_android(ANDROID_LOG_ERROR, "pthread_mutex_unlock failed");
         } else {
             recheck = 1;
             log_android(ANDROID_LOG_DEBUG, "Skipped session checks");

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -837,7 +837,9 @@ jboolean handle_tcp(const struct arguments *args,
             // Open socket
             s->socket = open_tcp_socket(args, &s->tcp, redirect);
             if (s->socket < 0) {
-                // Remote might retry
+                // Remote might retry. Any segment queued from SYN data above
+                // belongs to this session and is freed with it.
+                clear_tcp_data(&s->tcp);
                 ng_free(s, __FILE__, __LINE__);
                 return 0;
             }
@@ -1118,8 +1120,10 @@ int open_tcp_socket(const struct arguments *args,
     }
 
     // Protect
-    if (protect_socket(args, sock) < 0)
+    if (protect_socket(args, sock) < 0) {
+        close(sock);
         return -1;
+    }
 
     int on = 1;
     if (setsockopt(sock, SOL_TCP, TCP_NODELAY, &on, sizeof(on)) < 0)
@@ -1131,6 +1135,7 @@ int open_tcp_socket(const struct arguments *args,
     if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
         log_android(ANDROID_LOG_ERROR, "fcntl socket O_NONBLOCK error %d: %s",
                     errno, strerror(errno));
+        close(sock);
         return -1;
     }
 
@@ -1186,6 +1191,7 @@ int open_tcp_socket(const struct arguments *args,
                                    : sizeof(struct sockaddr_in6)));
     if (err < 0 && errno != EINPROGRESS) {
         log_android(ANDROID_LOG_ERROR, "connect error %d: %s", errno, strerror(errno));
+        close(sock);
         return -1;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,6 +364,7 @@
     <string name="msg_installed_n">Has been installed</string>
     <string name="msg_completed">Action completed</string>
     <string name="msg_no_file_manager">No file manager found to pick a file.</string>
+    <string name="msg_no_browser">No browser app found to open the link.</string>
     <string name="msg_vpn">TrackerControl uses a local VPN to filter internet traffic.
 For this reason, please allow a VPN connection in the next dialog.
 Your internet traffic is not being sent to a remote VPN server.</string>

--- a/app/src/test/java/eu/faircode/netguard/IdleStatePolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/IdleStatePolicyTest.java
@@ -1,0 +1,82 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IdleStatePolicyTest {
+    @Test
+    public void healthyVpnUpdatesWireGuardWithoutReload() {
+        boolean[] wireGuardInteractive = {false};
+        boolean[] reload = {false};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                false,
+                false,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        wireGuardInteractive[0] = interactive;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        reload[0] = true;
+                    }
+                });
+
+        assertTrue(wireGuardInteractive[0]);
+        assertFalse(reload[0]);
+    }
+
+    @Test
+    public void enabledWithoutVpnReloadsAfterIdle() {
+        boolean[] wireGuardUpdated = {false};
+        boolean[] reload = {false};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                false,
+                true,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        wireGuardUpdated[0] = true;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        reload[0] = true;
+                    }
+                });
+
+        assertTrue(wireGuardUpdated[0]);
+        assertTrue(reload[0]);
+    }
+
+    @Test
+    public void enteringIdleDoesNothing() {
+        int[] callbacks = {0};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                true,
+                true,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        callbacks[0]++;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        callbacks[0]++;
+                    }
+                });
+
+        assertEquals(0, callbacks[0]);
+    }
+}

--- a/wgbridge-rs/Cargo.lock
+++ b/wgbridge-rs/Cargo.lock
@@ -405,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "gotatun"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121650b305d0ee6d45b08bbec1d5781a43b915a0a89a2fd869028647eb475cc9"
+checksum = "e9275d1c102aab3fa53182a0a55daff1f19eebf13e7aff336bec0c3c02e56658"
 dependencies = [
  "aead",
  "base64 0.22.1",
@@ -567,9 +567,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "memchr"

--- a/wgbridge-rs/Cargo.toml
+++ b/wgbridge-rs/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 tc-dns = { path = "tc-dns" }
-gotatun = { version = "=0.9.0", default-features = false, features = ["ring", "device"] }
+gotatun = { version = "=0.9.1", default-features = false, features = ["ring", "device"] }
 tokio = { version = "1.43", features = ["rt-multi-thread", "net", "sync", "time", "macros"] }
 base64 = "0.23"
 hex = "0.4"


### PR DESCRIPTION
## Context

A read-only rollout-readiness review of the recent Compose migration (everything unreleased since tag `2026080501`) found two release blockers, verified independently against the source and history rather than taken on trust from the review agents. `#883` (the `ProtectionActivity` ANR) is a separate, already-open fix and out of scope here.

## Changes

- **Unguarded browser intents crash without a browser app.** `ActivityWireGuardProfiles.showProtonDialog()`'s "Open Proton VPN dashboard" button and `ActionsFragment`'s "Contact officials" link both called `startActivity()` on an implicit `ACTION_VIEW` with no resolver check, throwing `ActivityNotFoundException` on a device with no browser (e.g. a fresh emulator or a locked-down device). Both now catch it and show a message (`msg_no_browser`), matching the existing pattern used elsewhere in the app (`ActivitySettings`, `ActionsFragment.sendEmail`).
- **Details screen silently dropped pending internet-block entries.** `DetailsActivity.savePrefs()` (called from `ProtectionActivity.onPause()` and `DetailsActivity.onPause()`) rebuilt the internet blocklist from `InternetBlocklist.getBlocklist()`, which only returns resolved UIDs. An entry restored for an app that is not yet installed — kept in `InternetBlocklist`'s raw map so it can resolve once the app installs — was silently dropped every time the details screen saved. It now calls `InternetBlocklist.saveSettings(c)` directly, the same path `TrackerBlocklist` already uses, which persists both the resolved and raw maps.

## Test plan

- [x] Read the full diff and the surrounding code paths (`InternetBlocklist`/`UidKeyedStore`, the app-wide `ActivityNotFoundException` handling convention) to confirm both fixes are correct and consistent with existing style.
- [ ] `./gradlew :app:compileGithubDebugJavaWithJavac` and `:app:testGithubDebugUnitTest` — not run: no Android SDK in this environment. Please run before merging.
- [ ] Manual smoke test: open WireGuard profiles → Add via Proton on a browser-less device/profile; open per-app Actions → Contact officials the same way.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5kkz8ZLi8yraa1pTd924R

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5kkz8ZLi8yraa1pTd924R)_