### PR TITLE
Fix resource leaks on TCP connect failure and service teardown

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2289,9 +2289,21 @@ public class ServiceSinkhole extends VpnService {
             }
             tunnelThread = null;
 
-            jni_clear(jni_context);
-
             Log.i(TAG, "Stopped tunnel thread");
+        }
+
+        // Clear the session list even when there was no thread to join. When
+        // jni_run() returns on a native error the tunnel thread nulls
+        // tunnelThread itself, so the recovery restart arrives here with
+        // nothing to stop — but the context still holds every session that run
+        // built up. jni_start() keeps ctx->ng_session, and the new epoll
+        // instance registers only the pipe and tun, so those UDP/ICMP sockets
+        // would never be polled again while still holding their descriptors.
+        // Nothing can race this: either the thread was joined above, or it has
+        // already exited.
+        synchronized (jni_lock) {
+            if (jni_context != 0)
+                jni_clear(jni_context);
         }
 
         // NOTE: WireGuard is intentionally NOT torn down here. NetGuard's
@@ -4214,6 +4226,22 @@ public class ServiceSinkhole extends VpnService {
                     vpn = null;
                     unprepare();
                 }
+            } catch (Throwable ex) {
+                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            }
+
+            // Final teardown of the egress side, mirroring CommandHandler.stop().
+            // Only that command path used to do this, so a destroy that did not
+            // come through it — a system revoke (onRevoke -> stopSelf), or
+            // stopService — left the Rust tunnel, its duplicated descriptors,
+            // the connectivity monitor and callbacks capturing this now-dead
+            // service alive until some later start replaced them. Both stops
+            // are idempotent, and both must precede jni_done() below.
+            try {
+                net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.stop(
+                        () -> { jni_wireguard_stop(); return kotlin.Unit.INSTANCE; });
+                jni_wireguard_required(false);
+                net.kollnig.missioncontrol.dns.DnsProxyServer.getInstance(ServiceSinkhole.this).stop();
             } catch (Throwable ex) {
                 Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             }

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -837,7 +837,9 @@ jboolean handle_tcp(const struct arguments *args,
             // Open socket
             s->socket = open_tcp_socket(args, &s->tcp, redirect);
             if (s->socket < 0) {
-                // Remote might retry
+                // Remote might retry. Any segment queued from SYN data above
+                // belongs to this session and is freed with it.
+                clear_tcp_data(&s->tcp);
                 ng_free(s, __FILE__, __LINE__);
                 return 0;
             }
@@ -1118,8 +1120,10 @@ int open_tcp_socket(const struct arguments *args,
     }
 
     // Protect
-    if (protect_socket(args, sock) < 0)
+    if (protect_socket(args, sock) < 0) {
+        close(sock);
         return -1;
+    }
 
     int on = 1;
     if (setsockopt(sock, SOL_TCP, TCP_NODELAY, &on, sizeof(on)) < 0)
@@ -1131,6 +1135,7 @@ int open_tcp_socket(const struct arguments *args,
     if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
         log_android(ANDROID_LOG_ERROR, "fcntl socket O_NONBLOCK error %d: %s",
                     errno, strerror(errno));
+        close(sock);
         return -1;
     }
 
@@ -1186,6 +1191,7 @@ int open_tcp_socket(const struct arguments *args,
                                    : sizeof(struct sockaddr_in6)));
     if (err < 0 && errno != EINPROGRESS) {
         log_android(ANDROID_LOG_ERROR, "connect error %d: %s", errno, strerror(errno));
+        close(sock);
         return -1;
     }
 


### PR DESCRIPTION
## Summary

The resource-lifecycle cluster from the codebase review — three medium-severity findings, all independently re-verified against source. Follow-up to #889 (independent of it: branched off `master`, and the changed regions don't overlap, so the two can merge in either order).

- **Descriptor leak on every failed TCP connect.** `open_tcp_socket()` (`tcp.c`) returned `-1` without closing the socket on three paths: `protect_socket()` failure, `fcntl(O_NONBLOCK)` failure, and an immediate `connect()` error. A run of refused or unreachable connections therefore burned descriptors until the process hit its limit. Checked that `protect_socket()` never closes the fd itself, so none of these is a double close.

- **SYN-data segment leaked with the session.** When `open_tcp_socket()` fails, `handle_tcp()` freed the session struct but not the `struct segment` (and its payload) queued a few lines earlier from SYN data. Now calls `clear_tcp_data()` first. Both `tcp.forward` and `tls_data` are set to `NULL` before that point, so the call is also correct on the ordinary no-SYN-data path.

- **Native recovery restarted on a dirty context.** `stopNative()` only called `jni_clear()` inside `if (tunnelThread != null)`. But when `jni_run()` returns on a native error, the tunnel thread nulls `tunnelThread` itself as its last act — so the delayed recovery restart reached `stopNative()` with nothing to join and skipped the clear entirely. `jni_start()` keeps `ctx->ng_session`, and the fresh epoll instance registers only the pipe and tun, so the previous run's UDP/ICMP sockets were never polled again while still holding their descriptors. Now cleared unconditionally, guarded on a live context (`jni_clear(0)` would dereference NULL in `clear()`). This can't race the tunnel thread: it was either joined just above or has already exited.

- **WireGuard and the DoH proxy survived teardown.** Both were stopped only by `CommandHandler.stop()`. A destroy that didn't come through that path — a system revoke (`onRevoke` → `super.onRevoke()` → `stopSelf()` → `onDestroy()`), or a plain `stopService` — left the Rust tunnel, its duplicated descriptors, the connectivity monitor, and callbacks capturing the now-dead service alive until some later start replaced them. `onDestroy()` now mirrors that teardown; because revoke routes through `stopSelf()`, covering `onDestroy` covers both paths without duplicating the logic.

## Notes for review

- The new teardown does **not** contradict the `// NOTE: WireGuard is intentionally NOT torn down here` comment in `stopNative()`. That note is about transient *native restarts* (`stopNative` + `startNative` on the same PFD for DHCP/connectivity changes), where a WG teardown would force a fresh handshake every few seconds. `onDestroy` is the genuine end of the service, which is the case that comment explicitly defers to `stop()`.
- `WgEgress.stop()` reaches `Tunnel.stop()`, which is a `runtime.block_on(...)`, and `onDestroy` runs on the main thread. Worth a maintainer's eye, though I think it's the right trade: it only does real work when `tunnel != null`, i.e. precisely the leak case, and is a cheap no-op on the common path where `CommandHandler.stop()` already ran. `onDestroy` also already blocks on an unbounded `thread.join()` in `stopNative()`, so this doesn't introduce blocking where there was none.

## Test plan

- [x] `./gradlew :app:compileGithubDebugJavaWithJavac` — clean
- [x] `./gradlew :app:testGithubDebugUnitTest` — all JVM unit tests pass
- [x] `./gradlew :app:externalNativeBuildGithubDebug` — native engine builds clean for all four ABIs; confirmed `tcp.c` recompiled and all four `libnetguard.so` produced
- [x] `./gradlew :app:lintGithubDebug` — clean
- [ ] Not run: `connectedAndroidTest` and manual device testing (no device/emulator in this environment). The revoke path in particular is worth exercising on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UaCJMn3aT1WineJydEZaCL

---
_Generated by [Claude Code](https://claude.ai/code/session_01UaCJMn3aT1WineJydEZaCL)_