### PR TITLE
Toggle WireGuard keepalive per peer instead of reapplying the config

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConfig.kt
@@ -38,6 +38,16 @@ data class WgConfig(
         }
         return sb.toString()
     }
+
+    /**
+     * Per-peer keepalive intervals to push when the screen-state policy
+     * changes: (public key, seconds), 0 meaning disabled. Peers without a
+     * configured PersistentKeepalive are left alone.
+     */
+    fun keepaliveUpdates(keepaliveEnabled: Boolean): List<Pair<String, Int>> =
+        peers.mapNotNull { peer ->
+            peer.persistentKeepalive?.let { peer.publicKey to (if (keepaliveEnabled) it else 0) }
+        }
 }
 
 data class WgPeer(

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgEgress.kt
@@ -296,7 +296,7 @@ object WgEgress {
             val oldKeepaliveEnabled = currentInteractive || currentKeepaliveAlwaysOn
             val newKeepaliveEnabled = interactive || keepaliveAlwaysOn
             if (oldKeepaliveEnabled != newKeepaliveEnabled &&
-                !reapplyConfigOrError(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn))
+                !updateKeepaliveOrError(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn))
                 return false
             // The tunnel can outlive a monitor whose initial stats read raced
             // tunnel startup (or which exited after a stale sample). Keep the
@@ -815,7 +815,7 @@ object WgEgress {
         }
 
         try {
-            reapplyConfig(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn)
+            updateKeepalive(configText!!, newKeepaliveEnabled, interactive, keepaliveAlwaysOn)
         } catch (e: Throwable) {
             Log.w(TAG, "could not update WG keepalive for screen state", e)
         }
@@ -872,21 +872,50 @@ object WgEgress {
         return wgEnabled && !configText.isNullOrEmpty() && tunnel != null
     }
 
-    private fun reapplyConfigOrError(
+    private fun updateKeepaliveOrError(
         configText: String,
         keepaliveEnabled: Boolean,
         interactive: Boolean,
         keepaliveAlwaysOn: Boolean
     ): Boolean {
         return try {
-            reapplyConfig(configText, keepaliveEnabled, interactive, keepaliveAlwaysOn)
+            updateKeepalive(configText, keepaliveEnabled, interactive, keepaliveAlwaysOn)
             true
         } catch (e: Throwable) {
             lastError = "WireGuard tunnel failed to update: ${e.message ?: e.javaClass.simpleName}"
-            Log.e(TAG, "Wgbridge.setConfig failed", e)
+            Log.e(TAG, "WG keepalive update failed", e)
             notifyStateChanged()
             false
         }
+    }
+
+    /**
+     * Applies the screen-state keepalive policy by changing only the peers'
+     * keepalive intervals. Routing this through [reapplyConfig] re-resolved
+     * every endpoint (a DNS lookup, with a bounded wait, over a tunnel that
+     * may itself be half-dead on most screen-on events after an idle period)
+     * and re-serialised the whole config for a single field. The full reapply
+     * remains the fallback if the cheap path is refused.
+     */
+    private fun updateKeepalive(
+        configText: String,
+        keepaliveEnabled: Boolean,
+        interactive: Boolean,
+        keepaliveAlwaysOn: Boolean
+    ) {
+        val t = tunnel ?: return
+        val updates = WgConfigParser.parse(configText).keepaliveUpdates(keepaliveEnabled)
+        try {
+            for ((publicKey, seconds) in updates) t.setKeepalive(publicKey, seconds)
+        } catch (e: Throwable) {
+            Log.w(TAG, "setKeepalive failed, reapplying full config", e)
+            reapplyConfig(configText, keepaliveEnabled, interactive, keepaliveAlwaysOn)
+            return
+        }
+        currentInteractive = interactive
+        currentKeepaliveAlwaysOn = keepaliveAlwaysOn
+        lastError = null
+        notifyStateChanged()
     }
 
     private fun reapplyConfig(

--- a/app/src/main/java/net/kollnig/missioncontrol/wgbridge/Tunnel.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wgbridge/Tunnel.java
@@ -63,6 +63,16 @@ public final class Tunnel {
     }
 
     /**
+     * Sets one peer's persistent keepalive interval in seconds (0 disables
+     * it) without disturbing the session. This is how the screen-state
+     * keepalive policy is applied; {@link #setConfig} would re-serialise the
+     * whole configuration, endpoint resolution included, for a single field.
+     */
+    public synchronized void setKeepalive(String peerPublicKeyBase64, int seconds) {
+        nativeSetKeepalive(handle, peerPublicKeyBase64, seconds);
+    }
+
+    /**
      * Tears down gotatun and closes the duplicated fds. Idempotent.
      */
     public synchronized void stop() {
@@ -81,6 +91,8 @@ public final class Tunnel {
     private static native void nativeRebind(long handle);
 
     private static native void nativeUpdateEndpoint(long handle, String peerPublicKeyBase64, String endpoint);
+
+    private static native void nativeSetKeepalive(long handle, String peerPublicKeyBase64, int seconds);
 
     private static native void nativeStop(long handle);
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConfigParserTest.java
@@ -7,6 +7,10 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Collections;
+
+import kotlin.Pair;
+
 public class WgConfigParserTest {
     private static final String KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 
@@ -72,6 +76,21 @@ public class WgConfigParserTest {
                 () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("2001:db8::1%wlan0/64")));
         assertThrows(WgConfigException.class,
                 () -> WgConfigParser.INSTANCE.parse(configWithAllowedIps("::ffff:999.0.2.0/120")));
+    }
+
+    @Test
+    public void keepaliveUpdatesFollowThePolicy() throws Exception {
+        WgConfig config = WgConfigParser.INSTANCE.parse(config("PersistentKeepalive = 25"));
+
+        assertEquals(Collections.singletonList(new Pair<>(KEY, 25)), config.keepaliveUpdates(true));
+        assertEquals(Collections.singletonList(new Pair<>(KEY, 0)), config.keepaliveUpdates(false));
+    }
+
+    @Test
+    public void keepaliveUpdatesSkipPeersWithoutKeepalive() throws Exception {
+        WgConfig config = WgConfigParser.INSTANCE.parse(config(""));
+
+        assertTrue(config.keepaliveUpdates(true).isEmpty());
     }
 
     private static String config(String keepaliveLine) {

--- a/wgbridge-rs/README.md
+++ b/wgbridge-rs/README.md
@@ -189,6 +189,7 @@ class Tunnel {
     void sendKeepalive();
     void rebind();                // re-bind + re-protect UDP sockets (roaming)
     void updateEndpoint(String peerPublicKeyBase64, String endpoint);
+    void setKeepalive(String peerPublicKeyBase64, int seconds);  // 0 disables
     void stop();
 }
 ```

--- a/wgbridge-rs/src/jni_bindings.rs
+++ b/wgbridge-rs/src/jni_bindings.rs
@@ -12,7 +12,7 @@ use jni::{jni_sig, jni_str, Env, EnvUnowned, JavaVM};
 
 use crate::callbacks::{BridgeLogger, DnsSink, NullLogger, SocketProtector};
 use crate::keys;
-use crate::tunnel::{start_tunnel, Tunnel};
+use crate::tunnel::{keepalive_from_secs, start_tunnel, Tunnel};
 
 static LOGGER_INIT: Once = Once::new();
 
@@ -413,6 +413,43 @@ pub extern "system" fn Java_net_kollnig_missioncontrol_wgbridge_Tunnel_nativeUpd
             }
         };
         if let Err(e) = tunnel.update_endpoint(&key, &endpoint) {
+            throw(env, &e);
+        }
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_net_kollnig_missioncontrol_wgbridge_Tunnel_nativeSetKeepalive(
+    mut unowned_env: EnvUnowned,
+    _class: JClass,
+    handle: jlong,
+    public_key: JString,
+    seconds: jint,
+) {
+    with_native_env!(unowned_env, env, {
+        let Some(tunnel) = tunnel_from_handle(handle) else {
+            throw(env, "tunnel stopped");
+            return;
+        };
+        let Some(public_key) = get_string(env, &public_key) else {
+            throw(env, "publicKey must not be null");
+            return;
+        };
+        let key = match keys::parse_public_key_b64(&public_key) {
+            Ok(key) => key,
+            Err(e) => {
+                throw(env, &e);
+                return;
+            }
+        };
+        let keepalive = match keepalive_from_secs(seconds) {
+            Ok(keepalive) => keepalive,
+            Err(e) => {
+                throw(env, &e);
+                return;
+            }
+        };
+        if let Err(e) = tunnel.set_keepalive(&key, keepalive) {
             throw(env, &e);
         }
     })

--- a/wgbridge-rs/src/tunnel.rs
+++ b/wgbridge-rs/src/tunnel.rs
@@ -227,6 +227,15 @@ impl Tunnel {
 
             tokio::time::sleep(PROD_RESTORE_AFTER).await;
 
+            // Take the device lock before deciding anything. set_keepalive and
+            // set_config update the peer table while holding it, and a newer
+            // prod bumps the generation before taking it, so checking the
+            // generation and snapshotting the configured intervals under the
+            // lock leaves no window for a policy change to land between the
+            // snapshot and the write below and then be overwritten by it.
+            let guard = inner.device.lock().await;
+            let Some(device) = guard.as_ref() else { return };
+
             // A newer prod owns the interval now; let its restore run instead.
             if inner.prod_generation.load(Ordering::SeqCst) != generation {
                 return;
@@ -236,8 +245,6 @@ impl Tunnel {
                 let peers = inner.peers.lock().unwrap();
                 peers.iter().map(|p| (p.public_key, p.keepalive)).collect()
             };
-            let guard = inner.device.lock().await;
-            let Some(device) = guard.as_ref() else { return };
             let _ = device
                 .write(async |d| {
                     for (key, keepalive) in &configured {

--- a/wgbridge-rs/src/tunnel.rs
+++ b/wgbridge-rs/src/tunnel.rs
@@ -129,7 +129,8 @@ pub fn start_tunnel(
 
 impl Tunnel {
     /// Reapplies UAPI configuration to the running device without restarting
-    /// it (used for the screen-state keepalive toggle).
+    /// it. The screen-state keepalive toggle goes through [`Tunnel::set_keepalive`]
+    /// instead, which touches one field per peer.
     pub fn set_config(&self, uapi_config: &str) -> Result<(), String> {
         let config = parse_uapi_config(uapi_config).map_err(|e| e.to_string())?;
         let inner = Arc::clone(&self.inner);
@@ -309,6 +310,44 @@ impl Tunnel {
         })
     }
 
+    /// Changes one peer's persistent keepalive interval (`None` disables it)
+    /// without disturbing its session or endpoint. This carries the
+    /// screen-state keepalive policy: reapplying the whole config for it
+    /// re-resolved every endpoint and re-serialised every peer for one field.
+    pub fn set_keepalive(
+        &self,
+        public_key: &PublicKey,
+        keepalive: Option<u16>,
+    ) -> Result<(), String> {
+        let inner = Arc::clone(&self.inner);
+        let key = public_key.clone();
+
+        self.runtime.block_on(async move {
+            let guard = inner.device.lock().await;
+            let device = guard.as_ref().ok_or("tunnel stopped")?;
+            let found = device
+                .write(async |d| d.modify_peer(&key, |p| p.set_keepalive(keepalive)).await)
+                .await
+                .map_err(|e| e.to_string())?;
+            if !found {
+                return Err("no such peer".to_owned());
+            }
+            // The prod restore reads the configured interval from here, so a
+            // prod in flight restores to the new value rather than the old one.
+            {
+                let mut peers = inner.peers.lock().unwrap();
+                if let Some(p) = peers.iter_mut().find(|p| p.public_key == key) {
+                    p.keepalive = keepalive;
+                }
+            }
+            inner.logger.verbose(&format!(
+                "peer keepalive set to {}s",
+                keepalive.unwrap_or(0)
+            ));
+            Ok(())
+        })
+    }
+
     /// Tears down gotatun and closes the duplicated fds. Idempotent.
     pub fn stop(&self) {
         let inner = Arc::clone(&self.inner);
@@ -325,5 +364,38 @@ impl Tunnel {
 impl Drop for Tunnel {
     fn drop(&mut self) {
         self.stop();
+    }
+}
+
+/// Maps the Java-side keepalive seconds (0 or negative disables) onto the
+/// interval gotatun stores, rejecting values the wire format cannot carry.
+pub fn keepalive_from_secs(secs: i32) -> Result<Option<u16>, String> {
+    if secs <= 0 {
+        return Ok(None);
+    }
+    u16::try_from(secs)
+        .map(Some)
+        .map_err(|_| format!("keepalive {secs}s exceeds 65535"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::keepalive_from_secs;
+
+    #[test]
+    fn zero_or_negative_disables_keepalive() {
+        assert_eq!(keepalive_from_secs(0), Ok(None));
+        assert_eq!(keepalive_from_secs(-5), Ok(None));
+    }
+
+    #[test]
+    fn positive_seconds_are_kept() {
+        assert_eq!(keepalive_from_secs(25), Ok(Some(25)));
+        assert_eq!(keepalive_from_secs(65535), Ok(Some(65535)));
+    }
+
+    #[test]
+    fn out_of_range_is_rejected() {
+        assert!(keepalive_from_secs(65536).is_err());
     }
 }


### PR DESCRIPTION
Part of #884 (item 3).

## What changed

Screen on/off applied the keepalive policy through `WgEgress.reapplyConfig`, which re-resolved every peer endpoint and re-serialised the whole UAPI config to change a single field. With the endpoint cache at five minutes, most screen-on events after an idle period spawned a `wg-resolve` thread and did a DNS lookup over a tunnel that may itself have been half-dead, with a four second bounded wait.

- **Rust**: `Tunnel::set_keepalive(peer, Option<u16>)` uses gotatun's `modify_peer` to change just that peer's interval, and records it in the bridge's peer table so a keepalive prod already in flight restores to the new value rather than the old one. `keepalive_from_secs` maps the Java `int` (0 or negative disables) and rejects values above `u16`.
- **JNI / Java**: `Tunnel.setKeepalive(String peerPublicKeyBase64, int seconds)`, mirroring `updateEndpoint`.
- **Kotlin**: `WgConfig.keepaliveUpdates(enabled)` yields the per-peer (key, seconds) list, skipping peers with no configured keepalive. `WgEgress.updateKeepalive` pushes it for both the screen-state event and the same-config `startOrUpdate` path. If the cheap path throws, it falls back to the full `reapplyConfig`, so behaviour is never worse than before.
- README lists the new entry point.

Tunnel start is unchanged: it still serialises `persistent_keepalive_interval=0` when the screen is off, and the first screen-on sets the configured value through the new path.

## Tests

- `cargo test --workspace` passes locally (host build), including three new `keepalive_from_secs` cases.
- `WgConfigParserTest` gains `keepaliveUpdatesFollowThePolicy` and `keepaliveUpdatesSkipPeersWithoutKeepalive`.
- Not run locally: the Android build and Robolectric suite (no SDK in this container); CI covers them.

## Device check worth doing

With a WireGuard profile that has `PersistentKeepalive`, toggle the screen and watch `logcat -s wgbridge`: it should log `peer keepalive set to 0s` / `25s` and no `wg-resolve` activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam)_