### PR TITLE
Import WireGuard profiles from a file or a zip archive

### DIFF
--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -50,8 +50,10 @@ wgbridge-rs/                 Rust crate embedding gotatun (Mullvad WireGuard)
     QR code (ZXing decode on CameraX frames; nothing leaves the device).
   - `wg/WgImporter.java` — reading profiles out of a picked `.conf` or a `.zip`
     of them (Android-free; the activity supplies the stream). Bulk saving is
-    `WgProfileManager.importProfiles`, which matches an existing custom profile
-    by name so a re-import refreshes rather than duplicates.
+    `WgProfileManager.importProfiles`, which refreshes an existing custom
+    profile when the file name matches *and* the config still shares a peer
+    public key, so a re-import updates rather than duplicating — and two
+    providers' identically-named files stay separate profiles.
   - `wgbridge/` — hand-written JNI bindings to the Rust crate: `Wgbridge`,
     `Tunnel`, `Protector`, `Logger`, `DnsRecorder`. Mirror of `wgbridge-rs`.
 - **Native C packet engine** — `app/src/main/jni/netguard/`: `netguard.c`,

--- a/agents/docs/codebase-map.md
+++ b/agents/docs/codebase-map.md
@@ -48,6 +48,10 @@ wgbridge-rs/                 Rust crate embedding gotatun (Mullvad WireGuard)
     (the 1 s stats poll — battery-relevant).
   - `wg/QrDecoder.java`, `ActivityScanQr.java` — reading a WireGuard config off a
     QR code (ZXing decode on CameraX frames; nothing leaves the device).
+  - `wg/WgImporter.java` — reading profiles out of a picked `.conf` or a `.zip`
+    of them (Android-free; the activity supplies the stream). Bulk saving is
+    `WgProfileManager.importProfiles`, which matches an existing custom profile
+    by name so a re-import refreshes rather than duplicates.
   - `wgbridge/` — hand-written JNI bindings to the Rust crate: `Wgbridge`,
     `Tunnel`, `Protector`, `Logger`, `DnsRecorder`. Mirror of `wgbridge-rs`.
 - **Native C packet engine** — `app/src/main/jni/netguard/`: `netguard.c`,

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityWireGuardProfiles.java
@@ -6,6 +6,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.OpenableColumns;
+import android.database.Cursor;
 import android.content.pm.PackageManager;
 import android.text.InputType;
 import android.text.TextUtils;
@@ -30,14 +32,19 @@ import net.kollnig.missioncontrol.ui.compose.WireGuardProfilesScreen;
 import net.kollnig.missioncontrol.ui.compose.WireGuardProfilesScreenCallbacks;
 import net.kollnig.missioncontrol.ui.compose.WireGuardProfilesScreenController;
 import net.kollnig.missioncontrol.ui.compose.WireGuardProfilesScreenModel;
+import net.kollnig.missioncontrol.wg.WgImporter;
 import net.kollnig.missioncontrol.wg.WgProfileManager;
 import net.kollnig.missioncontrol.wg.WgConfigParser;
 import net.kollnig.missioncontrol.wg.MullvadProfileGenerator;
 
 import org.json.JSONException;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -57,6 +64,7 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
     private WgProfileManager manager;
     private WireGuardProfilesScreenController screenController;
     private ActivityResultLauncher<Intent> scanLauncher;
+    private ActivityResultLauncher<String[]> importLauncher;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final Handler mainHandler = new Handler(Looper.getMainLooper());
 
@@ -82,6 +90,12 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
                     if (result.getResultCode() != RESULT_OK || result.getData() == null)
                         return;
                     onQrScanned(result.getData().getStringExtra(ActivityScanQr.EXTRA_RESULT));
