### PR TITLE
Propagate database migration failures instead of swallowing them

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -484,7 +484,13 @@ public class DatabaseHelper extends SQLiteOpenHelper {
                         DB_NAME + " upgraded to " + oldVersion + " but required " + DB_VERSION);
 
         } catch (Throwable ex) {
-            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+            // Rethrow rather than swallow: SQLiteOpenHelper wraps onUpgrade and its own
+            // version write in an outer transaction, so propagating the failure rolls
+            // back the version as well and the migration runs again on the next open.
+            // Returning normally would leave the old schema marked as the new version.
+            Log.e(TAG, DB_NAME + " upgrade failed at version " + oldVersion + ": "
+                    + ex + "\n" + Log.getStackTraceString(ex));
+            throw ex;
         } finally {
             db.endTransaction();
         }

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperMigrationTest.java
@@ -1,10 +1,13 @@
 package eu.faircode.netguard;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -123,6 +126,17 @@ public class DatabaseHelperMigrationTest {
             assertEquals("203.0.113.25", cursor.getString(2));
             assertEquals(5000L, cursor.getLong(3));
         }
+    }
+
+    @Test
+    public void failedUpgradePropagatesAndLeavesVersionUnchanged() {
+        // No access table, so the version 22 step's ALTER TABLE cannot succeed.
+        database.setVersion(22);
+
+        assertThrows(SQLiteException.class, () -> helper.onUpgrade(database, 22, 23));
+
+        assertEquals(22, database.getVersion());
+        assertFalse(database.inTransaction());
     }
 
     private static void createVersion16AccessTable(SQLiteDatabase db) {


### PR DESCRIPTION
Closes #893 (item 3, the last one open after #899).

## What changed

`DatabaseHelper.onUpgrade` logged and swallowed any exception thrown by a migration step. The inner transaction rolled back the schema changes, but `SQLiteOpenHelper` saw the method return normally and wrote the new `user_version` anyway, leaving the database on the old schema while marked as upgraded. The migration never ran again and later queries failed against columns that were never added.

The catch block now logs the failing version and rethrows. `SQLiteOpenHelper` wraps `onUpgrade` and its own version write in an outer transaction, so the version is rolled back too and the migration retries on the next open. A failed migration now fails loudly instead of leaving a silently broken schema.

The rethrow uses Java's precise rethrow: the try block throws only unchecked exceptions, so `onUpgrade` keeps its `throws`-free signature.

## Tests

- New `failedUpgradePropagatesAndLeavesVersionUnchanged` in `DatabaseHelperMigrationTest`: runs the 22→23 step against a database with no `access` table, asserts the `SQLiteException` propagates, the version stays at 22 and no transaction is left open.
- Not run locally: this container has no Android SDK, so the Robolectric suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam)_