### PR TITLE
Fix five high-severity bugs from the codebase review

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
@@ -64,6 +64,12 @@ public class ActivityForwardApproval extends Activity {
         // native side copies it into a fixed INET6_ADDRSTRLEN buffer.
         String resolved = "127.0.0.1";
         try {
+            // A blank address is malformed input, not a request to forward to
+            // localhost: InetAddress.getByName("") resolves to the loopback
+            // address, which would silently turn it into a working redirect.
+            if (addr != null && TextUtils.isEmpty(addr))
+                throw new IllegalArgumentException("Forwarding address is empty");
+
             InetAddress iraddr = InetAddress.getByName(addr == null ? "127.0.0.1" : addr);
             if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                 throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwardApproval.java
@@ -58,16 +58,21 @@ public class ActivityForwardApproval extends Activity {
         String addr = getIntent().getStringExtra("raddr");
         final int rport = getIntent().getIntExtra("rport", 0);
         final int ruid = getIntent().getIntExtra("ruid", 0);
-        final String raddr = (addr == null ? "127.0.0.1" : addr);
 
+        // Resolve and re-derive as the numeric address: this activity is
+        // exported, so raddr is attacker-controlled from any app, and the
+        // native side copies it into a fixed INET6_ADDRSTRLEN buffer.
+        String resolved = "127.0.0.1";
         try {
-            InetAddress iraddr = InetAddress.getByName(raddr);
+            InetAddress iraddr = InetAddress.getByName(addr == null ? "127.0.0.1" : addr);
             if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                 throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");
+            resolved = iraddr.getHostAddress();
         } catch (Throwable ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             finish();
         }
+        final String raddr = resolved;
 
         String pname;
         if (protocol == 6)

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -24,6 +24,7 @@ import android.content.DialogInterface;
 import android.database.Cursor;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -198,7 +199,11 @@ public class ActivityForwarding extends AppCompatActivity {
                                     final int rport = Integer.parseInt(etRPort.getText().toString());
                                     final int ruid = ((Rule) spRuid.getSelectedItem()).uid;
 
-                                    InetAddress iraddr = InetAddress.getByName(etRAddr.getText().toString());
+                                    String raddrInput = etRAddr.getText().toString();
+                                    if (TextUtils.isEmpty(raddrInput))
+                                        throw new IllegalArgumentException("Forwarding address is required");
+
+                                    InetAddress iraddr = InetAddress.getByName(raddrInput);
                                     if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                                         throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");
                                     // Store the resolved numeric address, not the raw

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -195,13 +195,18 @@ public class ActivityForwarding extends AppCompatActivity {
                                     String[] values = getResources().getStringArray(R.array.protocolValues);
                                     final int protocol = Integer.valueOf(values[pos]);
                                     final int dport = Integer.parseInt(etDPort.getText().toString());
-                                    final String raddr = etRAddr.getText().toString();
                                     final int rport = Integer.parseInt(etRPort.getText().toString());
                                     final int ruid = ((Rule) spRuid.getSelectedItem()).uid;
 
-                                    InetAddress iraddr = InetAddress.getByName(raddr);
+                                    InetAddress iraddr = InetAddress.getByName(etRAddr.getText().toString());
                                     if (rport < 1024 && (iraddr.isLoopbackAddress() || iraddr.isAnyLocalAddress()))
                                         throw new IllegalArgumentException("Port forwarding to privileged port on local address not possible");
+                                    // Store the resolved numeric address, not the raw
+                                    // (possibly hostname) text: the native side copies
+                                    // this into a fixed INET6_ADDRSTRLEN buffer, and a
+                                    // hostname is neither bounded in length nor
+                                    // resolvable from native code.
+                                    final String raddr = iraddr.getHostAddress();
 
                                     new AsyncTask<Object, Object, Throwable>() {
                                         @Override

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1738,10 +1738,16 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                 int rport = Integer.parseInt(attributes.getValue("rport"));
 
                 try {
+                    // Re-derive as the numeric address: the imported file is
+                    // untrusted input, and the native side copies raddr into a
+                    // fixed INET6_ADDRSTRLEN buffer.
+                    raddr = InetAddress.getByName(raddr).getHostAddress();
                     int uid = getUid(pkg);
                     DatabaseHelper.getInstance(context).addForward(protocol, dport, raddr, rport, uid);
                 } catch (PackageManager.NameNotFoundException ex) {
                     Log.w(TAG, "Package not found pkg=" + pkg);
+                } catch (java.io.IOException ex) {
+                    Log.w(TAG, "Invalid forward raddr=" + raddr + ": " + ex);
                 }
 
             } else

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -1740,8 +1740,12 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                 try {
                     // Re-derive as the numeric address: the imported file is
                     // untrusted input, and the native side copies raddr into a
-                    // fixed INET6_ADDRSTRLEN buffer.
-                    raddr = InetAddress.getByName(raddr).getHostAddress();
+                    // fixed INET6_ADDRSTRLEN buffer. A blank address is left
+                    // alone: native treats it as "no redirect", and resolving
+                    // it would turn an inert exported rule into a live
+                    // redirect to loopback on re-import.
+                    if (!TextUtils.isEmpty(raddr))
+                        raddr = InetAddress.getByName(raddr).getHostAddress();
                     int uid = getUid(pkg);
                     DatabaseHelper.getInstance(context).addForward(protocol, dport, raddr, rport, uid);
                 } catch (PackageManager.NameNotFoundException ex) {

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -90,9 +90,15 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private static final int DB_VERSION = 23;
 
     private static boolean once = true;
-    private static List<LogChangedListener> logChangedListeners = new ArrayList<>();
-    private static List<AccessChangedListener> accessChangedListeners = new ArrayList<>();
-    private static List<ForwardChangedListener> forwardChangedListeners = new ArrayList<>();
+    // CopyOnWriteArrayList: listeners are added/removed from activity/fragment
+    // lifecycle methods on the main thread while handleChangedNotification()
+    // iterates them on the DB handler thread. A plain ArrayList let a
+    // same-tick removal throw ConcurrentModificationException out of that
+    // iteration, which is not covered by the per-listener try/catch below and
+    // kills the notification thread.
+    private static List<LogChangedListener> logChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private static List<AccessChangedListener> accessChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
+    private static List<ForwardChangedListener> forwardChangedListeners = new java.util.concurrent.CopyOnWriteArrayList<>();
 
     private static HandlerThread hthread = null;
     private static Handler handler = null;

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -106,12 +106,18 @@ public class Rule {
     public boolean expanded = false;
 
     private static List<PackageInfo> cachePackageInfo = null;
-    private static Map<PackageInfo, String> cacheLabel = new HashMap<>();
-    private static Map<String, Boolean> cacheSystem = new HashMap<>();
+    // ConcurrentHashMap + computeIfAbsent: isSystem() is called from the
+    // packet path (ServiceSinkhole.isAddressAllowed) while clearCache() runs
+    // from package-change broadcasts on another thread. A plain HashMap with
+    // separate containsKey()/get() calls let a concurrent clear() land
+    // between them, auto-unboxing a null Boolean into an NPE inside a JNI
+    // callback; computeIfAbsent() makes the lookup-or-compute atomic instead.
+    private static Map<PackageInfo, String> cacheLabel = new java.util.concurrent.ConcurrentHashMap<>();
+    private static Map<String, Boolean> cacheSystem = new java.util.concurrent.ConcurrentHashMap<>();
     private static final Object predefinedLock = new Object();
     private static PredefinedRules cachePredefinedRules;
-    private static Map<String, Boolean> cacheInternet = new HashMap<>();
-    private static Map<PackageInfo, Boolean> cacheEnabled = new HashMap<>();
+    private static Map<String, Boolean> cacheInternet = new java.util.concurrent.ConcurrentHashMap<>();
+    private static Map<PackageInfo, Boolean> cacheEnabled = new java.util.concurrent.ConcurrentHashMap<>();
     private static Map<Integer, Long> trackerRecent = new HashMap<>();
 
     private static final class PredefinedRules {
@@ -135,20 +141,18 @@ public class Rule {
     }
 
     private static String getLabel(PackageInfo info, Context context) {
-        if (!cacheLabel.containsKey(info)) {
+        return cacheLabel.computeIfAbsent(info, i -> {
             PackageManager pm = context.getPackageManager();
-            cacheLabel.put(info, info.applicationInfo.loadLabel(pm).toString());
-        }
-        return cacheLabel.get(info);
+            return i.applicationInfo.loadLabel(pm).toString();
+        });
     }
 
     public static boolean isSystem(String packageName, Context context) {
-        if (!cacheSystem.containsKey(packageName)) {
-            boolean system = Util.isSystem(packageName, context);
-            Boolean predefined = getPredefinedRules(context).system.get(packageName);
-            cacheSystem.put(packageName, resolveSystemClassification(system, predefined));
-        }
-        return cacheSystem.get(packageName);
+        return cacheSystem.computeIfAbsent(packageName, pkg -> {
+            boolean system = Util.isSystem(pkg, context);
+            Boolean predefined = getPredefinedRules(context).system.get(pkg);
+            return resolveSystemClassification(system, predefined);
+        });
     }
 
     static boolean resolveSystemClassification(boolean system, Boolean predefined) {
@@ -196,15 +200,11 @@ public class Rule {
     }
 
     private static boolean hasInternet(String packageName, Context context) {
-        if (!cacheInternet.containsKey(packageName))
-            cacheInternet.put(packageName, Util.hasInternet(packageName, context));
-        return cacheInternet.get(packageName);
+        return cacheInternet.computeIfAbsent(packageName, pkg -> Util.hasInternet(pkg, context));
     }
 
     private static boolean isEnabled(PackageInfo info, Context context) {
-        if (!cacheEnabled.containsKey(info))
-            cacheEnabled.put(info, Util.isEnabled(info, context));
-        return cacheEnabled.get(info);
+        return cacheEnabled.computeIfAbsent(info, i -> Util.isEnabled(i, context));
     }
 
     public static void clearCache(Context context) {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -498,7 +498,11 @@ public class ServiceSinkhole extends VpnService {
             String f = prefs.getString("pcap_file_size", null);
             if (TextUtils.isEmpty(f))
                 f = "2";
-            file_size = Integer.parseInt(f) * 1024 * 1024;
+            // jni_pcap takes a jint, so compute in long first: an in-int
+            // multiplication of a few thousand (MB) overflows to a negative
+            // file size, which native then truncates on every write.
+            long sizeBytes = Long.parseLong(f) * 1024 * 1024;
+            file_size = (int) Math.min(sizeBytes, Integer.MAX_VALUE);
         } catch (Throwable ex) {
             Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
         }

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -172,7 +172,17 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
             log_android(ANDROID_LOG_ERROR, "wg outbound unlock failed during init");
     }
     atomic_store_explicit(&wg_required, 0, memory_order_release);
-    pcap_file = NULL;
+
+    // A prior instance in this process may have left a capture open (jni_done
+    // does not necessarily run before a fresh jni_init, e.g. process reuse);
+    // never just overwrite the pointer and leak the fd.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        pcap_close_locked();
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
 
     if (pthread_mutex_init(&ctx->lock, NULL))
         log_android(ANDROID_LOG_ERROR, "pthread_mutex_init failed");
@@ -309,24 +319,14 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
     pcap_record_size = (size_t) record_size;
     pcap_file_size = file_size;
 
-    //if (pthread_mutex_lock(&lock))
-    //    log_android(ANDROID_LOG_ERROR, "pthread_mutex_lock failed");
+    // Guards pcap_file (and the two settings above) against the packet
+    // threads, which check pcap_file and write through it via
+    // write_pcap_rec() without otherwise synchronizing with this function.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
 
     if (name_ == NULL) {
-        if (pcap_file != NULL) {
-            int flags = fcntl(fileno(pcap_file), F_GETFL, 0);
-            if (flags < 0 || fcntl(fileno(pcap_file), F_SETFL, flags & ~O_NONBLOCK) < 0)
-                log_android(ANDROID_LOG_ERROR, "PCAP fcntl ~O_NONBLOCK error %d: %s",
-                            errno, strerror(errno));
-
-            if (fsync(fileno(pcap_file)))
-                log_android(ANDROID_LOG_ERROR, "PCAP fsync error %d: %s", errno, strerror(errno));
-
-            if (fclose(pcap_file))
-                log_android(ANDROID_LOG_ERROR, "PCAP fclose error %d: %s", errno, strerror(errno));
-
-            pcap_file = NULL;
-        }
+        pcap_close_locked();
         log_android(ANDROID_LOG_WARN, "PCAP disabled");
     } else {
         const char *name = (*env)->GetStringUTFChars(env, name_, 0);
@@ -346,7 +346,7 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
             long size = ftell(pcap_file);
             if (size == 0) {
                 log_android(ANDROID_LOG_WARN, "PCAP initialize");
-                write_pcap_hdr();
+                write_pcap_hdr_locked();
             } else
                 log_android(ANDROID_LOG_WARN, "PCAP current size %ld", size);
         }
@@ -355,8 +355,8 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1pcap(
         ng_delete_alloc(name, __FILE__, __LINE__);
     }
 
-    //if (pthread_mutex_unlock(&lock))
-    //    log_android(ANDROID_LOG_ERROR, "pthread_mutex_unlock failed");
+    if (pthread_mutex_unlock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
 }
 
 JNIEXPORT void JNICALL
@@ -522,6 +522,16 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1done(
     log_android(ANDROID_LOG_INFO, "Done");
 
     clear(ctx);
+
+    // Service teardown: any capture still enabled must be flushed and closed
+    // here, since nothing else closes it once this context goes away.
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        pcap_close_locked();
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
 
     if (pthread_mutex_destroy(&ctx->lock))
         log_android(ANDROID_LOG_ERROR, "pthread_mutex_destroy failed");
@@ -959,7 +969,11 @@ struct allowed *is_address_allowed(const struct arguments *args, jobject jpacket
         else {
             const char *raddr = (*args->env)->GetStringUTFChars(args->env, jraddr, NULL);
             ng_add_alloc(raddr, "raddr");
-            strcpy(allowed.raddr, raddr);
+            // Defense in depth: allowed.raddr is a fixed INET6_ADDRSTRLEN
+            // buffer. The Java caller is expected to hand back a numeric
+            // address, but never trust that from native code.
+            strncpy(allowed.raddr, raddr, sizeof(allowed.raddr) - 1);
+            allowed.raddr[sizeof(allowed.raddr) - 1] = 0;
             (*args->env)->ReleaseStringUTFChars(args->env, jraddr, raddr);
             ng_delete_alloc(raddr, __FILE__, __LINE__);
         }

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -600,11 +600,14 @@ jobject create_packet(const struct arguments *args,
 void account_usage(const struct arguments *args, jint version, jint protocol,
                    const char *daddr, jint dport, jint uid, jlong sent, jlong received);
 
-void write_pcap_hdr();
+extern pthread_mutex_t pcap_lock;
+
+// Caller must hold pcap_lock; see pcap.c.
+void write_pcap_hdr_locked();
+
+void pcap_close_locked();
 
 void write_pcap_rec(const uint8_t *buffer, size_t len);
-
-void write_pcap(const void *ptr, size_t len);
 
 int compare_u32(uint32_t seq1, uint32_t seq2);
 

--- a/app/src/main/jni/netguard/pcap.c
+++ b/app/src/main/jni/netguard/pcap.c
@@ -23,40 +23,15 @@ FILE *pcap_file = NULL;
 size_t pcap_record_size = 64;
 long pcap_file_size = 2 * 1024 * 1024;
 
-void write_pcap_hdr() {
-    struct pcap_hdr_s pcap_hdr;
-    pcap_hdr.magic_number = 0xa1b2c3d4;
-    pcap_hdr.version_major = 2;
-    pcap_hdr.version_minor = 4;
-    pcap_hdr.thiszone = 0;
-    pcap_hdr.sigfigs = 0;
-    pcap_hdr.snaplen = pcap_record_size;
-    pcap_hdr.network = LINKTYPE_RAW;
-    write_pcap(&pcap_hdr, sizeof(struct pcap_hdr_s));
-}
+// Guards pcap_file (open/close/write) against concurrent access from the
+// packet threads (write_pcap_rec, from ip.c/tcp.c/udp.c/icmp.c) and whatever
+// thread toggles capture via jni_pcap()/jni_init()/jni_done(). Every function
+// below that touches pcap_file either takes this lock itself or is documented
+// as requiring the caller to already hold it.
+pthread_mutex_t pcap_lock = PTHREAD_MUTEX_INITIALIZER;
 
-void write_pcap_rec(const uint8_t *buffer, size_t length) {
-    struct timespec ts;
-    if (clock_gettime(CLOCK_REALTIME, &ts))
-        log_android(ANDROID_LOG_ERROR, "clock_gettime error %d: %s", errno, strerror(errno));
-
-    size_t plen = (length < pcap_record_size ? length : pcap_record_size);
-    size_t rlen = sizeof(struct pcaprec_hdr_s) + plen;
-    struct pcaprec_hdr_s *pcap_rec = ng_malloc(rlen, "pcap");
-
-    pcap_rec->ts_sec = (guint32_t) ts.tv_sec;
-    pcap_rec->ts_usec = (guint32_t) (ts.tv_nsec / 1000);
-    pcap_rec->incl_len = (guint32_t) plen;
-    pcap_rec->orig_len = (guint32_t) length;
-
-    memcpy(((uint8_t *) pcap_rec) + sizeof(struct pcaprec_hdr_s), buffer, plen);
-
-    write_pcap(pcap_rec, rlen);
-
-    ng_free(pcap_rec, __FILE__, __LINE__);
-}
-
-void write_pcap(const void *ptr, size_t len) {
+// Caller must hold pcap_lock and pcap_file must be non-NULL.
+static void write_pcap_locked(const void *ptr, size_t len) {
     if (fwrite(ptr, len, 1, pcap_file) < 1)
         log_android(ANDROID_LOG_ERROR, "PCAP fwrite error %d: %s", errno, strerror(errno));
     else {
@@ -78,4 +53,65 @@ void write_pcap(const void *ptr, size_t len) {
             }
         }
     }
+}
+
+// Caller must hold pcap_lock and pcap_file must be non-NULL (called from
+// jni_pcap() right after opening a fresh capture file, under the same lock).
+void write_pcap_hdr_locked() {
+    struct pcap_hdr_s pcap_hdr;
+    pcap_hdr.magic_number = 0xa1b2c3d4;
+    pcap_hdr.version_major = 2;
+    pcap_hdr.version_minor = 4;
+    pcap_hdr.thiszone = 0;
+    pcap_hdr.sigfigs = 0;
+    pcap_hdr.snaplen = pcap_record_size;
+    pcap_hdr.network = LINKTYPE_RAW;
+    write_pcap_locked(&pcap_hdr, sizeof(struct pcap_hdr_s));
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    struct timespec ts;
+    if (clock_gettime(CLOCK_REALTIME, &ts))
+        log_android(ANDROID_LOG_ERROR, "clock_gettime error %d: %s", errno, strerror(errno));
+
+    size_t plen = (length < pcap_record_size ? length : pcap_record_size);
+    size_t rlen = sizeof(struct pcaprec_hdr_s) + plen;
+    struct pcaprec_hdr_s *pcap_rec = ng_malloc(rlen, "pcap");
+
+    pcap_rec->ts_sec = (guint32_t) ts.tv_sec;
+    pcap_rec->ts_usec = (guint32_t) (ts.tv_nsec / 1000);
+    pcap_rec->incl_len = (guint32_t) plen;
+    pcap_rec->orig_len = (guint32_t) length;
+
+    memcpy(((uint8_t *) pcap_rec) + sizeof(struct pcaprec_hdr_s), buffer, plen);
+
+    if (pthread_mutex_lock(&pcap_lock))
+        log_android(ANDROID_LOG_ERROR, "pcap_lock lock failed");
+    else {
+        if (pcap_file != NULL)
+            write_pcap_locked(pcap_rec, rlen);
+        if (pthread_mutex_unlock(&pcap_lock))
+            log_android(ANDROID_LOG_ERROR, "pcap_lock unlock failed");
+    }
+
+    ng_free(pcap_rec, __FILE__, __LINE__);
+}
+
+// Closes pcap_file if open. Caller must hold pcap_lock.
+void pcap_close_locked() {
+    if (pcap_file == NULL)
+        return;
+
+    int flags = fcntl(fileno(pcap_file), F_GETFL, 0);
+    if (flags < 0 || fcntl(fileno(pcap_file), F_SETFL, flags & ~O_NONBLOCK) < 0)
+        log_android(ANDROID_LOG_ERROR, "PCAP fcntl ~O_NONBLOCK error %d: %s",
+                    errno, strerror(errno));
+
+    if (fsync(fileno(pcap_file)))
+        log_android(ANDROID_LOG_ERROR, "PCAP fsync error %d: %s", errno, strerror(errno));
+
+    if (fclose(pcap_file))
+        log_android(ANDROID_LOG_ERROR, "PCAP fclose error %d: %s", errno, strerror(errno));
+
+    pcap_file = NULL;
 }

--- a/app/src/main/jni/netguard/session.c
+++ b/app/src/main/jni/netguard/session.c
@@ -125,6 +125,12 @@ void *handle_events(void *a) {
         if (ms - last_check > EPOLL_MIN_CHECK) {
             last_check = ms;
 
+            // jni_get_stats() (netguard.c) walks ctx->ng_session under this
+            // same lock from the stats-reporting thread; take it here too so
+            // a session freed below can never be a session it is reading.
+            if (pthread_mutex_lock(&args->ctx->lock))
+                log_android(ANDROID_LOG_ERROR, "pthread_mutex_lock failed");
+
             time_t now = time(NULL);
             struct ng_session *sl = NULL;
             s = args->ctx->ng_session;
@@ -172,6 +178,9 @@ void *handle_events(void *a) {
                     s = s->next;
                 }
             }
+
+            if (pthread_mutex_unlock(&args->ctx->lock))
+                log_android(ANDROID_LOG_ERROR, "pthread_mutex_unlock failed");
         } else {
             recheck = 1;
             log_android(ANDROID_LOG_DEBUG, "Skipped session checks");


### PR DESCRIPTION
## Summary

Fixes the five high-severity findings from a full codebase bug review (native C engine, `ServiceSinkhole`, data/DNS layer, WireGuard code, `wgbridge-rs`, and UI — reviewed by six read-only agents, each finding independently re-verified against source before being counted).

- **Native stack corruption via port-forward addresses.** `netguard.c`'s `strcpy()` copies `Allowed.raddr` into a fixed `INET6_ADDRSTRLEN` buffer. That value came from raw, unbounded text in three places: `ActivityForwarding`'s UI dialog, the **exported** `ActivityForwardApproval` activity (reachable via Intent from any app on the device), and XML settings import. All three resolve the address with `InetAddress.getByName` but were storing the original string, not the resolved one. Fixed to store the resolved numeric address everywhere, and hardened the native copy with `strncpy` as defense in depth.
- **PCAP `FILE*` race + overflow + leak.** The mutex meant to guard `pcap_file` was commented out in `netguard.c`, while capture toggling (from the UI thread) and packet writes (from the tunnel thread) touched it concurrently — a working use-after-close. Added a real `pcap_lock` around every open/close/write in `pcap.c`/`netguard.c`, and close any capture left open in `jni_init`/`jni_done` so it can't leak across service restarts. Also fixed `pcap_file_size` computing in 32-bit `int` in `ServiceSinkhole.setPcap`, which silently went negative for ordinary file-size settings and truncated the capture on every write.
- **Session-list use-after-free.** The native session-timeout sweep in `session.c` freed sessions without holding `ctx->lock`, while `jni_get_stats()` walks the same list under that lock from the stats-reporting thread. Took the lock around the sweep too.
- **`Rule.isSystem()` cache race.** `Rule.java`'s static caches used `containsKey`+`get` against a plain `HashMap` while `clearCache()` cleared it from a different thread (package-change broadcasts vs. the packet path in `ServiceSinkhole.isAddressAllowed`), which could auto-unbox a `null` `Boolean` into an `NullPointerException` inside a JNI callback. Switched to `ConcurrentHashMap` with `computeIfAbsent` for the atomic lookup-or-compute.
- **`DatabaseHelper` listener races.** The `LogChangedListener`/`AccessChangedListener`/`ForwardChangedListener` lists were plain `ArrayList`s, added/removed from activity lifecycle callbacks on the main thread while iterated on the DB handler thread — a `ConcurrentModificationException` waiting to happen, uncaught by the per-listener `try`/`catch`. Switched to `CopyOnWriteArrayList`.

## Test plan

- [x] `./gradlew :app:compileGithubDebugJavaWithJavac` — compiles clean
- [x] `./gradlew :app:testGithubDebugUnitTest` — all JVM unit tests pass
- [x] `./gradlew :app:externalNativeBuildGithubDebug` — native C engine builds clean for all four ABIs (armeabi-v7a, arm64-v8a, x86, x86_64), including the Rust `wgbridge` crate
- [ ] Not run: `connectedAndroidTest` and manual device testing (no device/emulator available in this environment)

## Remaining risk

Full bug-review report (25 findings total; these five are the high-severity subset) is available on request. The medium/low findings from that review are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaCJMn3aT1WineJydEZaCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaCJMn3aT1WineJydEZaCL)_