### PR TITLE
Stop clearing every network session when the device leaves Doze

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/IdleStatePolicy.java
+++ b/app/src/main/java/eu/faircode/netguard/IdleStatePolicy.java
@@ -1,0 +1,40 @@
+package eu.faircode.netguard;
+
+/**
+ * What happens when the device enters or leaves Doze.
+ *
+ * <p>Leaving Doze used to reload unconditionally. That was inherited from NetGuard and had
+ * no purpose here: nothing in rule building depends on idle state, while the reload's
+ * "Native restart" path calls {@code jni_clear}, which closes the socket of every live
+ * session. Every maintenance window therefore dropped all connections for all apps, and
+ * charged a wakelock, a rule rebuild and a full {@code access} table rescan for it.
+ *
+ * <p>What genuinely has to happen on the way out of Doze is the screen-state keepalive
+ * policy, which the WireGuard egress owns. The reload survives only as a recovery net for
+ * the case where the VPN really did die while the device was idle — protection enabled but
+ * no established tunnel — since nothing else would notice until the next network event.
+ */
+final class IdleStatePolicy {
+    interface Callbacks {
+        void onWireGuardInteractiveStateChanged(boolean interactive);
+
+        void onReload();
+    }
+
+    private IdleStatePolicy() {
+    }
+
+    /**
+     * @param recoveryCondition protection is enabled but no VPN is established, i.e. the
+     *                          only case in which leaving Doze should still reload
+     */
+    static void onDeviceIdleModeChanged(boolean deviceIdleMode, boolean recoveryCondition,
+                                        boolean interactive, Callbacks callbacks) {
+        if (deviceIdleMode)
+            return;
+
+        callbacks.onWireGuardInteractiveStateChanged(interactive);
+        if (recoveryCondition)
+            callbacks.onReload();
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3319,13 +3319,28 @@ public class ServiceSinkhole extends VpnService {
             Util.logExtras(intent);
 
             PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            Log.i(TAG, "device idle=" + pm.isDeviceIdleMode());
+            boolean deviceIdleMode = pm.isDeviceIdleMode();
+            Log.i(TAG, "device idle=" + deviceIdleMode);
 
-            // Reload rules when coming from idle mode
-            if (!pm.isDeviceIdleMode()) {
-                reload("idle state changed", ServiceSinkhole.this, false);
-                updateWireGuardInteractiveState(Util.isInteractive(ServiceSinkhole.this));
-            }
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this);
+            IdleStatePolicy.onDeviceIdleModeChanged(
+                    deviceIdleMode,
+                    prefs.getBoolean("enabled", false) && vpn == null,
+                    Util.isInteractive(ServiceSinkhole.this),
+                    new IdleStatePolicy.Callbacks() {
+                        @Override
+                        public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                            updateWireGuardInteractiveState(interactive);
+                        }
+
+                        @Override
+                        public void onReload() {
+                            // Only reached when the VPN died while the device was idle. A
+                            // reload on every Doze exit closed every native session, so
+                            // apps reconnected after each maintenance window for nothing.
+                            reload("idle state changed", ServiceSinkhole.this, false);
+                        }
+                    });
         }
     };
 

--- a/app/src/test/java/eu/faircode/netguard/IdleStatePolicyTest.java
+++ b/app/src/test/java/eu/faircode/netguard/IdleStatePolicyTest.java
@@ -1,0 +1,82 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class IdleStatePolicyTest {
+    @Test
+    public void healthyVpnUpdatesWireGuardWithoutReload() {
+        boolean[] wireGuardInteractive = {false};
+        boolean[] reload = {false};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                false,
+                false,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        wireGuardInteractive[0] = interactive;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        reload[0] = true;
+                    }
+                });
+
+        assertTrue(wireGuardInteractive[0]);
+        assertFalse(reload[0]);
+    }
+
+    @Test
+    public void enabledWithoutVpnReloadsAfterIdle() {
+        boolean[] wireGuardUpdated = {false};
+        boolean[] reload = {false};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                false,
+                true,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        wireGuardUpdated[0] = true;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        reload[0] = true;
+                    }
+                });
+
+        assertTrue(wireGuardUpdated[0]);
+        assertTrue(reload[0]);
+    }
+
+    @Test
+    public void enteringIdleDoesNothing() {
+        int[] callbacks = {0};
+
+        IdleStatePolicy.onDeviceIdleModeChanged(
+                true,
+                true,
+                true,
+                new IdleStatePolicy.Callbacks() {
+                    @Override
+                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                        callbacks[0]++;
+                    }
+
+                    @Override
+                    public void onReload() {
+                        callbacks[0]++;
+                    }
+                });
+
+        assertEquals(0, callbacks[0]);
+    }
+}


### PR DESCRIPTION
## What

Leaving Doze no longer reloads the VPN. It now only re-applies the screen-state WireGuard
keepalive policy, and reloads solely as a recovery net when protection is enabled but no
tunnel is established.

## Why

`idleStateReceiver` called `reload("idle state changed", ...)` on every exit from idle
mode. That reload reaches `CommandHandler.reload()`, which — when the VpnService builder is
unchanged, i.e. the normal case — takes the "Native restart" path:
`stopNative(vpn)` → `jni_stop` + thread join + `jni_clear`. `jni_clear` reaches `clear()`
in `jni/netguard/session.c`, which closes the socket of **every** live session and frees it.

So each Doze maintenance window killed every TCP/UDP session for every app, and they all
had to be re-established. The same reload also took the service wakelock, re-ran
`Rule.getRules`, re-parsed the blocklist through `prepareHostsBlocked`, and rescanned the
whole `access` table via `prepareUidIPFilters(null)`.

Nothing in rule building depends on Doze state. The call is inherited from NetGuard and
served no purpose here beyond acting as an accidental crash-recovery net, so that is the
only part kept.

## How

Adds `IdleStatePolicy`, following the existing `InteractiveStatePolicy` /
`NetworkReloadPolicy` / `VpnRevokePolicy` pattern: a pure, package-private decision
function driven through a `Callbacks` interface, unit-testable on a plain JVM.

Decision table:

| Event | WireGuard interactive update | Reload |
|---|---|---|
| Entering idle | no | no |
| Leaving idle, VPN established | yes | no |
| Leaving idle, enabled but `vpn == null` | yes | yes |

The recovery condition is deliberately just `enabled && vpn == null`. It does not also
check `user_foreground`, `temporarilyStopped` or `state == enforcing` — the reload path
re-checks those itself, and duplicating them here is how the gate would become
unsatisfiable and leave a genuinely dead VPN unrecovered.

## Testing

- `./gradlew :app:compileGithubDebugJavaWithJavac` — passes
- `./gradlew :app:testGithubDebugUnitTest` — 408 tests across 59 suites, 0 failures

New `IdleStatePolicyTest` covers all three rows of the table above.

Not exercised on a device: no device or emulator is available in this environment, so the
end-to-end behaviour of a real Doze cycle is unverified. Worth a manual check with
`adb shell dumpsys deviceidle force-idle` before release.

## Related

Found in the same review as #884, which collects six smaller battery items, and #888, which
covers the `gotatun` timer tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018kqBbWk7fjX9qdRddNdb21