### PR TITLE
Download blocklists conditionally and skip the reload when unchanged

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -67,10 +67,8 @@ import androidx.preference.ListPreference;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.preference.PreferenceManager;
 import androidx.work.Constraints;
-import androidx.work.ExistingPeriodicWorkPolicy;
 import androidx.work.NetworkType;
 import androidx.work.OneTimeWorkRequest;
-import androidx.work.PeriodicWorkRequest;
 import androidx.work.WorkManager;
 
 import net.kollnig.missioncontrol.BuildConfig;
@@ -109,7 +107,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
@@ -528,24 +525,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             pref_hosts_auto_update.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 @Override
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    boolean enabled = (Boolean) newValue;
-                    if (enabled) {
-                        Constraints constraints = new Constraints.Builder()
-                                .setRequiredNetworkType(NetworkType.CONNECTED)
-                                .setRequiresBatteryNotLow(true)
-                                .build();
-
-                        PeriodicWorkRequest saveRequest = new PeriodicWorkRequest.Builder(HostsDownloadWorker.class, 24,
-                                TimeUnit.HOURS)
-                                .setConstraints(constraints)
-                                .build();
-                        WorkManager.getInstance(ActivitySettings.this).enqueueUniquePeriodicWork(
-                                "HostsUpdate",
-                                ExistingPeriodicWorkPolicy.UPDATE,
-                                saveRequest);
-                    } else {
-                        WorkManager.getInstance(ActivitySettings.this).cancelUniqueWork("HostsUpdate");
-                    }
+                    HostsDownloadWorker.scheduleAutoUpdate(ActivitySettings.this, (Boolean) newValue);
                     return true;
                 }
             });

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -532,6 +532,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     if (enabled) {
                         Constraints constraints = new Constraints.Builder()
                                 .setRequiredNetworkType(NetworkType.CONNECTED)
+                                .setRequiresBatteryNotLow(true)
                                 .build();
 
                         PeriodicWorkRequest saveRequest = new PeriodicWorkRequest.Builder(HostsDownloadWorker.class, 24,

--- a/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
@@ -122,6 +122,16 @@ public class ApplicationEx extends Application {
 
         SharedPreferences prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(this);
         migratePreferences(prefs);
+        // An install that enabled the daily blocklist update under an older version
+        // still has it enqueued with that version's constraints, and the preference
+        // listener only runs when the user changes the setting. Guarded because this
+        // is the startup path: a WorkManager that cannot initialise should cost the
+        // reconcile, not the app.
+        try {
+            HostsDownloadWorker.reconcileAutoUpdate(this, prefs);
+        } catch (Throwable ex) {
+            Log.w(TAG, "Could not reconcile the hosts auto-update: " + ex);
+        }
         BlockingMode.enforcePlayStoreMode(this);
 
         // Keep VPN exclusions aligned with the selected blocking mode on startup.

--- a/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
@@ -21,10 +21,16 @@
 package eu.faircode.netguard;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.preference.PreferenceManager;
+import androidx.work.Constraints;
+import androidx.work.ExistingPeriodicWorkPolicy;
+import androidx.work.NetworkType;
+import androidx.work.PeriodicWorkRequest;
+import androidx.work.WorkManager;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -42,11 +48,33 @@ import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 import java.util.zip.GZIPInputStream;
 
 public class HostsDownloadWorker extends Worker {
     private static final String TAG = "TrackerControl.Hosts";
+
+    /** Unique name of the daily auto-update work. */
+    static final String WORK_AUTO_UPDATE = "HostsUpdate";
+
+    /**
+     * Set as soon as a list's file has been replaced and cleared only once the
+     * merged hosts file has been rebuilt from it. Without it, a run killed
+     * between the two would leave a stale merged file that every later 304
+     * would then treat as current.
+     */
+    static final String PREF_MERGE_PENDING = "hosts_merge_pending";
+
+    /**
+     * Schedule version the enqueued auto-update work was last built with. Bump
+     * {@link #SCHEDULE_VERSION} whenever the constraints or the period below change,
+     * so installs that already have the work enqueued are rescheduled once with the
+     * new specification rather than keeping the old one until the user toggles the
+     * setting off and on.
+     */
+    private static final String PREF_SCHEDULE_VERSION = "hosts_auto_update_schedule_version";
+    private static final int SCHEDULE_VERSION = 1;
 
     /** Whether a single blocklist's body actually needed re-downloading. */
     enum DownloadOutcome {
@@ -72,6 +100,7 @@ public class HostsDownloadWorker extends Worker {
         Log.i(TAG, "Starting hosts download");
 
         Context context = getApplicationContext();
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
         BlocklistManager manager = BlocklistManager.getInstance(context);
         List<Blocklist> lists = manager.getBlocklists();
         boolean anySuccess = false;
@@ -101,6 +130,10 @@ public class HostsDownloadWorker extends Worker {
 
                 if (outcome == DownloadOutcome.UPDATED) {
                     item.lastModified = new Date().getTime();
+                    // Written durably, and before the validators that would let the
+                    // next run answer 304 for every list: the merged file is out of
+                    // date from here until the merge below succeeds.
+                    prefs.edit().putBoolean(PREF_MERGE_PENDING, true).commit();
                     anyChanged = true;
                 }
                 manager.updateBlocklist(item);
@@ -126,13 +159,12 @@ public class HostsDownloadWorker extends Worker {
 
         if (anySuccess) {
             File hostsFile = new File(context.getFilesDir(), "hosts.txt");
-            if (!anyChanged && hostsFile.exists()) {
-                // Every successful list came back unchanged and we already have a merged
-                // file, so there is nothing to re-merge and no reason to disturb live
-                // connections with a reload.
+            if (canSkipMerge(anyChanged, prefs.getBoolean(PREF_MERGE_PENDING, false), hostsFile.exists())) {
+                // Every successful list came back unchanged and the merged file is
+                // known to be built from them, so there is nothing to re-merge and no
+                // reason to disturb live connections with a reload.
                 String last = SimpleDateFormat.getDateTimeInstance().format(new Date().getTime());
-                PreferenceManager.getDefaultSharedPreferences(context).edit()
-                        .putString("hosts_last_download", last).apply();
+                prefs.edit().putString("hosts_last_download", last).apply();
 
                 Log.i(TAG, "Hosts unchanged, skipping merge and reload");
                 return Result.success();
@@ -140,8 +172,10 @@ public class HostsDownloadWorker extends Worker {
 
             if (manager.mergeBlocklists()) {
                 String last = SimpleDateFormat.getDateTimeInstance().format(new Date().getTime());
-                PreferenceManager.getDefaultSharedPreferences(context).edit()
-                        .putString("hosts_last_download", last).apply();
+                prefs.edit()
+                        .putString("hosts_last_download", last)
+                        .putBoolean(PREF_MERGE_PENDING, false)
+                        .commit();
 
                 Log.i(TAG, "Hosts downloaded and merged successfully");
                 ServiceSinkhole.reload("hosts file download", context, false);
@@ -156,6 +190,59 @@ public class HostsDownloadWorker extends Worker {
             showNotification(context, "Hosts download failed");
             return Result.failure();
         }
+    }
+
+    /**
+     * Whether the merged hosts file can be left alone: every successful list came
+     * back unchanged, no earlier run left a replacement unmerged, and a merged file
+     * exists to leave alone in the first place.
+     */
+    static boolean canSkipMerge(boolean anyChanged, boolean mergePending, boolean mergedFileExists) {
+        return !anyChanged && !mergePending && mergedFileExists;
+    }
+
+    /**
+     * Brings an already-enqueued auto-update in line with the current schedule
+     * version, once per version. Called from application startup, since the
+     * preference listener only runs when the user changes the setting.
+     */
+    static void reconcileAutoUpdate(Context context, SharedPreferences prefs) {
+        if (prefs.getInt(PREF_SCHEDULE_VERSION, 0) >= SCHEDULE_VERSION)
+            return;
+
+        // Nothing is enqueued while the setting is off, and switching it on goes
+        // through scheduleAutoUpdate anyway, so only record the version there.
+        if (prefs.getBoolean("hosts_auto_update", false))
+            scheduleAutoUpdate(context, true);
+        else
+            prefs.edit().putInt(PREF_SCHEDULE_VERSION, SCHEDULE_VERSION).apply();
+    }
+
+    /**
+     * Enqueues or cancels the daily blocklist update to match {@code enabled}.
+     * <p>
+     * Enqueued with {@link ExistingPeriodicWorkPolicy#UPDATE} rather than
+     * {@code KEEP} so an install that switched auto-update on under an older
+     * version keeps its schedule but picks up the current constraints, instead of
+     * carrying the old ones until the user toggles the setting.
+     */
+    static void scheduleAutoUpdate(Context context, boolean enabled) {
+        WorkManager workManager = WorkManager.getInstance(context);
+        if (!enabled) {
+            workManager.cancelUniqueWork(WORK_AUTO_UPDATE);
+            return;
+        }
+
+        Constraints constraints = new Constraints.Builder()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresBatteryNotLow(true)
+                .build();
+        PeriodicWorkRequest request = new PeriodicWorkRequest.Builder(HostsDownloadWorker.class, 24, TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build();
+        workManager.enqueueUniquePeriodicWork(WORK_AUTO_UPDATE, ExistingPeriodicWorkPolicy.UPDATE, request);
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putInt(PREF_SCHEDULE_VERSION, SCHEDULE_VERSION).apply();
     }
 
     /**

--- a/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
@@ -39,14 +39,28 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
+import java.util.function.BooleanSupplier;
 import java.util.zip.GZIPInputStream;
 
 public class HostsDownloadWorker extends Worker {
     private static final String TAG = "TrackerControl.Hosts";
+
+    /** Whether a single blocklist's body actually needed re-downloading. */
+    enum DownloadOutcome {
+        UPDATED,
+        UNCHANGED
+    }
+
+    /**
+     * Thrown from {@link #download} to abort a download promptly when
+     * {@code isStopped()} fires mid-copy; caught by {@link #doWork} only, never treated
+     * as a per-list failure.
+     */
+    private static final class StopRequestedException extends RuntimeException {
+    }
 
     public HostsDownloadWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
@@ -62,6 +76,7 @@ public class HostsDownloadWorker extends Worker {
         List<Blocklist> lists = manager.getBlocklists();
         boolean anySuccess = false;
         boolean allSuccess = true;
+        boolean anyChanged = false;
 
         for (Blocklist item : lists) {
             if (!item.enabled)
@@ -71,60 +86,28 @@ public class HostsDownloadWorker extends Worker {
             File tmp = new File(context.getFilesDir(), "blocklist_" + item.uuid + ".tmp");
             File target = manager.getBlocklistFile(item.uuid);
 
-            InputStream in = null;
-            OutputStream out = null;
-            URLConnection connection = null;
-
+            HttpURLConnection connection = null;
             try {
                 URL url = new URL(item.url);
                 if (!"https".equalsIgnoreCase(url.getProtocol()))
                     throw new IOException("Only HTTPS blocklist URLs are supported");
-                connection = url.openConnection();
+
+                connection = (HttpURLConnection) url.openConnection();
                 connection.setRequestProperty("Accept-Encoding", "gzip");
                 connection.setConnectTimeout(15000);
                 connection.setReadTimeout(15000);
-                connection.connect();
 
-                if (connection instanceof HttpURLConnection) {
-                    HttpURLConnection httpConnection = (HttpURLConnection) connection;
-                    if (httpConnection.getResponseCode() != HttpURLConnection.HTTP_OK)
-                        throw new IOException(
-                                httpConnection.getResponseCode() + " " + httpConnection.getResponseMessage());
-                }
+                DownloadOutcome outcome = download(item, connection, tmp, target, this::isStopped);
 
-                if ("gzip".equals(connection.getContentEncoding()))
-                    in = new GZIPInputStream(connection.getInputStream());
-                else
-                    in = connection.getInputStream();
-
-                out = new FileOutputStream(tmp);
-
-                byte[] buffer = new byte[4096];
-                int bytes;
-                while ((bytes = in.read(buffer)) != -1) {
-                    if (isStopped()) {
-                        return Result.failure();
-                    }
-                    out.write(buffer, 0, bytes);
-                }
-
-                if (target.exists()) {
-                    target.delete();
-                }
-                if (tmp.renameTo(target)) {
+                if (outcome == DownloadOutcome.UPDATED) {
                     item.lastModified = new Date().getTime();
-                    item.lastDownloadSuccess = true;
-                    item.lastErrorMessage = null;
-                    manager.updateBlocklist(item);
-                    anySuccess = true;
-                } else {
-                    Log.e(TAG, "Failed to rename temp file for " + item.url);
-                    item.lastDownloadSuccess = false;
-                    item.lastErrorMessage = "Failed to save file";
-                    manager.updateBlocklist(item);
-                    allSuccess = false;
+                    anyChanged = true;
                 }
+                manager.updateBlocklist(item);
+                anySuccess = true;
 
+            } catch (StopRequestedException stop) {
+                return Result.failure();
             } catch (Throwable ex) {
                 Log.e(TAG, "Failed to download " + item.url + ": " + ex.toString());
                 item.lastDownloadSuccess = false;
@@ -135,25 +118,26 @@ public class HostsDownloadWorker extends Worker {
                 if (tmp.exists()) {
                     tmp.delete();
                 }
-                try {
-                    if (out != null)
-                        out.close();
-                } catch (IOException ex) {
-                    Log.e(TAG, ex.toString());
-                }
-                try {
-                    if (in != null)
-                        in.close();
-                } catch (IOException ex) {
-                    Log.e(TAG, ex.toString());
-                }
-                if (connection instanceof HttpURLConnection) {
-                    ((HttpURLConnection) connection).disconnect();
+                if (connection != null) {
+                    connection.disconnect();
                 }
             }
         }
 
         if (anySuccess) {
+            File hostsFile = new File(context.getFilesDir(), "hosts.txt");
+            if (!anyChanged && hostsFile.exists()) {
+                // Every successful list came back unchanged and we already have a merged
+                // file, so there is nothing to re-merge and no reason to disturb live
+                // connections with a reload.
+                String last = SimpleDateFormat.getDateTimeInstance().format(new Date().getTime());
+                PreferenceManager.getDefaultSharedPreferences(context).edit()
+                        .putString("hosts_last_download", last).apply();
+
+                Log.i(TAG, "Hosts unchanged, skipping merge and reload");
+                return Result.success();
+            }
+
             if (manager.mergeBlocklists()) {
                 String last = SimpleDateFormat.getDateTimeInstance().format(new Date().getTime());
                 PreferenceManager.getDefaultSharedPreferences(context).edit()
@@ -172,6 +156,74 @@ public class HostsDownloadWorker extends Worker {
             showNotification(context, "Hosts download failed");
             return Result.failure();
         }
+    }
+
+    /**
+     * Downloads a single blocklist over an already-opened connection.
+     * <p>
+     * When {@code target} exists, sends {@code If-None-Match}/{@code If-Modified-Since}
+     * from {@code item}'s stored validators (a missing target is always fetched
+     * unconditionally, never conditionally). A {@code 304} response leaves
+     * {@code target} untouched and returns {@link DownloadOutcome#UNCHANGED}. A
+     * {@code 200} response is written to {@code tmp}, renamed onto {@code target}, has
+     * its {@code ETag}/{@code Last-Modified} response headers stored on {@code item}
+     * (either may end up null if the server stops sending them) and returns
+     * {@link DownloadOutcome#UPDATED}. Any other response code, or a failed rename,
+     * throws {@link IOException}.
+     */
+    static DownloadOutcome download(Blocklist item, HttpURLConnection connection, File tmp, File target,
+            BooleanSupplier isStopped) throws IOException {
+        if (target.exists()) {
+            if (item.etag != null)
+                connection.setRequestProperty("If-None-Match", item.etag);
+            if (item.lastModifiedHeader != null)
+                connection.setRequestProperty("If-Modified-Since", item.lastModifiedHeader);
+        }
+
+        connection.connect();
+
+        int responseCode = connection.getResponseCode();
+        if (responseCode == HttpURLConnection.HTTP_NOT_MODIFIED) {
+            item.lastDownloadSuccess = true;
+            item.lastErrorMessage = null;
+            return DownloadOutcome.UNCHANGED;
+        }
+        if (responseCode != HttpURLConnection.HTTP_OK)
+            throw new IOException(responseCode + " " + connection.getResponseMessage());
+
+        InputStream in = null;
+        OutputStream out = null;
+        try {
+            in = "gzip".equals(connection.getContentEncoding())
+                    ? new GZIPInputStream(connection.getInputStream())
+                    : connection.getInputStream();
+            out = new FileOutputStream(tmp);
+
+            byte[] buffer = new byte[4096];
+            int bytes;
+            while ((bytes = in.read(buffer)) != -1) {
+                if (isStopped.getAsBoolean())
+                    throw new StopRequestedException();
+                out.write(buffer, 0, bytes);
+            }
+        } finally {
+            if (out != null)
+                out.close();
+            if (in != null)
+                in.close();
+        }
+
+        if (target.exists())
+            target.delete();
+        if (!tmp.renameTo(target))
+            throw new IOException("Failed to save file");
+
+        item.etag = connection.getHeaderField("ETag");
+        item.lastModifiedHeader = connection.getHeaderField("Last-Modified");
+        item.lastDownloadSuccess = true;
+        item.lastErrorMessage = null;
+
+        return DownloadOutcome.UPDATED;
     }
 
     private void showNotification(Context context, String message) {

--- a/app/src/main/java/net/kollnig/missioncontrol/data/Blocklist.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/Blocklist.java
@@ -10,6 +10,8 @@ public class Blocklist implements Serializable {
     public long lastModified;
     public boolean lastDownloadSuccess;
     public String lastErrorMessage;
+    public String etag;
+    public String lastModifiedHeader;
 
     public Blocklist() {
         this.uuid = UUID.randomUUID().toString();

--- a/app/src/main/java/net/kollnig/missioncontrol/data/BlocklistManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/BlocklistManager.java
@@ -79,6 +79,8 @@ public class BlocklistManager {
                 item.lastModified = obj.optLong("lastModified", 0);
                 item.lastDownloadSuccess = obj.optBoolean("lastDownloadSuccess", true);
                 item.lastErrorMessage = obj.optString("lastErrorMessage", null);
+                item.etag = obj.optString("etag", null);
+                item.lastModifiedHeader = obj.optString("lastModifiedHeader", null);
                 list.add(item);
             }
         } catch (JSONException e) {
@@ -99,6 +101,8 @@ public class BlocklistManager {
                 obj.put("lastModified", item.lastModified);
                 obj.put("lastDownloadSuccess", item.lastDownloadSuccess);
                 obj.put("lastErrorMessage", item.lastErrorMessage);
+                obj.put("etag", item.etag);
+                obj.put("lastModifiedHeader", item.lastModifiedHeader);
                 jsonArray.put(obj);
             } catch (JSONException e) {
                 Log.e(TAG, "Error saving blocklist item", e);

--- a/app/src/test/java/eu/faircode/netguard/HostsDownloadWorkerTest.java
+++ b/app/src/test/java/eu/faircode/netguard/HostsDownloadWorkerTest.java
@@ -1,0 +1,205 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import net.kollnig.missioncontrol.data.Blocklist;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Covers {@link HostsDownloadWorker#download}, the seam that decides whether a single
+ * blocklist needs re-downloading. Plain JUnit: the method touches only {@code java.net}
+ * and {@code java.io}, no Android dependency.
+ */
+public class HostsDownloadWorkerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private static Blocklist blocklist() {
+        Blocklist item = new Blocklist("https://example.test/hosts", true);
+        item.etag = null;
+        item.lastModifiedHeader = null;
+        return item;
+    }
+
+    @Test
+    public void targetExistsWithStoredEtagSendsIfNoneMatchAndHandles304() throws IOException {
+        File target = folder.newFile("target.txt");
+        Files.write(target.toPath(), "old content".getBytes(StandardCharsets.UTF_8));
+        File tmp = new File(folder.getRoot(), "target.tmp");
+
+        Blocklist item = blocklist();
+        item.etag = "\"abc123\"";
+        item.lastDownloadSuccess = false;
+        item.lastErrorMessage = "previous failure";
+
+        FakeHttpURLConnection connection = new FakeHttpURLConnection(
+                HttpURLConnection.HTTP_NOT_MODIFIED, Collections.emptyMap(), new byte[0]);
+
+        HostsDownloadWorker.DownloadOutcome outcome =
+                HostsDownloadWorker.download(item, connection, tmp, target, () -> false);
+
+        assertEquals(HostsDownloadWorker.DownloadOutcome.UNCHANGED, outcome);
+        assertEquals("\"abc123\"", connection.capturedHeader("If-None-Match"));
+        assertEquals("old content", new String(Files.readAllBytes(target.toPath()), StandardCharsets.UTF_8));
+        assertTrue(item.lastDownloadSuccess);
+        assertNull(item.lastErrorMessage);
+    }
+
+    @Test
+    public void targetMissingSendsNoConditionalHeadersEvenWithStoredValidators() throws IOException {
+        File target = new File(folder.getRoot(), "target.txt");
+        File tmp = new File(folder.getRoot(), "target.tmp");
+        assertFalse(target.exists());
+
+        Blocklist item = blocklist();
+        item.etag = "\"stale-etag\"";
+        item.lastModifiedHeader = "Wed, 01 Jan 2025 00:00:00 GMT";
+
+        FakeHttpURLConnection connection = new FakeHttpURLConnection(
+                HttpURLConnection.HTTP_OK, Collections.emptyMap(), "fresh content".getBytes(StandardCharsets.UTF_8));
+
+        HostsDownloadWorker.DownloadOutcome outcome =
+                HostsDownloadWorker.download(item, connection, tmp, target, () -> false);
+
+        assertEquals(HostsDownloadWorker.DownloadOutcome.UPDATED, outcome);
+        assertNull(connection.capturedHeader("If-None-Match"));
+        assertNull(connection.capturedHeader("If-Modified-Since"));
+        assertEquals("fresh content", new String(Files.readAllBytes(target.toPath()), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void okWithValidatorsStoresThemOnItemAndReplacesFile() throws IOException {
+        File target = folder.newFile("target.txt");
+        Files.write(target.toPath(), "old content".getBytes(StandardCharsets.UTF_8));
+        File tmp = new File(folder.getRoot(), "target.tmp");
+
+        Blocklist item = blocklist();
+
+        Map<String, String> headers = Map.of(
+                "ETag", "\"new-etag\"",
+                "Last-Modified", "Thu, 02 Jan 2026 00:00:00 GMT");
+        FakeHttpURLConnection connection = new FakeHttpURLConnection(
+                HttpURLConnection.HTTP_OK, headers, "new content".getBytes(StandardCharsets.UTF_8));
+
+        HostsDownloadWorker.DownloadOutcome outcome =
+                HostsDownloadWorker.download(item, connection, tmp, target, () -> false);
+
+        assertEquals(HostsDownloadWorker.DownloadOutcome.UPDATED, outcome);
+        assertEquals("new content", new String(Files.readAllBytes(target.toPath()), StandardCharsets.UTF_8));
+        assertEquals("\"new-etag\"", item.etag);
+        assertEquals("Thu, 02 Jan 2026 00:00:00 GMT", item.lastModifiedHeader);
+        assertTrue(item.lastDownloadSuccess);
+        assertNull(item.lastErrorMessage);
+    }
+
+    @Test
+    public void okWithoutValidatorHeadersClearsStaleOnesFromItem() throws IOException {
+        File target = folder.newFile("target.txt");
+        Files.write(target.toPath(), "old content".getBytes(StandardCharsets.UTF_8));
+        File tmp = new File(folder.getRoot(), "target.tmp");
+
+        Blocklist item = blocklist();
+        item.etag = "\"stale-etag\"";
+        item.lastModifiedHeader = "Wed, 01 Jan 2025 00:00:00 GMT";
+
+        FakeHttpURLConnection connection = new FakeHttpURLConnection(
+                HttpURLConnection.HTTP_OK, Collections.emptyMap(), "new content".getBytes(StandardCharsets.UTF_8));
+
+        HostsDownloadWorker.DownloadOutcome outcome =
+                HostsDownloadWorker.download(item, connection, tmp, target, () -> false);
+
+        assertEquals(HostsDownloadWorker.DownloadOutcome.UPDATED, outcome);
+        assertNull(item.etag);
+        assertNull(item.lastModifiedHeader);
+    }
+
+    /**
+     * Minimal fake so the seam can be exercised without a real network stack. Request
+     * headers are captured into their own map rather than delegating to
+     * {@code URLConnection}'s, since that throws once {@link #connect()} has run (as
+     * {@link HostsDownloadWorker#download} always does before a test can inspect them).
+     */
+    private static final class FakeHttpURLConnection extends HttpURLConnection {
+        private final int responseCode;
+        private final Map<String, String> responseHeaders;
+        private final byte[] body;
+        private final Map<String, String> requestHeaders = new HashMap<>();
+
+        FakeHttpURLConnection(int responseCode, Map<String, String> responseHeaders, byte[] body)
+                throws MalformedURLException {
+            super(new URL("https://example.test/hosts"));
+            this.responseCode = responseCode;
+            this.responseHeaders = responseHeaders;
+            this.body = body;
+        }
+
+        @Override
+        public void setRequestProperty(String key, String value) {
+            requestHeaders.put(key, value);
+        }
+
+        String capturedHeader(String key) {
+            return requestHeaders.get(key);
+        }
+
+        @Override
+        public void connect() {
+            connected = true;
+        }
+
+        @Override
+        public void disconnect() {
+            connected = false;
+        }
+
+        @Override
+        public boolean usingProxy() {
+            return false;
+        }
+
+        @Override
+        public int getResponseCode() {
+            return responseCode;
+        }
+
+        @Override
+        public String getResponseMessage() {
+            return "fake";
+        }
+
+        @Override
+        public String getHeaderField(String name) {
+            return responseHeaders.get(name);
+        }
+
+        @Override
+        public String getContentEncoding() {
+            return null;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return new ByteArrayInputStream(body);
+        }
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/HostsDownloadWorkerTest.java
+++ b/app/src/test/java/eu/faircode/netguard/HostsDownloadWorkerTest.java
@@ -133,6 +133,18 @@ public class HostsDownloadWorkerTest {
         assertNull(item.lastModifiedHeader);
     }
 
+    @Test
+    public void mergeIsSkippedOnlyWhenNothingChangedAndTheMergedFileIsCurrent() {
+        assertTrue(HostsDownloadWorker.canSkipMerge(false, false, true));
+
+        // A list was replaced in this run.
+        assertFalse(HostsDownloadWorker.canSkipMerge(true, false, true));
+        // An earlier run replaced a list but died before merging it.
+        assertFalse(HostsDownloadWorker.canSkipMerge(false, true, true));
+        // Nothing to leave alone.
+        assertFalse(HostsDownloadWorker.canSkipMerge(false, false, false));
+    }
+
     /**
      * Minimal fake so the seam can be exercised without a real network stack. Request
      * headers are captured into their own map rather than delegating to


### PR DESCRIPTION
Part of #884 (item 6).

## What changed

The daily `HostsUpdate` work fetched every enabled blocklist in full, merged them and called `ServiceSinkhole.reload`, which on the native restart path closes every live connection, whether or not anything had changed.

- **Validators per list**: `Blocklist` gains `etag` and `lastModifiedHeader`, persisted by `BlocklistManager` alongside the existing fields (read with a null fallback, so stored JSON from older versions keeps working).
- **Conditional request**: when the list's file already exists, `HostsDownloadWorker` sends `If-None-Match` and `If-Modified-Since`. A 304 leaves the file alone and counts as success. A 200 downloads as before and stores the response validators, clearing them if the server stopped sending them. A missing file is always fetched unconditionally, so a stale validator can never leave the app without a list.
- **Skip the merge and reload** when every successful list came back unchanged and the merged `hosts.txt` exists. The last-download preference is still updated so the settings screen shows the check. Any change, or a missing merged file, takes the existing merge and reload path.
- **Battery constraint**: the 24-hour periodic request now also requires the battery not to be low. The manual download keeps its constraints, since the user asked for it.

The per-list download logic is extracted into a package-private static `download(...)` seam that takes an already-opened `HttpURLConnection`, so it is testable without WorkManager or a network. The mid-copy `isStopped()` check now throws a private `StopRequestedException` that `doWork` turns into `Result.failure()`, keeping the same cleanup in `finally`.

## Tests

- New `HostsDownloadWorkerTest` (plain JUnit, fake `HttpURLConnection`): 304 with a stored ETag leaves the file untouched and marks success; a missing target sends no conditional headers even with stored validators; 200 replaces the file and stores the validators; 200 without validator headers clears stale ones.
- Not run locally (no Android SDK in this container); CI runs the suite.

## Device check worth doing

Run the manual download twice in a row against the default StevenBlack list and watch `logcat -s TrackerControl.Hosts`: the second run should log `Hosts unchanged, skipping merge and reload` and no VPN reload should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSM3uYXrgB2Vs2ff9ZVkam)_