+                });
+
+        importLauncher = registerForActivityResult(
+                new ActivityResultContracts.OpenMultipleDocuments(), uris -> {
+                    if (uris != null && !uris.isEmpty())
+                        importFromFiles(uris);
                 });
 
         screenController = WireGuardProfilesScreen.install(
@@ -163,21 +177,104 @@ public class ActivityWireGuardProfiles extends AppCompatActivity {
     private void showAddProfileChoice() {
         new MaterialAlertDialogBuilder(this)
                 .setItems(new CharSequence[]{
+                        getString(R.string.setting_wg_profile_import_file),
                         getString(R.string.setting_wg_profile_import),
                         getString(R.string.setting_wg_profile_scan),
                         getString(R.string.setting_wg_mullvad_setup),
                         getString(R.string.setting_wg_proton_setup)
                 }, (dialog, which) -> {
                     if (which == 0)
-                        showProfileDialog(null);
+                        startFileImport();
                     else if (which == 1)
-                        startScan();
+                        showProfileDialog(null);
                     else if (which == 2)
+                        startScan();
+                    else if (which == 3)
                         showMullvadDialog();
                     else
                         showProtonDialog();
                 })
                 .show();
+    }
+
+    // Providers hand out one .conf per server, often twenty at a time in a
+    // zip, and pasting each one by hand is the complaint behind issue #904.
+    private void startFileImport() {
+        try {
+            // Configs carry no registered MIME type and file managers report
+            // them inconsistently, so filtering by type would hide the very
+            // files the user came to pick.
+            importLauncher.launch(new String[]{"*/*"});
+        } catch (ActivityNotFoundException ex) {
+            Toast.makeText(this, getString(R.string.msg_wg_profile_import_failed,
+                    ex.getMessage()), Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private void importFromFiles(List<Uri> uris) {
+        executor.execute(() -> {
+            List<WgProfileManager.ImportEntry> entries = new ArrayList<>();
+            // Shared so that picking several files whose names collide keeps
+            // every one of them.
+            Set<String> names = new HashSet<>();
+            int skipped = 0;
+            for (Uri uri : uris) {
+                String displayName = queryDisplayName(uri);
+                try (InputStream in = getContentResolver().openInputStream(uri)) {
+                    if (in == null) {
+                        skipped++;
+                        continue;
+                    }
+                    WgImporter.Result result = WgImporter.read(in, displayName, names);
+                    for (WgImporter.Entry entry : result.entries)
+                        entries.add(new WgProfileManager.ImportEntry(entry.name, entry.config));
+                    skipped += result.skipped.size();
+                } catch (IOException | SecurityException ex) {
+                    skipped++;
+                }
+            }
+
+            final int failed = skipped;
+            mainHandler.post(() -> finishImport(entries, failed));
+        });
+    }
+
+    private void finishImport(List<WgProfileManager.ImportEntry> entries, int skipped) {
+        if (isFinishing() || isDestroyed())
+            return;
+        if (entries.isEmpty()) {
+            Toast.makeText(this, R.string.msg_wg_profile_import_none, Toast.LENGTH_LONG).show();
+            return;
+        }
+        try {
+            WgProfileManager.ImportResult result = manager.importProfiles(entries);
+            applyProfiles();
+            refresh();
+            StringBuilder message = new StringBuilder(getResources().getQuantityString(
+                    R.plurals.msg_wg_profile_imported, result.total(), result.total()));
+            if (skipped > 0)
+                message.append('\n').append(getResources().getQuantityString(
+                        R.plurals.msg_wg_profile_import_skipped, skipped, skipped));
+            Toast.makeText(this, message.toString(), Toast.LENGTH_LONG).show();
+        } catch (JSONException ex) {
+            Toast.makeText(this, ex.toString(), Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private String queryDisplayName(Uri uri) {
+        try (Cursor cursor = getContentResolver().query(uri,
+                new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+            if (cursor != null && cursor.moveToFirst()) {
+                String name = cursor.getString(0);
+                if (!TextUtils.isEmpty(name))
+                    return name;
+            }
+        } catch (Throwable ignored) {
+            // Not every provider answers OpenableColumns; the path is a fine
+            // fallback, and naming is cosmetic either way.
+        }
+        String path = uri.getLastPathSegment();
+        return path == null ? "" : path;
     }
 
     // Proton documents downloading a standard WireGuard config for third-party

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgImporter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgImporter.java
@@ -26,10 +26,22 @@ import java.util.zip.ZipInputStream;
  * than failing as a whole.
  */
 public final class WgImporter {
-    /** Ceiling on entries read from one archive, to bound a hostile zip. */
+    /** Ceiling on configs taken from one archive, to bound a hostile zip. */
     static final int MAX_ENTRIES = 200;
+    /**
+     * Ceiling on entries walked in one archive. Directories and other files
+     * are skipped without being imported, so they must be counted separately
+     * or an archive of a million empty entries would still be walked whole.
+     */
+    static final int MAX_SCANNED_ENTRIES = 5000;
     /** Ceiling on a single config, far above any real one (they are ~1 KiB). */
-    static final int MAX_ENTRY_BYTES = 512 * 1024;
+    static final int MAX_ENTRY_BYTES = 128 * 1024;
+    /**
+     * Ceiling on everything read out of one archive. The per-entry limit alone
+     * would still let a padded archive hold megabytes of text in memory at
+     * once, all of which is then serialised into the profile store.
+     */
+    static final int MAX_TOTAL_BYTES = 2 * 1024 * 1024;
 
     private WgImporter() {
     }
@@ -100,21 +112,27 @@ public final class WgImporter {
 
         ZipInputStream zip = new ZipInputStream(in);
         ZipEntry entry;
-        int seen = 0;
-        while ((entry = zip.getNextEntry()) != null && seen < MAX_ENTRIES) {
-            String path = entry.getName();
+        int scanned = 0;
+        int taken = 0;
+        int budget = MAX_TOTAL_BYTES;
+        while ((entry = zip.getNextEntry()) != null) {
+            if (++scanned > MAX_SCANNED_ENTRIES || taken >= MAX_ENTRIES || budget <= 0)
+                break;
+
             // Only the base name is ever used, so a traversing path in a
             // hostile archive cannot escape anywhere: nothing is written out.
-            String file = baseName(path);
+            String file = baseName(entry.getName());
             if (entry.isDirectory() || !isConfigName(file))
                 continue;
-            seen++;
 
-            String text = new String(readBounded(zip, MAX_ENTRY_BYTES), StandardCharsets.UTF_8);
+            byte[] bytes = readBounded(zip, Math.min(MAX_ENTRY_BYTES, budget));
+            budget -= bytes.length;
+            String text = new String(bytes, StandardCharsets.UTF_8);
             if (!parses(text)) {
                 skipped.add(file);
                 continue;
             }
+            taken++;
             entries.add(new Entry(uniqueName(stripExtension(file), used), text));
         }
         return new Result(entries, skipped);

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgImporter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgImporter.java
@@ -1,0 +1,200 @@
+package net.kollnig.missioncontrol.wg;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+/**
+ * Reads WireGuard profiles out of a file the user picked: either a single
+ * {@code .conf} or a {@code .zip} of them, which is what providers hand out
+ * when an account covers many servers (issue #904).
+ *
+ * The logic here is deliberately free of Android dependencies — the caller
+ * opens the stream through the content resolver and passes the picker's
+ * display name for naming. Every candidate is parsed by {@link WgConfigParser}
+ * before it is offered for saving, so an archive that mixes configs with
+ * unrelated files imports the configs and reports the rest as skipped rather
+ * than failing as a whole.
+ */
+public final class WgImporter {
+    /** Ceiling on entries read from one archive, to bound a hostile zip. */
+    static final int MAX_ENTRIES = 200;
+    /** Ceiling on a single config, far above any real one (they are ~1 KiB). */
+    static final int MAX_ENTRY_BYTES = 512 * 1024;
+
+    private WgImporter() {
+    }
+
+    public static final class Entry {
+        public final String name;
+        public final String config;
+
+        public Entry(String name, String config) {
+            this.name = name;
+            this.config = config;
+        }
+    }
+
+    public static final class Result {
+        /** Configs that parsed, in the order they appeared. */
+        public final List<Entry> entries;
+        /** File names that looked importable but did not parse. */
+        public final List<String> skipped;
+
+        Result(List<Entry> entries, List<String> skipped) {
+            this.entries = entries;
+            this.skipped = skipped;
+        }
+
+        public boolean isEmpty() {
+            return entries.isEmpty();
+        }
+    }
+
+    /** Reads one file with a fresh name space. */
+    public static Result read(InputStream in, String displayName) throws IOException {
+        return read(in, displayName, new HashSet<>());
+    }
+
+    /**
+     * @param in          stream over the picked file; the caller closes it
+     * @param displayName file name from the picker, used for profile naming
+     *                    and to tell an archive from a single config
+     * @param usedNames   names already taken, carried across the files of one
+     *                    multi-file pick so two servers that share a file name
+     *                    both survive instead of one overwriting the other
+     */
+    public static Result read(InputStream in, String displayName, Set<String> usedNames)
+            throws IOException {
+        String name = displayName == null ? "" : displayName.trim();
+        // Not every document provider reports a usable file name, so the
+        // archive check falls back to the zip magic rather than treating an
+        // archive as one unparsable config.
+        BufferedInputStream buffered = new BufferedInputStream(in);
+        if (isArchiveName(name) || (!isConfigName(name) && looksLikeArchive(buffered)))
+            return readArchive(buffered, usedNames);
+
+        List<Entry> entries = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+        String text = new String(readBounded(buffered, MAX_ENTRY_BYTES), StandardCharsets.UTF_8);
+        String label = name.isEmpty() ? "" : stripExtension(baseName(name));
+        if (parses(text))
+            entries.add(new Entry(uniqueName(label, usedNames), text));
+        else
+            skipped.add(name.isEmpty() ? label : name);
+        return new Result(entries, skipped);
+    }
+
+    private static Result readArchive(InputStream in, Set<String> used) throws IOException {
+        List<Entry> entries = new ArrayList<>();
+        List<String> skipped = new ArrayList<>();
+
+        ZipInputStream zip = new ZipInputStream(in);
+        ZipEntry entry;
+        int seen = 0;
+        while ((entry = zip.getNextEntry()) != null && seen < MAX_ENTRIES) {
+            String path = entry.getName();
+            // Only the base name is ever used, so a traversing path in a
+            // hostile archive cannot escape anywhere: nothing is written out.
+            String file = baseName(path);
+            if (entry.isDirectory() || !isConfigName(file))
+                continue;
+            seen++;
+
+            String text = new String(readBounded(zip, MAX_ENTRY_BYTES), StandardCharsets.UTF_8);
+            if (!parses(text)) {
+                skipped.add(file);
+                continue;
+            }
+            entries.add(new Entry(uniqueName(stripExtension(file), used), text));
+        }
+        return new Result(entries, skipped);
+    }
+
+    /**
+     * Two servers can share a file name across an archive's folders. Keeping
+     * both matters more than the tidier name, so later collisions get a
+     * numeric suffix instead of overwriting the first.
+     */
+    private static String uniqueName(String base, Set<String> used) {
+        // An empty label means the picker gave no usable name; the profile
+        // store substitutes a default, so there is nothing to reserve here.
+        if (base.isEmpty())
+            return base;
+        if (used.add(base))
+            return base;
+        for (int i = 2; ; i++) {
+            String candidate = base + " (" + i + ")";
+            if (used.add(candidate))
+                return candidate;
+        }
+    }
+
+    private static boolean parses(String text) {
+        try {
+            WgConfigParser.INSTANCE.parse(text);
+            return true;
+        } catch (Throwable ex) {
+            return false;
+        }
+    }
+
+    private static byte[] readBounded(InputStream in, int limit) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        byte[] buffer = new byte[8192];
+        int read;
+        while (out.size() <= limit && (read = in.read(buffer)) != -1)
+            out.write(buffer, 0, read);
+        byte[] bytes = out.toByteArray();
+        // Truncated content simply fails to parse and is reported as skipped.
+        return bytes.length > limit ? java.util.Arrays.copyOf(bytes, limit) : bytes;
+    }
+
+    private static final byte[] ZIP_MAGIC = {0x50, 0x4B, 0x03, 0x04};
+
+    private static boolean looksLikeArchive(BufferedInputStream in) throws IOException {
+        in.mark(ZIP_MAGIC.length);
+        byte[] head = new byte[ZIP_MAGIC.length];
+        int read = 0;
+        while (read < head.length) {
+            int n = in.read(head, read, head.length - read);
+            if (n < 0)
+                break;
+            read += n;
+        }
+        in.reset();
+        return read == head.length && java.util.Arrays.equals(head, ZIP_MAGIC);
+    }
+
+    static boolean isArchiveName(String name) {
+        return name != null && name.toLowerCase(Locale.ROOT).endsWith(".zip");
+    }
+
+    static boolean isConfigName(String name) {
+        return name != null && name.toLowerCase(Locale.ROOT).endsWith(".conf");
+    }
+
+    static String baseName(String path) {
+        if (path == null)
+            return "";
+        String name = path.replace('\\', '/');
+        int slash = name.lastIndexOf('/');
+        return slash < 0 ? name : name.substring(slash + 1);
+    }
+
+    static String stripExtension(String name) {
+        if (name == null)
+            return "";
+        int dot = name.lastIndexOf('.');
+        return dot <= 0 ? name : name.substring(0, dot);
+    }
+}

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
@@ -73,6 +73,31 @@ public class WgProfileManager {
         }
     }
 
+    /** One config to import, named after the file it came from. */
+    public static class ImportEntry {
+        public final String name;
+        public final String config;
+
+        public ImportEntry(String name, String config) {
+            this.name = name;
+            this.config = config;
+        }
+    }
+
+    public static class ImportResult {
+        public final int added;
+        public final int updated;
+
+        public ImportResult(int added, int updated) {
+            this.added = added;
+            this.updated = updated;
+        }
+
+        public int total() {
+            return added + updated;
+        }
+    }
+
     public static class MullvadCountry {
         public final String code;
         public final String name;
@@ -210,6 +235,90 @@ public class WgProfileManager {
             editor.putString(PREF_WG_CONFIG, config);
             editor.apply();
         }
+    }
+
+    /**
+     * Bulk counterpart to {@link #saveProfile}, for a file or archive import.
+     *
+     * One read-modify-write for the whole batch, so importing twenty configs
+     * costs one preference commit rather than twenty. A re-import updates the
+     * custom profile of the same name instead of duplicating it — providers
+     * hand out stable per-server file names, so the second import of the same
+     * archive refreshes keys rather than doubling the list. Provider-managed
+     * profiles (Mullvad, IVPN) are never matched: their names are ours, and an
+     * imported file must not silently take one over.
+     *
+     * The active profile is left alone unless there was none, so an import
+     * cannot move the user off the tunnel they are on.
+     */
+    public ImportResult importProfiles(List<ImportEntry> entries) throws JSONException {
+        synchronized (STORE_LOCK) {
+            JSONArray profiles = readProfilesJson();
+            int added = 0;
+            int updated = 0;
+            String firstId = null;
+
+            for (ImportEntry entry : entries) {
+                if (entry == null || TextUtils.isEmpty(entry.config))
+                    continue;
+                String name = TextUtils.isEmpty(entry.name)
+                        ? context.getString(R.string.msg_wg_profile_default_name)
+                        : entry.name;
+
+                JSONObject profile = findCustomJsonProfileByName(profiles, name);
+                if (profile == null) {
+                    profile = new JSONObject();
+                    profile.put("id", newId());
+                    profile.put("name", name);
+                    profile.put("provider", "");
+                    profile.put("account", "");
+                    profile.put("countryCode", "");
+                    profile.put("countryName", "");
+                    profiles.put(profile);
+                    added++;
+                } else {
+                    updated++;
+                }
+                profile.put("config", entry.config);
+                if (firstId == null)
+                    firstId = profile.optString("id");
+            }
+
+            if (added == 0 && updated == 0)
+                return new ImportResult(0, 0);
+
+            SharedPreferences.Editor editor = prefs.edit();
+            writeProfilesJson(editor, profiles);
+
+            String active = getActiveProfileId();
+            JSONObject activeProfile = findJsonProfile(profiles, active);
+            if (activeProfile == null) {
+                if (firstId != null) {
+                    JSONObject imported = findJsonProfile(profiles, firstId);
+                    editor.putString(PREF_WG_PROFILE, firstId);
+                    editor.putString(PREF_WG_CONFIG,
+                            imported == null ? "" : imported.optString("config", ""));
+                }
+            } else {
+                // An update may have rewritten the active profile's config.
+                editor.putString(PREF_WG_CONFIG, activeProfile.optString("config", ""));
+            }
+            editor.apply();
+            return new ImportResult(added, updated);
+        }
+    }
+
+    private JSONObject findCustomJsonProfileByName(JSONArray profiles, String name) {
+        for (int i = 0; i < profiles.length(); i++) {
+            JSONObject profile = profiles.optJSONObject(i);
+            if (profile == null)
+                continue;
+            if (!TextUtils.isEmpty(profile.optString("provider")))
+                continue;
+            if (name.equals(profile.optString("name")))
+                return profile;
+        }
+        return null;
     }
 
     public void deleteProfile(String id) {

--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgProfileManager.java
@@ -241,12 +241,19 @@ public class WgProfileManager {
      * Bulk counterpart to {@link #saveProfile}, for a file or archive import.
      *
      * One read-modify-write for the whole batch, so importing twenty configs
-     * costs one preference commit rather than twenty. A re-import updates the
-     * custom profile of the same name instead of duplicating it — providers
-     * hand out stable per-server file names, so the second import of the same
-     * archive refreshes keys rather than doubling the list. Provider-managed
-     * profiles (Mullvad, IVPN) are never matched: their names are ours, and an
-     * imported file must not silently take one over.
+     * costs one preference commit rather than twenty.
+     *
+     * A re-import refreshes an existing custom profile instead of duplicating
+     * it — providers hand out stable per-server file names, so importing the
+     * same archive again should not double the list. The name alone does not
+     * decide that: two providers both shipping a "wg0.conf" would otherwise
+     * see the second import overwrite the first, and switch the tunnel under
+     * the user if that profile was active. A profile is only refreshed when it
+     * also still describes the same tunnel, meaning the two configs share a
+     * peer public key; anything else is imported alongside it under a
+     * disambiguated name. Provider-managed profiles (Mullvad, IVPN) are never
+     * matched at all: their names are ours, and an imported file must not
+     * silently take one over.
      *
      * The active profile is left alone unless there was none, so an import
      * cannot move the user off the tunnel they are on.
@@ -265,11 +272,11 @@ public class WgProfileManager {
                         ? context.getString(R.string.msg_wg_profile_default_name)
                         : entry.name;
 
-                JSONObject profile = findCustomJsonProfileByName(profiles, name);
+                JSONObject profile = findRefreshableJsonProfile(profiles, name, entry.config);
                 if (profile == null) {
                     profile = new JSONObject();
                     profile.put("id", newId());
-                    profile.put("name", name);
+                    profile.put("name", unusedProfileName(profiles, name));
                     profile.put("provider", "");
                     profile.put("account", "");
                     profile.put("countryCode", "");
@@ -308,17 +315,81 @@ public class WgProfileManager {
         }
     }
 
-    private JSONObject findCustomJsonProfileByName(JSONArray profiles, String name) {
+    /**
+     * The custom profile an imported config refreshes: one carrying this file's
+     * name, and still describing the same tunnel. Returns null when the config
+     * should be imported as a new profile instead.
+     *
+     * Profiles previously disambiguated from this name ("wg0 (2)") are
+     * candidates too, or the second provider's "wg0.conf" would duplicate on
+     * every re-import rather than refreshing the profile it created.
+     */
+    private JSONObject findRefreshableJsonProfile(JSONArray profiles, String name, String config) {
         for (int i = 0; i < profiles.length(); i++) {
             JSONObject profile = profiles.optJSONObject(i);
             if (profile == null)
                 continue;
             if (!TextUtils.isEmpty(profile.optString("provider")))
                 continue;
-            if (name.equals(profile.optString("name")))
+            String stored = profile.optString("name");
+            if (!name.equals(stored) && !stored.startsWith(name + " ("))
+                continue;
+            if (describesSameTunnel(profile.optString("config", ""), config))
                 return profile;
         }
         return null;
+    }
+
+    /**
+     * Whether two configs are the same tunnel, judged by a shared peer public
+     * key. A provider rotating keys replaces the interface's private key but
+     * keeps the server's public key, so this holds across a genuine refresh
+     * while still separating two unrelated providers' files. A config that no
+     * longer parses is treated as different: keeping it costs a duplicate,
+     * overwriting it costs the user their profile.
+     */
+    private static boolean describesSameTunnel(String existing, String imported) {
+        java.util.Set<String> keys = peerPublicKeys(existing);
+        if (keys.isEmpty())
+            return false;
+        for (String key : peerPublicKeys(imported))
+            if (keys.contains(key))
+                return true;
+        return false;
+    }
+
+    private static java.util.Set<String> peerPublicKeys(String config) {
+        java.util.Set<String> keys = new java.util.HashSet<>();
+        if (TextUtils.isEmpty(config))
+            return keys;
+        try {
+            for (WgPeer peer : WgConfigParser.INSTANCE.parse(config).getPeers())
+                keys.add(peer.getPublicKey());
+        } catch (Throwable ignored) {
+            // Only ever used to decide refresh versus add; an unparsable
+            // config simply never matches.
+        }
+        return keys;
+    }
+
+    /** A name no stored profile is using, suffixed only when one already is. */
+    private String unusedProfileName(JSONArray profiles, String name) {
+        if (!isProfileNameTaken(profiles, name))
+            return name;
+        for (int i = 2; ; i++) {
+            String candidate = name + " (" + i + ")";
+            if (!isProfileNameTaken(profiles, candidate))
+                return candidate;
+        }
+    }
+
+    private boolean isProfileNameTaken(JSONArray profiles, String name) {
+        for (int i = 0; i < profiles.length(); i++) {
+            JSONObject profile = profiles.optJSONObject(i);
+            if (profile != null && name.equals(profile.optString("name")))
+                return true;
+        }
+        return false;
     }
 
     public void deleteProfile(String id) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,6 +187,7 @@
     <string name="setting_wg_profile_manage">Custom WireGuard profiles</string>
     <string name="setting_wg_profile_import">Import WireGuard config</string>
     <string name="setting_wg_profile_scan">Scan QR code</string>
+    <string name="setting_wg_profile_import_file">Import from file or archive</string>
     <string name="setting_wg_mullvad_setup">Set up Mullvad</string>
     <string name="setting_wg_proton_setup">Use a Proton VPN config</string>
     <string name="setting_wg_keepalive_when_screen_off">Keep WireGuard alive when screen is off</string>
@@ -275,6 +276,16 @@
     <string name="msg_wg_profile_scan_no_camera_permission">Camera permission is needed to scan a QR code</string>
     <string name="msg_wg_profile_scan_failed">Could not start the camera: %1$s</string>
     <string name="msg_wg_profile_scan_not_config">This QR code is not a WireGuard config: %1$s</string>
+    <string name="msg_wg_profile_import_none">No WireGuard config was found in the selected file</string>
+    <string name="msg_wg_profile_import_failed">Could not read the selected file: %1$s</string>
+    <plurals name="msg_wg_profile_imported">
+        <item quantity="one">%1$d WireGuard profile imported</item>
+        <item quantity="other">%1$d WireGuard profiles imported</item>
+    </plurals>
+    <plurals name="msg_wg_profile_import_skipped">
+        <item quantity="one">%1$d file skipped: not a valid WireGuard config</item>
+        <item quantity="other">%1$d files skipped: not valid WireGuard configs</item>
+    </plurals>
     <string name="msg_wg_mullvad_account">Mullvad account number</string>
     <string name="msg_wg_mullvad_recommended">Recommended location</string>
     <string name="msg_wg_mullvad_note">TrackerControl creates a Mullvad WireGuard profile. The account number is saved locally for future Mullvad profiles. Tokens are not stored, and deleting the profile here does not remove the device from Mullvad.</string>

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgImporterTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgImporterTest.java
@@ -1,0 +1,169 @@
+package net.kollnig.missioncontrol.wg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+public class WgImporterTest {
+    private static final String KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    private static final String CONFIG = "[Interface]\n" +
+            "PrivateKey = " + KEY + "\n" +
+            "Address = 10.0.0.2/32\n" +
+            "\n" +
+            "[Peer]\n" +
+            "PublicKey = " + KEY + "\n" +
+            "AllowedIPs = 0.0.0.0/0, ::/0\n" +
+            "Endpoint = 192.0.2.1:51820\n";
+
+    @Test
+    public void singleConfigIsNamedAfterItsFile() throws Exception {
+        WgImporter.Result result = read(CONFIG.getBytes(StandardCharsets.UTF_8), "berlin.conf");
+
+        assertEquals(1, result.entries.size());
+        assertEquals("berlin", result.entries.get(0).name);
+        assertEquals(CONFIG, result.entries.get(0).config);
+        assertTrue(result.skipped.isEmpty());
+    }
+
+    @Test
+    public void fileThatIsNotAConfigIsReportedAsSkipped() throws Exception {
+        WgImporter.Result result = read("shopping list".getBytes(StandardCharsets.UTF_8), "notes.txt");
+
+        assertTrue(result.isEmpty());
+        assertEquals(1, result.skipped.size());
+        assertEquals("notes.txt", result.skipped.get(0));
+    }
+
+    @Test
+    public void archiveImportsEveryConfigAndSkipsTheRest() throws Exception {
+        // The case from issue #904: a provider's zip of per-server configs,
+        // with the stray files such an archive usually also carries.
+        byte[] archive = zip(
+                "us-nyc.conf", CONFIG,
+                "de-ber.conf", CONFIG,
+                "README.txt", "not a config",
+                "truncated.conf", "[Interface]\n");
+
+        WgImporter.Result result = read(archive, "servers.zip");
+
+        assertEquals(2, result.entries.size());
+        assertEquals("us-nyc", result.entries.get(0).name);
+        assertEquals("de-ber", result.entries.get(1).name);
+        // README.txt is not a candidate at all; the malformed .conf is.
+        assertEquals(1, result.skipped.size());
+        assertEquals("truncated.conf", result.skipped.get(0));
+    }
+
+    @Test
+    public void sameFileNameInTwoFoldersKeepsBothProfiles() throws Exception {
+        byte[] archive = zip("us/newyork.conf", CONFIG, "de/newyork.conf", CONFIG);
+
+        WgImporter.Result result = read(archive, "servers.zip");
+
+        assertEquals(2, result.entries.size());
+        assertEquals("newyork", result.entries.get(0).name);
+        assertEquals("newyork (2)", result.entries.get(1).name);
+    }
+
+    @Test
+    public void directoryEntriesAreIgnored() throws Exception {
+        byte[] archive = zip("confs/", "", "confs/a.conf", CONFIG);
+
+        WgImporter.Result result = read(archive, "servers.zip");
+
+        assertEquals(1, result.entries.size());
+        assertEquals("a", result.entries.get(0).name);
+    }
+
+    @Test
+    public void traversingPathIsReducedToItsBaseName() throws Exception {
+        // Nothing is written to disk, but the name must not carry the path
+        // either, or a hostile archive picks how profiles are labelled.
+        WgImporter.Result result = read(zip("../../etc/evil.conf", CONFIG), "servers.zip");
+
+        assertEquals(1, result.entries.size());
+        assertEquals("evil", result.entries.get(0).name);
+    }
+
+    @Test
+    public void archiveEntryCountIsCapped() throws Exception {
+        String[] entries = new String[(WgImporter.MAX_ENTRIES + 50) * 2];
+        for (int i = 0; i < WgImporter.MAX_ENTRIES + 50; i++) {
+            entries[i * 2] = "server" + i + ".conf";
+            entries[i * 2 + 1] = CONFIG;
+        }
+
+        WgImporter.Result result = read(zip(entries), "servers.zip");
+
+        assertEquals(WgImporter.MAX_ENTRIES, result.entries.size());
+    }
+
+    @Test
+    public void oversizedEntryIsBounded() throws Exception {
+        StringBuilder padded = new StringBuilder(CONFIG);
+        while (padded.length() <= WgImporter.MAX_ENTRY_BYTES)
+            padded.append("# padding\n");
+
+        WgImporter.Result result = read(zip("big.conf", padded.toString()), "servers.zip");
+
+        // Either outcome is fine; what matters is that the read stopped at
+        // the cap instead of pulling an unbounded entry into memory.
+        assertEquals(1, result.entries.size() + result.skipped.size());
+    }
+
+    @Test
+    public void extensionsAreMatchedCaseInsensitively() throws Exception {
+        WgImporter.Result result = read(zip("SERVER.CONF", CONFIG), "SERVERS.ZIP");
+
+        assertEquals(1, result.entries.size());
+        assertEquals("SERVER", result.entries.get(0).name);
+    }
+
+    @Test
+    public void namesTakenByAnEarlierFileInTheSamePickAreNotReused() throws Exception {
+        // Picking several providers' files at once often means several
+        // "wg0.conf"; both must survive as separate profiles.
+        java.util.Set<String> used = new java.util.HashSet<>();
+
+        WgImporter.Result first = WgImporter.read(
+                new ByteArrayInputStream(CONFIG.getBytes(StandardCharsets.UTF_8)), "wg0.conf", used);
+        WgImporter.Result second = WgImporter.read(
+                new ByteArrayInputStream(CONFIG.getBytes(StandardCharsets.UTF_8)), "wg0.conf", used);
+
+        assertEquals("wg0", first.entries.get(0).name);
+        assertEquals("wg0 (2)", second.entries.get(0).name);
+    }
+
+    @Test
+    public void archiveIsDetectedWhenThePickerGivesNoUsableName() throws Exception {
+        // Some document providers report a name such as "content" or nothing
+        // at all; the zip magic keeps such a pick importable.
+        WgImporter.Result result = read(zip("a.conf", CONFIG, "b.conf", CONFIG), "download");
+
+        assertEquals(2, result.entries.size());
+    }
+
+    private static WgImporter.Result read(byte[] bytes, String name) throws IOException {
+        return WgImporter.read(new ByteArrayInputStream(bytes), name);
+    }
+
+    private static byte[] zip(String... namesAndBodies) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(out)) {
+            for (int i = 0; i < namesAndBodies.length; i += 2) {
+                zip.putNextEntry(new ZipEntry(namesAndBodies[i]));
+                zip.write(namesAndBodies[i + 1].getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+        }
+        return out.toByteArray();
+    }
+}

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgImporterTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgImporterTest.java
@@ -143,6 +143,45 @@ public class WgImporterTest {
     }
 
     @Test
+    public void archiveTraversalIsBoundedByEntriesThatAreNotConfigs() throws Exception {
+        // Directories and other files are skipped rather than imported, so
+        // they must count against a cap of their own; otherwise an archive of
+        // a million empty entries is still walked from end to end.
+        String[] entries = new String[(WgImporter.MAX_SCANNED_ENTRIES + 1) * 2];
+        for (int i = 0; i < WgImporter.MAX_SCANNED_ENTRIES; i++) {
+            entries[i * 2] = "filler" + i + ".txt";
+            entries[i * 2 + 1] = "";
+        }
+        entries[WgImporter.MAX_SCANNED_ENTRIES * 2] = "server.conf";
+        entries[WgImporter.MAX_SCANNED_ENTRIES * 2 + 1] = CONFIG;
+
+        WgImporter.Result result = read(zip(entries), "servers.zip");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void totalBytesReadFromAnArchiveAreBounded() throws Exception {
+        // Each config here is valid and under the per-entry limit, so only an
+        // aggregate limit keeps the batch from being held in memory at once.
+        StringBuilder padded = new StringBuilder(CONFIG);
+        while (padded.length() < WgImporter.MAX_ENTRY_BYTES / 2)
+            padded.append("# padding\n");
+        int count = (WgImporter.MAX_TOTAL_BYTES / padded.length()) + 10;
+
+        String[] entries = new String[count * 2];
+        for (int i = 0; i < count; i++) {
+            entries[i * 2] = "server" + i + ".conf";
+            entries[i * 2 + 1] = padded.toString();
+        }
+
+        WgImporter.Result result = read(zip(entries), "servers.zip");
+
+        assertTrue(result.entries.size() < count);
+        assertTrue(result.entries.size() > 0);
+    }
+
+    @Test
     public void archiveIsDetectedWhenThePickerGivesNoUsableName() throws Exception {
         // Some document providers report a name such as "content" or nothing
         // at all; the zip magic keeps such a pick importable.

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
@@ -212,76 +212,148 @@ public class WgProfileManagerTest {
         assertEquals("legacy", manager.getActiveProfile().config);
     }
 
+    private static final String PEER_A = "A".repeat(43) + "=";
+    private static final String PEER_B = "B".repeat(42) + "A=";
+    private static final String PEER_C = "C".repeat(42) + "A=";
+
+    /** A parsable config for the given peer, with an interface key that varies. */
+    private static String config(String peerKey, String interfaceKey) {
+        return "[Interface]\n" +
+                "PrivateKey = " + interfaceKey + "\n" +
+                "Address = 10.0.0.2/32\n" +
+                "\n" +
+                "[Peer]\n" +
+                "PublicKey = " + peerKey + "\n" +
+                "AllowedIPs = 0.0.0.0/0\n";
+    }
+
     @Test
     public void importAddsEveryProfileAndActivatesTheFirstWhenNoneWasActive() throws Exception {
         WgProfileManager.ImportResult result = manager.importProfiles(java.util.Arrays.asList(
-                new WgProfileManager.ImportEntry("us-nyc", "config-a"),
-                new WgProfileManager.ImportEntry("de-ber", "config-b")));
+                new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_A)),
+                new WgProfileManager.ImportEntry("de-ber", config(PEER_B, PEER_A))));
 
         assertEquals(2, result.added);
         assertEquals(0, result.updated);
         assertEquals(2, manager.getProfiles().size());
         assertEquals("us-nyc", manager.getActiveProfile().name);
-        assertEquals("config-a", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+        assertEquals(config(PEER_A, PEER_A), prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
     }
 
     @Test
     public void importLeavesTheActiveProfileAlone() throws Exception {
-        manager.saveProfile(null, "Existing", "existing-config");
+        manager.saveProfile(null, "Existing", config(PEER_C, PEER_A));
         String active = manager.getActiveProfileId();
 
         manager.importProfiles(java.util.Collections.singletonList(
-                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+                new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_A))));
 
         assertEquals(active, manager.getActiveProfileId());
-        assertEquals("existing-config", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+        assertEquals(config(PEER_C, PEER_A), prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
     }
 
     @Test
-    public void reimportUpdatesTheProfileOfTheSameNameInsteadOfDuplicatingIt() throws Exception {
+    public void reimportOfTheSameTunnelRefreshesItInsteadOfDuplicatingIt() throws Exception {
         manager.importProfiles(java.util.Collections.singletonList(
-                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+                new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_A))));
 
+        // Same server, rotated interface key: what a provider re-issue looks like.
         WgProfileManager.ImportResult result = manager.importProfiles(
                 java.util.Collections.singletonList(
-                        new WgProfileManager.ImportEntry("us-nyc", "config-b")));
+                        new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_B))));
 
         assertEquals(0, result.added);
         assertEquals(1, result.updated);
         assertEquals(1, manager.getProfiles().size());
-        assertEquals("config-b", manager.getProfiles().get(0).config);
+        assertEquals(config(PEER_A, PEER_B), manager.getProfiles().get(0).config);
     }
 
     @Test
     public void reimportOfTheActiveProfileRefreshesTheLiveConfig() throws Exception {
         manager.importProfiles(java.util.Collections.singletonList(
-                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+                new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_A))));
 
         manager.importProfiles(java.util.Collections.singletonList(
-                new WgProfileManager.ImportEntry("us-nyc", "config-b")));
+                new WgProfileManager.ImportEntry("us-nyc", config(PEER_A, PEER_B))));
 
-        assertEquals("config-b", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+        assertEquals(config(PEER_A, PEER_B), prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void aDifferentTunnelSharingAFileNameIsImportedAlongsideTheFirst() throws Exception {
+        // Two providers both shipping "wg0.conf": overwriting the first would
+        // lose a profile, and switch the tunnel if that profile were active.
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("wg0", config(PEER_A, PEER_A))));
+
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("wg0", config(PEER_B, PEER_B))));
+
+        assertEquals(1, result.added);
+        assertEquals(0, result.updated);
+        List<WgProfileManager.Profile> profiles = manager.getProfiles();
+        assertEquals(2, profiles.size());
+        assertEquals("wg0", profiles.get(0).name);
+        assertEquals("wg0 (2)", profiles.get(1).name);
+        assertEquals(config(PEER_A, PEER_A), profiles.get(0).config);
+        // The first profile was active and must have stayed on its own config.
+        assertEquals(config(PEER_A, PEER_A), prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void theSecondProviderFileRefreshesItsOwnProfileOnReimport() throws Exception {
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("wg0", config(PEER_A, PEER_A))));
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("wg0", config(PEER_B, PEER_B))));
+
+        // Importing the second provider's file again must refresh "wg0 (2)"
+        // rather than pile up a "wg0 (3)".
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("wg0", config(PEER_B, PEER_C))));
+
+        assertEquals(0, result.added);
+        assertEquals(1, result.updated);
+        List<WgProfileManager.Profile> profiles = manager.getProfiles();
+        assertEquals(2, profiles.size());
+        assertEquals(config(PEER_B, PEER_C), profiles.get(1).config);
+    }
+
+    @Test
+    public void aProfileWhoseStoredConfigNoLongerParsesIsNeverOverwritten() throws Exception {
+        manager.saveProfile(null, "wg0", "not a config");
+
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("wg0", config(PEER_A, PEER_A))));
+
+        assertEquals(1, result.added);
+        assertEquals(2, manager.getProfiles().size());
+        assertEquals("not a config", manager.getProfiles().get(0).config);
     }
 
     @Test
     public void importNeverTakesOverAProviderManagedProfile() throws Exception {
         // Mullvad and IVPN profiles are named by us and rewritten by key
         // rotation; a file that happens to share the name must not land on one.
-        manager.saveProfile(null, "Mullvad", "mullvad-config", "mullvad", "1234");
+        manager.saveProfile(null, "Mullvad", config(PEER_A, PEER_A), "mullvad", "1234");
 
         WgProfileManager.ImportResult result = manager.importProfiles(
                 java.util.Collections.singletonList(
-                        new WgProfileManager.ImportEntry("Mullvad", "imported-config")));
+                        new WgProfileManager.ImportEntry("Mullvad", config(PEER_A, PEER_B))));
 
         assertEquals(1, result.added);
         assertEquals(2, manager.getProfiles().size());
