### PR TITLE
Persist unresolved package names when saving details-screen blocklist

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -17,10 +17,6 @@
 
 package net.kollnig.missioncontrol;
 
-import static net.kollnig.missioncontrol.data.InternetBlocklist.SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY;
-import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
-import static net.kollnig.missioncontrol.data.TrackerBlocklist.SHARED_PREFS_BLOCKLIST_APPS_KEY;
-
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -68,7 +64,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import java.util.Set;
 
 import eu.faircode.netguard.DatabaseHelper;
 import eu.faircode.netguard.Util;
@@ -91,19 +86,15 @@ public class DetailsActivity extends AppCompatActivity {
      * @param c The context
      */
     public static void savePrefs(Context c) {
-        SharedPreferences prefs = c.getSharedPreferences(PREF_BLOCKLIST, Context.MODE_PRIVATE);
-
         // Tracker settings
         TrackerBlocklist b = TrackerBlocklist.getInstance(c);
         b.saveSettings(c);
 
-        // Internet settings
-        SharedPreferences.Editor editor = prefs.edit();
-        InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(c);
-        Set<String> internetSet = Common.intToStringSet(internetBlocklist.getBlocklist());
-        editor.putStringSet(SHARED_PREFS_INTERNET_BLOCKLIST_APPS_KEY, internetSet);
-
-        editor.apply();
+        // Internet settings. Routed through InternetBlocklist itself so that
+        // package names pending resolution (apps blocked while not yet
+        // installed) are persisted alongside the resolved UIDs, rather than
+        // being dropped by a numeric-only rewrite of the preference.
+        InternetBlocklist.getInstance(c).saveSettings(c);
     }
 
     @Override


### PR DESCRIPTION
## What

Follow-up from a pre-release review of recent non-UI changes on `master`. Fixes one of the findings: `DetailsActivity.savePrefs()` rewrote the internet-blocklist preference from `InternetBlocklist.getBlocklist()`, which only exposes resolved UIDs.

## Why it matters

`InternetBlocklist` retains package names it can't yet resolve to a UID (an app blocked by a restored backup while not yet installed) in `rawBlockmap`, so it can resolve them once the app is installed. But `DetailsActivity.savePrefs()` — called whenever the details screen saves state — rewrote the same preference key from the numeric UID set alone, silently dropping any pending package-name entries the moment the screen was opened and left.

## Fix

Route the save through `InternetBlocklist.saveSettings(c)`, which already persists both the resolved UIDs and the pending package names, rather than duplicating a narrower version of the same write in `DetailsActivity`. Also drops the now-unused imports this left behind.

## Test plan

- [x] Diff reviewed against `InternetBlocklist.saveSettings`/`loadSettings` to confirm the write is a strict superset of the previous behaviour
- [ ] `./gradlew :app:compileGithubDebugJavaWithJavac` — not run: no Android SDK in this container
- [ ] `./gradlew :app:testGithubDebugUnitTest` — not run: no Android SDK in this container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YMogX7yY8rM2eio7Kxux3K

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMogX7yY8rM2eio7Kxux3K)_