### PR TITLE
Fix hosts-list matching misses and harden the DNS path

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/HostsBlocklistLogic.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsBlocklistLogic.java
@@ -6,13 +6,25 @@ import java.io.Reader;
 import java.util.Locale;
 import java.util.Map;
 
-final class HostsBlocklistLogic {
+public final class HostsBlocklistLogic {
     interface Logger {
         void log(String message);
     }
 
     private static final Logger NOOP_LOGGER = message -> {
     };
+
+    /**
+     * Strip a single trailing root-zone dot (as in {@code ads.example.}), so a
+     * hosts entry written in that fully-qualified form still matches the qname
+     * the DNS parser hands back, which never carries one. A bare "." is left
+     * alone rather than reduced to an empty string.
+     */
+    public static String stripTrailingDot(String hostname) {
+        int length = hostname.length();
+        return (length > 1 && hostname.charAt(length - 1) == '.')
+                ? hostname.substring(0, length - 1) : hostname;
+    }
 
     static final class State {
         private final Map<String, Boolean> mapHostsBlocked;
@@ -55,11 +67,17 @@ final class HostsBlocklistLogic {
                 line = line.trim();
                 if (line.length() > 0) {
                     String[] words = line.split("\\s+");
-                    if (words.length == 2) {
-                        count++;
-                        // Keyed lowercase to match TrackerList.findTracker(),
-                        // which normalises qnames before the hosts lookup.
-                        mapHostsBlocked.put(words[1].toLowerCase(Locale.ROOT), true);
+                    // hosts(5) allows several hostnames after the address on one
+                    // line, which merged blocklists rely on; only a bare address
+                    // with no hostname at all is invalid.
+                    if (words.length >= 2) {
+                        for (int i = 1; i < words.length; i++) {
+                            count++;
+                            // Keyed lowercase to match TrackerList.findTracker(),
+                            // which normalises qnames before the hosts lookup.
+                            mapHostsBlocked.put(
+                                    stripTrailingDot(words[i].toLowerCase(Locale.ROOT)), true);
+                        }
                     } else
                         logger.log("Invalid hosts file line: " + line);
                 }

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -2419,9 +2419,32 @@ public class ServiceSinkhole extends VpnService {
      */
     private String resolveDirectDnsTarget() {
         List<String> sysDns = Util.getDefaultDNS(ServiceSinkhole.this);
-        for (String dns : sysDns)
-            if (!TextUtils.isEmpty(dns))
+
+        // Mirror the "ip6" preference gate that getDns()/collectDns() apply to
+        // the normal resolver list: only accept an IPv6 resolver when IPv6 is
+        // enabled at all. Unlike getDns(), no separate IPv6-only fallback pass
+        // is needed here – the first usable candidate, of either family, wins.
+        boolean allowIp6 = PreferenceManager.getDefaultSharedPreferences(ServiceSinkhole.this)
+                .getBoolean("ip6", true);
+
+        for (String dns : sysDns) {
+            if (TextUtils.isEmpty(dns) || !Util.isNumericAddress(dns))
+                continue;
+
+            // getDefaultDNS() already stripped any interface scope, so a
+            // link-local candidate here can never be reached from the tun –
+            // avoid handing it to a direct app. A numeric string never
+            // triggers a resolver lookup, so getByName() is safe to call.
+            InetAddress address;
+            try {
+                address = InetAddress.getByName(dns);
+            } catch (Throwable ex) {
+                continue;
+            }
+
+            if (isUsableDns(address, allowIp6))
                 return dns;
+        }
 
         Log.w(TAG, "No system DNS for direct apps; keeping their DNS in the tunnel");
         return null;

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -675,6 +675,7 @@ public class Util {
             connection = (HttpURLConnection) url.openConnection();
             connection.setRequestProperty("Accept-Encoding", "gzip");
             connection.setRequestMethod("GET");
+            connection.setConnectTimeout(15 * 1000);
             connection.setReadTimeout(15 * 1000);
             connection.connect();
             if ("gzip".equals(connection.getContentEncoding()))

--- a/app/src/main/java/eu/faircode/netguard/VpnRoutes.java
+++ b/app/src/main/java/eu/faircode/netguard/VpnRoutes.java
@@ -22,7 +22,6 @@ package eu.faircode.netguard;
 
 import android.util.Log;
 
-import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -222,15 +221,50 @@ public class VpnRoutes {
                 int prefix = parts.length > 1 ? Integer.parseInt(parts[1].trim()) : 32;
                 if (prefix < 0 || prefix > 32)
                     continue;
-                InetAddress addr = InetAddress.getByName(ip);
-                if (!(addr instanceof Inet4Address))
-                    continue;
-                allowedV4.add(new IPUtil.CIDR(ip, prefix));
+                // A hostile profile can put anything in AllowedIPs, so parse
+                // this by hand rather than calling InetAddress.getByName(ip):
+                // that resolves any entry that is not itself a numeric
+                // literal, causing a DNS lookup on the VPN setup thread for
+                // e.g. "AllowedIPs = attacker.example/32".
+                byte[] address = parseIPv4Literal(ip);
+                if (address == null)
+                    continue; // not a dotted-quad literal (e.g. a hostname)
+                allowedV4.add(new IPUtil.CIDR(InetAddress.getByAddress(address), prefix));
             } catch (Throwable ex) {
                 Log.w(TAG, "Ignoring malformed AllowedIPs entry '" + entry + "': " + ex);
             }
         }
         return allowedV4;
+    }
+
+    /**
+     * Parse a dotted-quad IPv4 literal without ever resolving a hostname –
+     * unlike {@link InetAddress#getByName(String)}, which falls back to a DNS
+     * lookup for anything that is not itself a numeric address. Four decimal
+     * octets (0-255), no leading '+' or embedded whitespace; anything else,
+     * including a hostname, returns null.
+     */
+    private static byte[] parseIPv4Literal(String ip) {
+        String[] octets = ip.split("\\.", -1);
+        if (octets.length != 4)
+            return null;
+
+        byte[] address = new byte[4];
+        for (int i = 0; i < 4; i++) {
+            String octet = octets[i];
+            if (octet.isEmpty() || octet.length() > 3)
+                return null;
+            for (int j = 0; j < octet.length(); j++) {
+                char c = octet.charAt(j);
+                if (c < '0' || c > '9')
+                    return null;
+            }
+            int value = Integer.parseInt(octet);
+            if (value > 255)
+                return null;
+            address[i] = (byte) value;
+        }
+        return address;
     }
 
     private static long[] toInterval(String ip, int prefix) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/TrackerList.java
@@ -51,6 +51,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import eu.faircode.netguard.DatabaseHelper;
+import eu.faircode.netguard.HostsBlocklistLogic;
 import eu.faircode.netguard.ServiceSinkhole;
 
 /**
@@ -184,8 +185,10 @@ public class TrackerList {
         // lowercase and qnames are stored as they appear on the wire. Without
         // normalising here, a query for Graph.Facebook.Com — whether a
         // deliberate evasion or a resolver using 0x20 case randomisation —
-        // would slip past detection and blocking.
-        hostname = hostname.toLowerCase(Locale.ROOT);
+        // would slip past detection and blocking. A trailing root-zone dot is
+        // stripped too, so a hosts entry written as "ads.example." still
+        // matches – the DNS parser never hands back a qname carrying one.
+        hostname = HostsBlocklistLogic.stripTrailingDot(hostname.toLowerCase(Locale.ROOT));
 
         TrackerSnapshot snapshot = trackerSnapshot;
         Map<String, Tracker> hostnameToTracker = snapshot.hostnameToTracker;
@@ -231,7 +234,7 @@ public class TrackerList {
      * never consults or mutates the hosts-file map.
      */
     public static Tracker findMinimalTracker(@NonNull String hostname) {
-        hostname = hostname.toLowerCase(Locale.ROOT);
+        hostname = HostsBlocklistLogic.stripTrailingDot(hostname.toLowerCase(Locale.ROOT));
         return lookupHost(trackerSnapshot.minimalHostnameToTracker, hostname);
     }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -62,6 +62,11 @@ public class DnsOverHttpsClient {
     private static final int CONNECT_TIMEOUT_MS = 5000;
     private static final int READ_TIMEOUT_MS = 5000;
     private static final int WRITE_TIMEOUT_MS = 5000;
+    // Whole-call ceiling (connect + write + read + a margin for retries within
+    // OkHttp itself), so an endpoint that dribbles bytes cannot hold a worker
+    // forever. Must stay at or above the sum of the three per-phase timeouts
+    // above, or it would fire before a healthy call has a chance to finish.
+    private static final int CALL_TIMEOUT_MS = 20000;
     private static final long HTTP_CACHE_MAX_BYTES = 2L * 1024L * 1024L;
     private static final int MAX_GET_URL_LENGTH = 2048;
     private static final int MAX_DOH_RESPONSE_BYTES = 65535;
@@ -85,6 +90,7 @@ public class DnsOverHttpsClient {
                 .connectTimeout(CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .readTimeout(READ_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .writeTimeout(WRITE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .callTimeout(CALL_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .connectionPool(new ConnectionPool(2, 30, TimeUnit.SECONDS))
                 .cache(getResponseCache(context))
                 .retryOnConnectionFailure(true)

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -57,6 +57,11 @@ public class DnsProxyServer {
     private DatagramSocket serverSocket;
     private ServerSocket tcpServerSocket;
     private ExecutorService executor;
+    // Tracked so stop() can wait for the listeners to actually exit, rather
+    // than just closing their sockets and returning immediately.
+    private Thread udpListenerThread;
+    private Thread tcpListenerThread;
+    private static final long LISTENER_JOIN_TIMEOUT_MS = 2000;
     private final AtomicInteger dohFailures = new AtomicInteger(0);
     // Trips after this many consecutive failed network attempts (not queries):
     // a single failing resolve burns up to three full timeout budgets, so a
@@ -119,7 +124,8 @@ public class DnsProxyServer {
             executor = Executors.newFixedThreadPool(16);
 
             // Start the main listener thread
-            new Thread(this::runServer, "DnsProxyServer").start();
+            udpListenerThread = new Thread(this::runServer, "DnsProxyServer");
+            udpListenerThread.start();
 
             // Sync the screen-state policy so a start mid-doze (e.g. a network
             // reload at night) doesn't inherit the screen-on behaviour.
@@ -133,7 +139,8 @@ public class DnsProxyServer {
                     tcpServerSocket = new ServerSocket();
                     tcpServerSocket.setReuseAddress(true);
                     tcpServerSocket.bind(new InetSocketAddress(DNS_PROXY_ADDRESS, DNS_PROXY_PORT));
-                    new Thread(this::runTcpServer, "DnsProxyServer-TCP").start();
+                    tcpListenerThread = new Thread(this::runTcpServer, "DnsProxyServer-TCP");
+                    tcpListenerThread.start();
                     Log.i(TAG, "DNS TCP proxy server started on " + DNS_PROXY_ADDRESS + ":" + DNS_PROXY_PORT);
                 } catch (IOException e) {
                     Log.e(TAG, "Failed to bind DNS TCP proxy: " + e.getMessage());
@@ -167,6 +174,16 @@ public class DnsProxyServer {
             }
         }
 
+        // Closing the sockets above unblocks each listener's receive()/accept()
+        // call, but does not guarantee it has actually returned yet. Wait for
+        // both before proceeding, otherwise an immediate start() can leave an
+        // old listener still observing the just-restored running == true
+        // alongside the new socket/executor fields.
+        joinListenerThread(udpListenerThread, "UDP");
+        udpListenerThread = null;
+        joinListenerThread(tcpListenerThread, "TCP");
+        tcpListenerThread = null;
+
         if (executor != null) {
             executor.shutdownNow();
         }
@@ -175,6 +192,26 @@ public class DnsProxyServer {
         DnsOverHttpsClient.resetInstance();
 
         Log.i(TAG, "DNS proxy server stopped");
+    }
+
+    /**
+     * Wait (bounded) for a listener thread to exit after its socket was
+     * closed. Logs rather than throwing if it does not stop in time, since
+     * stop() must still complete and release the lock.
+     */
+    private void joinListenerThread(@Nullable Thread thread, String label) {
+        if (thread == null)
+            return;
+
+        try {
+            thread.join(LISTENER_JOIN_TIMEOUT_MS);
+            if (thread.isAlive())
+                Log.w(TAG, label + " listener thread did not stop within "
+                        + LISTENER_JOIN_TIMEOUT_MS + "ms");
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.w(TAG, "Interrupted while waiting for " + label + " listener thread to stop");
+        }
     }
 
     /**
@@ -220,7 +257,7 @@ public class DnsProxyServer {
      * pool.
      */
     private void runServer() {
-        byte[] buffer = new byte[4096]; // Increased for EDNS0 support
+        byte[] buffer = new byte[65535]; // Max UDP payload, so a larger EDNS0 query is not silently truncated
 
         while (running.get()) {
             try {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
@@ -110,7 +110,8 @@ object WgConfigParser {
                 "Peer" -> when (key) {
                     "publickey" -> peerPub = requireBase64Key(value)
                     "presharedkey" -> peerPsk = requireBase64Key(value)
-                    "allowedips" -> peerAllowed += value.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+                    "allowedips" -> peerAllowed += value.split(',').map { it.trim() }
+                        .filter { it.isNotEmpty() }.map { requireAllowedIp(it) }
                     "endpoint" -> peerEndpoint = value
                     "persistentkeepalive" -> peerPersistentKeepalive = parseKeepalive(value)
                     else -> throw WgConfigException("unknown Peer key: $key")
@@ -147,6 +148,53 @@ object WgConfigParser {
         if (value !in 0..65535)
             throw WgConfigException("PersistentKeepalive out of range: $s")
         return value
+    }
+
+    private val IPV4_OCTET = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])"
+    private val IPV4_REGEX = Regex("^$IPV4_OCTET(\\.$IPV4_OCTET){3}$")
+
+    // Standard eight-branch IPv6 literal regex (no zone id, no embedded IPv4
+    // tail – neither appears in a WireGuard AllowedIPs entry).
+    private val IPV6_REGEX = Regex(
+        "^(" +
+            "([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}" +
+            "|([0-9A-Fa-f]{1,4}:){1,7}:" +
+            "|([0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}" +
+            "|([0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}" +
+            "|([0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}" +
+            "|([0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}" +
+            "|([0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}" +
+            "|[0-9A-Fa-f]{1,4}:((:[0-9A-Fa-f]{1,4}){1,6})" +
+            "|:((:[0-9A-Fa-f]{1,4}){1,7}|:)" +
+            ")$"
+    )
+
+    /**
+     * Reject an AllowedIPs entry unless it is a numeric IPv4 or IPv6 address
+     * with an optional "/prefix". The Rust bridge (wgbridge-rs's
+     * parse_uapi_config) already requires this – allowed_ip is parsed as an
+     * IpNetwork, never resolved – so a hostname here would only surface as a
+     * native startup failure; rejecting it here instead gives a clear error
+     * at config-parse time, before any of it reaches the tunnel.
+     */
+    private fun requireAllowedIp(entry: String): String {
+        val slash = entry.indexOf('/')
+        val address = if (slash >= 0) entry.substring(0, slash) else entry
+        val prefix = if (slash >= 0) entry.substring(slash + 1) else null
+
+        val isV4 = IPV4_REGEX.matches(address)
+        if (!isV4 && !IPV6_REGEX.matches(address))
+            throw WgConfigException("invalid AllowedIPs entry: $entry")
+
+        if (prefix != null) {
+            val prefixLen = prefix.toIntOrNull()
+                ?: throw WgConfigException("invalid AllowedIPs prefix: $entry")
+            val maxPrefix = if (isV4) 32 else 128
+            if (prefixLen !in 0..maxPrefix)
+                throw WgConfigException("AllowedIPs prefix out of range: $entry")
+        }
+
+        return entry
     }
 
     internal fun base64ToHex(s: String): String {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
@@ -153,21 +153,46 @@ object WgConfigParser {
     private val IPV4_OCTET = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])"
     private val IPV4_REGEX = Regex("^$IPV4_OCTET(\\.$IPV4_OCTET){3}$")
 
-    // Standard eight-branch IPv6 literal regex (no zone id, no embedded IPv4
-    // tail – neither appears in a WireGuard AllowedIPs entry).
-    private val IPV6_REGEX = Regex(
-        "^(" +
-            "([0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}" +
-            "|([0-9A-Fa-f]{1,4}:){1,7}:" +
-            "|([0-9A-Fa-f]{1,4}:){1,6}:[0-9A-Fa-f]{1,4}" +
-            "|([0-9A-Fa-f]{1,4}:){1,5}(:[0-9A-Fa-f]{1,4}){1,2}" +
-            "|([0-9A-Fa-f]{1,4}:){1,4}(:[0-9A-Fa-f]{1,4}){1,3}" +
-            "|([0-9A-Fa-f]{1,4}:){1,3}(:[0-9A-Fa-f]{1,4}){1,4}" +
-            "|([0-9A-Fa-f]{1,4}:){1,2}(:[0-9A-Fa-f]{1,4}){1,5}" +
-            "|[0-9A-Fa-f]{1,4}:((:[0-9A-Fa-f]{1,4}){1,6})" +
-            "|:((:[0-9A-Fa-f]{1,4}){1,7}|:)" +
-            ")$"
-    )
+    private val IPV6_GROUP = Regex("^[0-9A-Fa-f]{1,4}$")
+
+    /**
+     * Numeric IPv6 literal check that never touches a resolver: up to eight
+     * hex groups, at most one "::" compression, and optionally an IPv4
+     * dotted-quad in place of the last two groups (as in ::ffff:192.0.2.0),
+     * which the Rust IpNetwork parser also accepts. Zone ids are not part
+     * of an AllowedIPs entry and are rejected.
+     */
+    internal fun isIpv6Literal(literal: String): Boolean {
+        if (literal.count { it == ':' } < 2) return false
+        var text = literal
+        var groupsNeeded = 8
+        val lastColon = text.lastIndexOf(':')
+        if (text.indexOf('.', lastColon) >= 0) {
+            if (!IPV4_REGEX.matches(text.substring(lastColon + 1))) return false
+            text = text.substring(0, lastColon + 1)
+            groupsNeeded = 6
+            // A trailing "::" before the IPv4 tail leaves text ending in "::";
+            // a plain group leaves it ending in a single ":" that must be
+            // dropped before splitting.
+            if (!text.endsWith("::")) text = text.dropLast(1)
+        }
+        val compressed = text.indexOf("::")
+        if (compressed >= 0 && text.indexOf("::", compressed + 1) >= 0) return false
+        val groups: List<String>
+        if (compressed >= 0) {
+            val head = text.substring(0, compressed)
+            val tail = text.substring(compressed + 2)
+            if (head.startsWith(":") || head.endsWith(":")) return false
+            if (tail.startsWith(":") || tail.endsWith(":")) return false
+            groups = (if (head.isEmpty()) emptyList() else head.split(':')) +
+                (if (tail.isEmpty()) emptyList() else tail.split(':'))
+            if (groups.size >= groupsNeeded) return false
+        } else {
+            groups = text.split(':')
+            if (groups.size != groupsNeeded) return false
+        }
+        return groups.all { IPV6_GROUP.matches(it) }
+    }
 
     /**
      * Reject an AllowedIPs entry unless it is a numeric IPv4 or IPv6 address
@@ -183,7 +208,7 @@ object WgConfigParser {
         val prefix = if (slash >= 0) entry.substring(slash + 1) else null
 
         val isV4 = IPV4_REGEX.matches(address)
-        if (!isV4 && !IPV6_REGEX.matches(address))
+        if (!isV4 && !isIpv6Literal(address))
             throw WgConfigException("invalid AllowedIPs entry: $entry")
 
         if (prefix != null) {

--- a/app/src/test/java/eu/faircode/netguard/HostsBlocklistLogicTest.java
+++ b/app/src/test/java/eu/faircode/netguard/HostsBlocklistLogicTest.java
@@ -43,6 +43,45 @@ public class HostsBlocklistLogicTest {
         assertEquals(3, hosts.size());
     }
 
+    @Test
+    public void parseAcceptsMultipleHostnamesPerLine() throws Exception {
+        Map<String, Boolean> hosts = new HashMap<>();
+        HostsBlocklistLogic.State state = new HostsBlocklistLogic.State(hosts, 0L);
+
+        assertTrue(state.load(new StringReader(
+                "0.0.0.0 single.example\n"
+                        + "0.0.0.0 first.example second.example third.example\n"), 1L));
+
+        // The single-hostname and multi-hostname lines, plus the always-added
+        // test entry.
+        assertEquals(5, hosts.size());
+        assertTrue(hosts.containsKey("single.example"));
+        assertTrue(hosts.containsKey("first.example"));
+        assertTrue(hosts.containsKey("second.example"));
+        assertTrue(hosts.containsKey("third.example"));
+        assertTrue(hosts.containsKey("test.netguard.me"));
+    }
+
+    @Test
+    public void parseRejectsLineWithNoHostname() throws Exception {
+        Map<String, Boolean> hosts = new HashMap<>();
+        HostsBlocklistLogic.State state = new HostsBlocklistLogic.State(hosts, 0L);
+
+        assertTrue(state.load(new StringReader("0.0.0.0\n"), 1L));
+
+        // Only the always-added test entry, since the address-only line has no
+        // hostname to key on.
+        assertEquals(1, hosts.size());
+        assertTrue(hosts.containsKey("test.netguard.me"));
+    }
+
+    @Test
+    public void stripTrailingDotNormalisesFullyQualifiedHostnames() {
+        assertEquals("ads.example", HostsBlocklistLogic.stripTrailingDot("ads.example."));
+        assertEquals("ads.example", HostsBlocklistLogic.stripTrailingDot("ads.example"));
+        assertEquals(".", HostsBlocklistLogic.stripTrailingDot("."));
+    }
+
     private static final class FailingReader extends Reader {
         private final String firstLine = "1.1.1.1 first.example\n";
         private int position;

--- a/app/src/test/java/eu/faircode/netguard/VpnRoutesTest.java
+++ b/app/src/test/java/eu/faircode/netguard/VpnRoutesTest.java
@@ -209,6 +209,21 @@ public class VpnRoutesTest {
     }
 
     @Test
+    public void hostnameAllowedIpsEntryIsIgnoredButNumericEntriesStillRoute() throws Exception {
+        // A hostile profile could set AllowedIPs to a hostname to trigger a
+        // resolver lookup on the VPN setup thread; it must instead be skipped
+        // exactly as if it were not present at all.
+        List<IPUtil.CIDR> withHostname = VpnRoutes.getRoutes(
+                Arrays.asList("attacker.example/32", "192.168.60.0/24"));
+        List<IPUtil.CIDR> numericOnly = VpnRoutes.getRoutes(
+                Collections.singletonList("192.168.60.0/24"));
+
+        assertEquals(numericOnly.size(), withHostname.size());
+        assertTrue(isRouted(withHostname, "192.168.60.5"));
+        assertFalse(isRouted(withHostname, "192.168.61.5"));
+    }
+
+    @Test
     public void allowedIpsNeverReExposeReservedRanges() throws Exception {
         // A profile that lists loopback/link-local must not route them.
         List<IPUtil.CIDR> routes = VpnRoutes.getRoutes(

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
@@ -56,6 +56,24 @@ public class WgConfigParserTest {
         assertEquals(2, config.getPeers().get(0).getAllowedIPs().size());
     }
 
+    @Test
+    public void ipv4EmbeddedIpv6AllowedIpsIsAccepted() throws Exception {
+        WgConfig config = WgConfigParser.INSTANCE.parse(
+                configWithAllowedIps("::ffff:192.0.2.0/120, 2001:db8::1/128, ::/0"));
+
+        assertEquals(3, config.getPeers().get(0).getAllowedIPs().size());
+    }
+
+    @Test
+    public void malformedIpv6AllowedIpsIsRejected() {
+        assertThrows(WgConfigException.class,
+                () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("1:::2/64")));
+        assertThrows(WgConfigException.class,
+                () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("2001:db8::1%wlan0/64")));
+        assertThrows(WgConfigException.class,
+                () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("::ffff:999.0.2.0/120")));
+    }
+
     private static String config(String keepaliveLine) {
         return configWithAllowedIps("0.0.0.0/0", keepaliveLine);
     }

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
@@ -41,14 +41,37 @@ public class WgConfigParserTest {
                 () -> WgConfigParser.INSTANCE.parse(config("PersistentKeepalive = invalid")));
     }
 
+    @Test
+    public void hostnameAllowedIpsIsRejected() {
+        // A hostname here would otherwise reach the Rust bridge and get
+        // resolved, leaking a DNS lookup for an address the user never chose.
+        assertThrows(WgConfigException.class,
+                () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("attacker.example/32")));
+    }
+
+    @Test
+    public void numericIpv6AllowedIpsIsAccepted() throws Exception {
+        WgConfig config = WgConfigParser.INSTANCE.parse(configWithAllowedIps("0.0.0.0/0, ::/0"));
+
+        assertEquals(2, config.getPeers().get(0).getAllowedIPs().size());
+    }
+
     private static String config(String keepaliveLine) {
+        return configWithAllowedIps("0.0.0.0/0", keepaliveLine);
+    }
+
+    private static String configWithAllowedIps(String allowedIps) {
+        return configWithAllowedIps(allowedIps, "");
+    }
+
+    private static String configWithAllowedIps(String allowedIps, String keepaliveLine) {
         return "[Interface]\n" +
                 "PrivateKey = " + KEY + "\n" +
                 "Address = 10.0.0.2/32\n" +
                 "\n" +
                 "[Peer]\n" +
                 "PublicKey = " + KEY + "\n" +
-                "AllowedIPs = 0.0.0.0/0\n" +
+                "AllowedIPs = " + allowedIps + "\n" +
                 "Endpoint = 198.51.100.1:51820\n" +
                 (keepaliveLine.isEmpty() ? "" : keepaliveLine + "\n");
     }


### PR DESCRIPTION
Addresses items 1, 2, 3 and 5 of #894, and the contained parts of item 4.

## 1. Trailing dot

`HostsBlocklistLogic.stripTrailingDot` removes a single terminal dot (a bare `.` is left alone) and is applied both when a hosts entry is parsed and when `TrackerList.findTracker`/`findMinimalTracker` look a qname up, so `0.0.0.0 ads.example.` matches a query for `ads.example`. The class becomes public so `TrackerList` can share the helper.

## 2. Several hostnames per line

The parser accepted only lines with exactly two tokens. It now iterates every token after the address, as `hosts(5)` allows and merged blocklists rely on; an address with no hostname is still logged as invalid.

## 3. Direct-app DNS redirect

`resolveDirectDnsTarget` took the first system resolver as-is. It now skips anything `isUsableDns` would reject (loopback, any-local, link-local), honouring the `ip6` preference the normal path uses, and falls through to the existing "keeping their DNS in the tunnel" warning. `getDefaultDNS` strips the interface scope, so a link-local candidate could never be reached from the tun.

## 4. Proxy hardening, contained parts only

- `DnsOverHttpsClient` gets a whole-call timeout of 20 s, above the sum of the three per-phase timeouts.
- `Util.getOrganization` gets a connect timeout to match its read timeout.
- `DnsProxyServer.stop()` keeps the listener threads and joins each with a 2 s bound after closing the sockets, so an immediate `start()` cannot leave an old listener observing the new socket and executor fields.
- The UDP receive buffer grows from 4096 to 65535 bytes so a larger EDNS query is not silently truncated.

Admission control for the pool and RFC 7766 TCP pipelining are design changes rather than fixes and are left for the issue.

## 5. `AllowedIPs` is validated as numeric

`WgConfigParser` rejects any `AllowedIPs` entry that is not a numeric IPv4 or IPv6 address with an optional in-range prefix, using the parser's existing `WgConfigException`. `VpnRoutes.parseV4AllowedIps` parses dotted-quad literals by hand and constructs the address with `getByAddress`, so a hostile profile can no longer trigger a resolver lookup on the VPN setup thread.

## Tests

`HostsBlocklistLogicTest` covers multi-hostname lines, address-only lines and the trailing-dot helper; `VpnRoutesTest` shows a hostname entry being ignored while numeric entries still route; `WgConfigParserTest` shows a hostname entry rejected and `0.0.0.0/0, ::/0` accepted.

## Verification

No Android SDK was available in this session, so this was reviewed line by line rather than compiled or run locally. CI runs the unit tests and the release assemble on the pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam)_