-        assertEquals("mullvad-config", manager.getProviderConfig("mullvad", "1234"));
+        assertEquals("Mullvad (2)", manager.getProfiles().get(1).name);
+        assertEquals(config(PEER_A, PEER_A), manager.getProviderConfig("mullvad", "1234"));
     }
 
     @Test
     public void importWithoutANameFallsBackToTheDefaultName() throws Exception {
         manager.importProfiles(java.util.Collections.singletonList(
-                new WgProfileManager.ImportEntry("", "config-a")));
+                new WgProfileManager.ImportEntry("", config(PEER_A, PEER_A))));
 
         assertEquals(context.getString(R.string.msg_wg_profile_default_name),
                 manager.getProfiles().get(0).name);

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgProfileManagerTest.java
@@ -212,6 +212,92 @@ public class WgProfileManagerTest {
         assertEquals("legacy", manager.getActiveProfile().config);
     }
 
+    @Test
+    public void importAddsEveryProfileAndActivatesTheFirstWhenNoneWasActive() throws Exception {
+        WgProfileManager.ImportResult result = manager.importProfiles(java.util.Arrays.asList(
+                new WgProfileManager.ImportEntry("us-nyc", "config-a"),
+                new WgProfileManager.ImportEntry("de-ber", "config-b")));
+
+        assertEquals(2, result.added);
+        assertEquals(0, result.updated);
+        assertEquals(2, manager.getProfiles().size());
+        assertEquals("us-nyc", manager.getActiveProfile().name);
+        assertEquals("config-a", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void importLeavesTheActiveProfileAlone() throws Exception {
+        manager.saveProfile(null, "Existing", "existing-config");
+        String active = manager.getActiveProfileId();
+
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+
+        assertEquals(active, manager.getActiveProfileId());
+        assertEquals("existing-config", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void reimportUpdatesTheProfileOfTheSameNameInsteadOfDuplicatingIt() throws Exception {
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("us-nyc", "config-b")));
+
+        assertEquals(0, result.added);
+        assertEquals(1, result.updated);
+        assertEquals(1, manager.getProfiles().size());
+        assertEquals("config-b", manager.getProfiles().get(0).config);
+    }
+
+    @Test
+    public void reimportOfTheActiveProfileRefreshesTheLiveConfig() throws Exception {
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("us-nyc", "config-a")));
+
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("us-nyc", "config-b")));
+
+        assertEquals("config-b", prefs.getString(WgProfileManager.PREF_WG_CONFIG, ""));
+    }
+
+    @Test
+    public void importNeverTakesOverAProviderManagedProfile() throws Exception {
+        // Mullvad and IVPN profiles are named by us and rewritten by key
+        // rotation; a file that happens to share the name must not land on one.
+        manager.saveProfile(null, "Mullvad", "mullvad-config", "mullvad", "1234");
+
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("Mullvad", "imported-config")));
+
+        assertEquals(1, result.added);
+        assertEquals(2, manager.getProfiles().size());
+        assertEquals("mullvad-config", manager.getProviderConfig("mullvad", "1234"));
+    }
+
+    @Test
+    public void importWithoutANameFallsBackToTheDefaultName() throws Exception {
+        manager.importProfiles(java.util.Collections.singletonList(
+                new WgProfileManager.ImportEntry("", "config-a")));
+
+        assertEquals(context.getString(R.string.msg_wg_profile_default_name),
+                manager.getProfiles().get(0).name);
+    }
+
+    @Test
+    public void importOfNothingUsableChangesNoState() throws Exception {
+        WgProfileManager.ImportResult result = manager.importProfiles(
+                java.util.Collections.singletonList(
+                        new WgProfileManager.ImportEntry("empty", "")));
+
+        assertEquals(0, result.total());
+        assertTrue(manager.getProfiles().isEmpty());
+        assertEquals("", manager.getActiveProfileId());
+    }
+
     private static JSONObject profile(String id, String name, String config, String provider,
                                       String account, String countryCode, String countryName) throws Exception {
         return new JSONObject()


### PR DESCRIPTION
Closes #904.

## What

Adding a WireGuard config meant pasting it into a text box, so a user with one `.conf` per server had to open each file in a text editor and copy it across — twenty times over, in the reporter's case.

The profile screen's add menu now offers **Import from file or archive**, which opens the system document picker:

- a single `.conf` becomes one profile, named after the file;
- a `.zip` becomes one profile per config inside it, which is how providers hand out per-server configs;
- several files can be picked at once.

Every candidate is parsed by the existing `WgConfigParser` before it is offered for saving, so an archive that also carries a `README.txt` imports the configs and reports the rest as skipped rather than failing as a whole. The result toast says how many were imported and how many were skipped.

This is deliberately the same scope as the official WireGuard app's *Import from file or archive*. No profile groups, and no random-relay selection over imported files — a list of static configs has nothing to randomise over, and picking a relay per connect belongs in the Mullvad/IVPN paths, where the relay list is already known.

## How

**`wg/WgImporter.java`** (new) keeps the reading logic free of Android dependencies — the activity opens the stream through the content resolver and passes the picker's display name. Notes:

- An archive is recognised by a `.zip` name, falling back to the zip magic when a document provider reports no usable name.
- Archives are bounded three ways: 200 configs taken, 5000 entries walked (directories and other files are skipped without being imported, so they need a cap of their own), and 2 MiB read in total across the archive at 128 KiB per entry. A real config is about 1 KiB.
- Only an entry's base name is ever used for naming, and nothing is written to disk, so a traversing path in an archive has nowhere to go.
- Two servers sharing a file name across folders both survive; the later one gets a numeric suffix. The name space is shared across the files of one multi-file pick for the same reason.

**`WgProfileManager.importProfiles`** (new) saves the batch in one read-modify-write under the existing `STORE_LOCK`, so twenty configs cost one preference commit.

A re-import refreshes an existing custom profile rather than duplicating it, but the file name alone does not decide that: two providers both shipping a `wg0.conf` would otherwise mean the second import overwrites the first, and switches the tunnel under the user if that profile was active. A profile is refreshed only when it also still describes the same tunnel, judged by a shared peer public key — which survives the provider rotating interface keys, the case a refresh exists for. Anything else is imported alongside under a disambiguated name, and a profile whose stored config no longer parses is never overwritten. Provider-managed profiles (Mullvad, IVPN) are never matched at all: their names are ours and key rotation rewrites their configs.

The active profile is left alone unless there was none, so an import cannot move the user off the tunnel they are on.

The picker filters on `*/*`: configs carry no registered MIME type and file managers report them inconsistently, so a narrower filter would hide the very files the user came to pick.

## Tests

- `WgImporterTest` (new, 13 cases): single config, non-config, mixed archive, name collisions across folders and across a multi-file pick, directory entries, traversing paths, the three archive bounds, case-insensitive extensions, and archive detection with no usable file name.
- `WgProfileManagerTest` (10 new cases): bulk add, activation only when nothing was active, a same-tunnel re-import refreshing rather than duplicating, the live config refreshing when the active profile is re-imported, a different tunnel sharing a file name being kept alongside, the second provider's file refreshing its own profile on the next import, an unparsable stored config never being overwritten, provider-managed profiles never being taken over, the default-name fallback, and an import of nothing changing no state.

CI (`test` and `instrumentation`) is green on this branch. It was not run locally — the container had no Android SDK, so `:app:lintGithubDebug` in particular has not been run anywhere.

## Not covered

- No `ACTION_VIEW` intent filter for `.conf`, so "Open with → TrackerControl" from a file manager does not work yet. Easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFoiFdfWyS2ffX4HfKeSQp