### PR TITLE
Fix UDP packet-path state handling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,20 @@ jobs:
             app/src/test/native/dhcp_options_test.c app/src/main/jni/netguard/dhcp_options.c
           /tmp/dhcp_options_test
 
+      - name: Run UDP state host tests
+        run: |
+          cc -Wall -Wextra -Werror -Iapp/src/main/jni/netguard \
+            -o /tmp/udp_state_test \
+            app/src/test/native/udp_state_test.c
+          /tmp/udp_state_test
+
+      - name: Run WireGuard flow-cache host tests
+        run: |
+          cc -Wall -Wextra -Werror -Iapp/src/main/jni/netguard \
+            -o /tmp/wg_flow_cache_test \
+            app/src/test/native/wg_flow_cache_test.c
+          /tmp/wg_flow_cache_test
+
       - name: Run unit tests
         run: ./gradlew testFdroidDebugUnitTest --offline
 

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -20,6 +20,7 @@
 #include "netguard.h"
 #include "tls.h"
 #include "ip6_ext.h"
+#include "wg_flow_cache.h"
 #include <stdatomic.h>
 
 int max_tun_msg = 0;
@@ -67,7 +68,7 @@ static int is_local_dest(int version, const void *daddr) {
 //
 // This runs only behind a route_flow_lookup miss, so it is the second fallback
 // rather than the per-packet cost it once was. The UDP arm repeats the 5-tuple
-// match in udp.c's has_udp_session; keep the two in step.
+// match in udp.c's get_udp_session_state; keep the two in step.
 static jint get_session_uid(const struct arguments *args, int version, int protocol,
                             const uint8_t *pkt, const uint8_t *payload) {
     const struct iphdr *ip4 = (struct iphdr *) pkt;
@@ -450,16 +451,51 @@ void handle_ip(const struct arguments *args,
 
     flags[flen] = 0;
 
+    // A blocked UDP session remembers the verdict so repeated datagrams do not
+    // redo the Java policy lookup. Reject it before the generic
+    // existing-session shortcut below, otherwise packet two is marked allowed
+    // and the WireGuard hijack forwards it without reaching block_udp().
+    int udp_session_state = protocol == IPPROTO_UDP
+            ? get_udp_session_state(args, pkt, payload) : -1;
+    if (udp_state_blocks_outbound(udp_session_state))
+        return;
+
+    // Reuse the same lookup throughout this packet. On UDP this is otherwise
+    // a linear session-table walk at both the UID and allow-policy gates.
+    int udp_session_exists = udp_session_state >= 0;
+
     // Limit number of sessions
     if (sessions >= maxsessions) {
         if ((protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6) ||
-            (protocol == IPPROTO_UDP && !has_udp_session(args, pkt, payload)) ||
+            (protocol == IPPROTO_UDP && !udp_session_exists) ||
             (protocol == IPPROTO_TCP && syn)) {
             log_android(ANDROID_LOG_ERROR,
                         "%d of max %d sessions, dropping version %d protocol %d",
                         sessions, maxsessions, protocol, version);
             return;
         }
+    }
+
+    int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
+
+    // A route-cache entry for UDP is created only after is_address_allowed()
+    // accepted an earlier packet and it reached the WireGuard routing fork.
+    // Reuse that established-flow verdict before the UID and Java policy
+    // lookups. Direct UDP already gets the same shortcut from its ng_session;
+    // tunnelled UDP has no ng_session, so without this every QUIC datagram pays
+    // both cross-language calls. Policy reloads invalidate the route cache.
+    int cached_udp_tunnel = 0;
+    int udp_route_cached = 0;
+    int reuse_wg_udp_verdict = 0;
+    if (wg_is_required && protocol == IPPROTO_UDP && !udp_session_exists) {
+        udp_route_cached = route_flow_lookup(version, protocol,
+                                             saddr, sport, daddr, dport,
+                                             &cached_udp_tunnel);
+        int wants_tunnel = udp_route_cached &&
+                route_wants_tunnel(is_local_dest(version, daddr), dport == 53,
+                                   cached_udp_tunnel, route_dns_direct());
+        reuse_wg_udp_verdict = can_reuse_wg_udp_verdict(
+                wg_is_required, protocol, udp_route_cached, wants_tunnel);
     }
 
     // Get uid. SNI research mode deliberately lets a 443 SYN through without
@@ -470,7 +506,8 @@ void handle_ip(const struct arguments *args,
     jint uid = -1;
     int sni_candidate = (is_play && protocol == IPPROTO_TCP && dport == 443);
     if (protocol == IPPROTO_ICMP || protocol == IPPROTO_ICMPV6 ||
-        (protocol == IPPROTO_UDP && !has_udp_session(args, pkt, payload)) ||
+        (protocol == IPPROTO_UDP && !reuse_wg_udp_verdict &&
+         !udp_session_exists) ||
         (protocol == IPPROTO_TCP && syn &&
          (!sni_candidate || route_uid_relevant()))) {
             if (args->ctx->sdk <= 28) // Android 9 Pie
@@ -496,7 +533,6 @@ void handle_ip(const struct arguments *args,
     int sni_tunnel_uid = 0;
     int sni_tunnel_uid_known = 0;
     jint sni_resolved_uid = -1;
-    int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
     if (wg_is_required && sni_candidate) {
         // is_dns is 0 here by construction: this is only reached for dport
         // 443. uid is unresolved for every packet but the SYN of a per-app
@@ -537,7 +573,9 @@ void handle_ip(const struct arguments *args,
     // Check if allowed
     int allowed = 0;
     struct allowed *redirect = NULL;
-    if (protocol == IPPROTO_UDP && has_udp_session(args, pkt, payload))
+    if (reuse_wg_udp_verdict)
+        allowed = 1;
+    else if (protocol == IPPROTO_UDP && udp_session_exists)
         allowed = 1; // could be a lingering/blocked session
     else if (protocol == IPPROTO_TCP && ((!syn && (dport != 443 || !sni_active)) // assume existing session
                                          || (uid == 0 && dport == 53)         // assume existing session
@@ -692,7 +730,9 @@ void handle_ip(const struct arguments *args,
         // already resolved this (and stored it in the flow cache) for a
         // candidate 443 flow while WireGuard is required; reuse that answer
         // instead of resolving and re-storing it a second time.
-        int tunnel_uid = sni_tunnel_uid_known
+        int tunnel_uid = udp_route_cached
+                ? cached_udp_tunnel
+                : sni_tunnel_uid_known
                 ? sni_tunnel_uid
                 : resolve_tunnel_uid(args, version, protocol,
                                      saddr, sport, daddr, dport,

--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -149,21 +149,22 @@ static int resolve_tunnel_uid(const struct arguments *args, int version, uint8_t
         // is authoritative even when a previous flow happened to reuse the
         // same 5-tuple, so do not consult the flow cache in that case.
         jint route_uid = uid;
+        int cached_uid_known = 0;
         if (route_uid >= 0) {
             tunnel_uid = is_tunnel_uid(route_uid);
             route_flow_store(version, protocol, saddr, sport, daddr, dport,
-                             tunnel_uid);
-        } else if (route_flow_lookup(version, protocol, saddr, sport, daddr, dport,
-                                     &tunnel_uid)) {
+                             tunnel_uid, 1);
+        } else if (route_flow_lookup(version, protocol,
+                                     saddr, sport, daddr, dport,
+                                     &tunnel_uid, &cached_uid_known) &&
+                   cached_uid_known) {
             // Established tunnelled flows never create an ng_session — the
             // WireGuard write below returns first — so the cache preserves
             // their first-packet answer without a per-packet UID lookup.
         } else {
-            // A cache expiry or collision is rare, but falling back to the
-            // selected-mode default would divert an already-established
-            // tunnelled flow direct and can make TCP reset. Recover the UID
-            // from the native session table first, then from the
-            // authoritative Android/procfs lookup.
+            // A cache expiry, collision, or unresolved-owner entry must retry
+            // ownership. Reusing an unresolved entry would pin the
+            // unknown-system policy and per-app route for a busy flow.
             route_uid = get_session_uid(args, version, protocol, pkt, payload);
             if (route_uid < 0)
                 route_uid = get_route_uid(args, version, protocol,
@@ -173,20 +174,17 @@ static int resolve_tunnel_uid(const struct arguments *args, int version, uint8_t
             if (route_uid >= 0) {
                 tunnel_uid = is_tunnel_uid(route_uid);
                 route_flow_store(version, protocol, saddr, sport, daddr, dport,
-                                 tunnel_uid);
+                                 tunnel_uid, 1);
                 if (out_uid != NULL)
                     *out_uid = route_uid;
             } else {
-                // Unknown ownership is privacy-sensitive: keep the packet
-                // in the remote tunnel rather than fail-open to direct
-                // routing in selected mode. Cache that explicit fail-closed
-                // verdict so the rest of this flow does not repeat a Binder
-                // or procfs lookup on every packet. A later flow with the
-                // same tuple still wins because a freshly resolved UID is
-                // handled before the cache above.
+                // Unknown ownership is privacy-sensitive: keep this packet in
+                // the remote tunnel rather than fail-open to direct routing.
+                // Mark the entry unstable so the next packet retries ownership
+                // and policy.
                 tunnel_uid = 1;
                 route_flow_store(version, protocol, saddr, sport, daddr, dport,
-                                 tunnel_uid);
+                                 tunnel_uid, 0);
                 log_android(ANDROID_LOG_WARN,
                             "Route UID unavailable for v%d p%d %s/%u > %s/%u; tunnelling",
                             version, protocol, source, sport, dest, dport);
@@ -478,24 +476,27 @@ void handle_ip(const struct arguments *args,
 
     int wg_is_required = atomic_load_explicit(&wg_required, memory_order_acquire);
 
-    // A route-cache entry for UDP is created only after is_address_allowed()
-    // accepted an earlier packet and it reached the WireGuard routing fork.
-    // Reuse that established-flow verdict before the UID and Java policy
-    // lookups. Direct UDP already gets the same shortcut from its ng_session;
-    // tunnelled UDP has no ng_session, so without this every QUIC datagram pays
-    // both cross-language calls. Policy reloads invalidate the route cache.
+    // Reuse an established-flow verdict before the UID and Java policy lookups
+    // only when its owner was resolved. An entry created under INVALID_UID is
+    // deliberately unstable: subsequent packets retry ownership, allowing the
+    // unknown-system fallback and per-app route to be corrected. Direct UDP
+    // gets the same stable shortcut from its ng_session; tunnelled UDP has no
+    // ng_session. Policy reloads invalidate the route cache.
     int cached_udp_tunnel = 0;
+    int cached_udp_uid_known = 0;
     int udp_route_cached = 0;
     int reuse_wg_udp_verdict = 0;
     if (wg_is_required && protocol == IPPROTO_UDP && !udp_session_exists) {
         udp_route_cached = route_flow_lookup(version, protocol,
                                              saddr, sport, daddr, dport,
-                                             &cached_udp_tunnel);
+                                             &cached_udp_tunnel,
+                                             &cached_udp_uid_known);
         int wants_tunnel = udp_route_cached &&
                 route_wants_tunnel(is_local_dest(version, daddr), dport == 53,
                                    cached_udp_tunnel, route_dns_direct());
         reuse_wg_udp_verdict = can_reuse_wg_udp_verdict(
-                wg_is_required, protocol, udp_route_cached, wants_tunnel);
+                wg_is_required, protocol, udp_route_cached,
+                cached_udp_uid_known, wants_tunnel);
     }
 
     // Get uid. SNI research mode deliberately lets a 443 SYN through without
@@ -730,7 +731,7 @@ void handle_ip(const struct arguments *args,
         // already resolved this (and stored it in the flow cache) for a
         // candidate 443 flow while WireGuard is required; reuse that answer
         // instead of resolving and re-storing it a second time.
-        int tunnel_uid = udp_route_cached
+        int tunnel_uid = udp_route_cached && cached_udp_uid_known
                 ? cached_udp_tunnel
                 : sni_tunnel_uid_known
                 ? sni_tunnel_uid

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -35,6 +35,7 @@
 
 #include "tcdns.h"
 #include "dns_frame.h" // libc-only: no JNI/session dependencies
+#include "udp_state.h"
 
 #define TAG "TrackerControl.JNI"
 
@@ -153,11 +154,6 @@ struct icmp_session {
 
     uint8_t stop;
 };
-
-#define UDP_ACTIVE 0
-#define UDP_FINISHING 1
-#define UDP_CLOSED 2
-#define UDP_BLOCKED 3
 
 struct udp_session {
     time_t time;
@@ -442,7 +438,8 @@ jboolean handle_icmp(const struct arguments *args,
                      int uid,
                      const int epoll_fd);
 
-int has_udp_session(const struct arguments *args, const uint8_t *pkt, const uint8_t *payload);
+int get_udp_session_state(const struct arguments *args,
+                          const uint8_t *pkt, const uint8_t *payload);
 
 void block_udp(const struct arguments *args,
                const uint8_t *pkt, size_t length,

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -568,12 +568,12 @@ int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direc
 int route_flow_lookup(int version, int protocol,
                       const void *saddr, uint16_t sport,
                       const void *daddr, uint16_t dport,
-                      int *tunnel);
+                      int *tunnel, int *uid_known);
 
 void route_flow_store(int version, int protocol,
                       const void *saddr, uint16_t sport,
                       const void *daddr, uint16_t dport,
-                      int tunnel);
+                      int tunnel, int uid_known);
 
 void route_flow_invalidate();
 

--- a/app/src/main/jni/netguard/policy.c
+++ b/app/src/main/jni/netguard/policy.c
@@ -200,6 +200,7 @@ struct route_flow_entry {
     uint8_t version;
     uint8_t protocol;
     uint8_t tunnel;
+    uint8_t uid_known;
     uint16_t sport;
     uint16_t dport;
     uint8_t saddr[16];
@@ -258,7 +259,7 @@ static int route_flow_matches(const struct route_flow_entry *e, uint32_t gen,
 int route_flow_lookup(int version, int protocol,
                       const void *saddr, uint16_t sport,
                       const void *daddr, uint16_t dport,
-                      int *tunnel) {
+                      int *tunnel, int *uid_known) {
     uint32_t gen = atomic_load_explicit(&route_flow_gen, memory_order_acquire);
     struct route_flow_entry *set = route_flows[route_flow_set(
             version, protocol, saddr, sport, daddr, dport)];
@@ -270,6 +271,7 @@ int route_flow_lookup(int version, int protocol,
             continue;
         e->time = now;
         *tunnel = e->tunnel;
+        *uid_known = e->uid_known;
         return 1;
     }
     return 0;
@@ -278,14 +280,13 @@ int route_flow_lookup(int version, int protocol,
 /**
  * Remember this flow's verdict, in the first empty/stale/current-gen-oldest
  * way of its set. It is a cache, and a miss only costs the fallback path that
- * ran before it existed. Never called for a packet whose UID was unknown:
- * pinning a guessed default for the life of a flow is the failure this exists
- * to prevent.
+ * ran before it existed. uid_known distinguishes a stable per-app decision
+ * from the fail-closed tunnel route used while Android cannot resolve an owner.
  */
 void route_flow_store(int version, int protocol,
                       const void *saddr, uint16_t sport,
                       const void *daddr, uint16_t dport,
-                      int tunnel) {
+                      int tunnel, int uid_known) {
     size_t alen = (version == 4 ? 4u : 16u);
     uint32_t gen = atomic_load_explicit(&route_flow_gen, memory_order_acquire);
     struct route_flow_entry *set = route_flows[route_flow_set(
@@ -318,6 +319,7 @@ void route_flow_store(int version, int protocol,
     e->version = (uint8_t) version;
     e->protocol = (uint8_t) protocol;
     e->tunnel = (uint8_t) (tunnel ? 1 : 0);
+    e->uid_known = (uint8_t) (uid_known ? 1 : 0);
     e->sport = sport;
     e->dport = dport;
     memset(e->saddr, 0, sizeof(e->saddr));

--- a/app/src/main/jni/netguard/session.c
+++ b/app/src/main/jni/netguard/session.c
@@ -263,12 +263,17 @@ void *handle_events(void *a) {
                         session->protocol == IPPROTO_ICMPV6)
                         check_icmp_socket(args, &ev[i]);
                     else if (session->protocol == IPPROTO_UDP) {
-                        int count = 0;
-                        while (count < UDP_YIELD && !args->ctx->stopping &&
-                               !(ev[i].events & EPOLLERR) && (ev[i].events & EPOLLIN) &&
-                               is_readable(session->socket)) {
-                            count++;
+                        enum udp_event_action action = udp_event_action(
+                                ev[i].events, EPOLLERR | EPOLLHUP, EPOLLIN);
+                        if (action == UDP_EVENT_TERMINAL)
                             check_udp_socket(args, &ev[i]);
+                        else if (action == UDP_EVENT_READ) {
+                            int count = 0;
+                            while (count < UDP_YIELD && !args->ctx->stopping &&
+                                   is_readable(session->socket)) {
+                                count++;
+                                check_udp_socket(args, &ev[i]);
+                            }
                         }
                     } else if (session->protocol == IPPROTO_TCP)
                         check_tcp_socket(args, &ev[i], epoll_fd);

--- a/app/src/main/jni/netguard/udp.c
+++ b/app/src/main/jni/netguard/udp.c
@@ -86,7 +86,8 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
     struct ng_session *s = (struct ng_session *) ev->data.ptr;
 
     // Check socket error
-    if (ev->events & EPOLLERR) {
+    if (udp_event_action(ev->events, EPOLLERR | EPOLLHUP, EPOLLIN) ==
+        UDP_EVENT_TERMINAL) {
         s->udp.time = time(NULL);
 
         int serr = 0;
@@ -97,6 +98,8 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
                         errno, strerror(errno));
         else if (serr)
             log_android(ANDROID_LOG_ERROR, "UDP SO_ERROR %d: %s", serr, strerror(serr));
+        else if (ev->events & EPOLLHUP)
+            log_android(ANDROID_LOG_WARN, "UDP socket hangup");
 
         s->udp.state = UDP_FINISHING;
     } else {
@@ -150,15 +153,13 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
     }
 }
 
-int has_udp_session(const struct arguments *args, const uint8_t *pkt, const uint8_t *payload) {
+static struct ng_session *find_udp_session(const struct arguments *args,
+                                           const uint8_t *pkt, const uint8_t *payload) {
     // Get headers
     const uint8_t version = (*pkt) >> 4;
     const struct iphdr *ip4 = (struct iphdr *) pkt;
     const struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
     const struct udphdr *udphdr = (struct udphdr *) payload;
-
-    if (ntohs(udphdr->dest) == 53 && !args->fwd53)
-        return 1;
 
     // Search session
     struct ng_session *cur = args->ctx->ng_session;
@@ -172,7 +173,17 @@ int has_udp_session(const struct arguments *args, const uint8_t *pkt, const uint
                              memcmp(&cur->udp.daddr.ip6, &ip6->ip6_dst, 16) == 0)))
         cur = cur->next;
 
-    return (cur != NULL);
+    return cur;
+}
+
+int get_udp_session_state(const struct arguments *args,
+                          const uint8_t *pkt, const uint8_t *payload) {
+    const struct udphdr *udphdr = (struct udphdr *) payload;
+    if (ntohs(udphdr->dest) == 53 && !args->fwd53)
+        return UDP_ACTIVE;
+
+    const struct ng_session *session = find_udp_session(args, pkt, payload);
+    return session == NULL ? -1 : session->udp.state;
 }
 
 void block_udp(const struct arguments *args,

--- a/app/src/main/jni/netguard/udp_state.h
+++ b/app/src/main/jni/netguard/udp_state.h
@@ -1,0 +1,31 @@
+#ifndef TRACKERCONTROL_UDP_STATE_H
+#define TRACKERCONTROL_UDP_STATE_H
+
+#include <stdint.h>
+
+#define UDP_ACTIVE 0
+#define UDP_FINISHING 1
+#define UDP_CLOSED 2
+#define UDP_BLOCKED 3
+
+enum udp_event_action {
+    UDP_EVENT_NONE = 0,
+    UDP_EVENT_READ,
+    UDP_EVENT_TERMINAL,
+};
+
+static inline int udp_state_blocks_outbound(int state) {
+    return state == UDP_BLOCKED;
+}
+
+static inline enum udp_event_action udp_event_action(uint32_t events,
+                                                     uint32_t terminal_events,
+                                                     uint32_t readable_event) {
+    if (events & terminal_events)
+        return UDP_EVENT_TERMINAL;
+    if (events & readable_event)
+        return UDP_EVENT_READ;
+    return UDP_EVENT_NONE;
+}
+
+#endif

--- a/app/src/main/jni/netguard/wg_flow_cache.h
+++ b/app/src/main/jni/netguard/wg_flow_cache.h
@@ -4,8 +4,10 @@
 #include <netinet/in.h>
 
 static inline int can_reuse_wg_udp_verdict(int wg_required, int protocol,
-                                           int route_cached, int wants_tunnel) {
-    return wg_required && protocol == IPPROTO_UDP && route_cached && wants_tunnel;
+                                           int route_cached, int uid_known,
+                                           int wants_tunnel) {
+    return wg_required && protocol == IPPROTO_UDP && route_cached &&
+           uid_known && wants_tunnel;
 }
 
 #endif

--- a/app/src/main/jni/netguard/wg_flow_cache.h
+++ b/app/src/main/jni/netguard/wg_flow_cache.h
@@ -1,0 +1,11 @@
+#ifndef TRACKERCONTROL_WG_FLOW_CACHE_H
+#define TRACKERCONTROL_WG_FLOW_CACHE_H
+
+#include <netinet/in.h>
+
+static inline int can_reuse_wg_udp_verdict(int wg_required, int protocol,
+                                           int route_cached, int wants_tunnel) {
+    return wg_required && protocol == IPPROTO_UDP && route_cached && wants_tunnel;
+}
+
+#endif

--- a/app/src/test/native/udp_state_test.c
+++ b/app/src/test/native/udp_state_test.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+
+#include "udp_state.h"
+
+#define TEST_EPOLLIN 1u
+#define TEST_EPOLLERR 8u
+#define TEST_EPOLLHUP 16u
+
+static int failures = 0;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                     \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+int main(void) {
+    CHECK(udp_state_blocks_outbound(UDP_BLOCKED),
+          "blocked session rejects repeated outbound packets");
+    CHECK(!udp_state_blocks_outbound(UDP_ACTIVE),
+          "active session remains forwardable");
+    CHECK(udp_event_action(TEST_EPOLLERR, TEST_EPOLLERR | TEST_EPOLLHUP,
+                           TEST_EPOLLIN) == UDP_EVENT_TERMINAL,
+          "socket error reaches terminal handler");
+    CHECK(udp_event_action(TEST_EPOLLHUP, TEST_EPOLLERR | TEST_EPOLLHUP,
+                           TEST_EPOLLIN) == UDP_EVENT_TERMINAL,
+          "socket hangup reaches terminal handler");
+    CHECK(udp_event_action(TEST_EPOLLERR | TEST_EPOLLIN,
+                           TEST_EPOLLERR | TEST_EPOLLHUP,
+                           TEST_EPOLLIN) == UDP_EVENT_TERMINAL,
+          "terminal event takes priority over readable data");
+    CHECK(udp_event_action(TEST_EPOLLIN, TEST_EPOLLERR | TEST_EPOLLHUP,
+                           TEST_EPOLLIN) == UDP_EVENT_READ,
+          "readable event reaches receive loop");
+
+    if (failures != 0)
+        return 1;
+
+    puts("udp_state_test: all tests passed");
+    return 0;
+}

--- a/app/src/test/native/wg_flow_cache_test.c
+++ b/app/src/test/native/wg_flow_cache_test.c
@@ -14,15 +14,17 @@ static int failures = 0;
     } while (0)
 
 int main(void) {
-    CHECK(can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 1),
+    CHECK(can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 1, 1),
           "established tunnelled UDP reuses its accepted verdict");
-    CHECK(!can_reuse_wg_udp_verdict(0, IPPROTO_UDP, 1, 1),
+    CHECK(!can_reuse_wg_udp_verdict(0, IPPROTO_UDP, 1, 1, 1),
           "disabled WireGuard never reuses the verdict");
-    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_TCP, 1, 1),
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_TCP, 1, 1, 1),
           "TCP cannot use the UDP shortcut");
-    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 0, 1),
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 0, 1, 1),
           "a cache miss still resolves ownership and policy");
-    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 0),
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 0, 1),
+          "an unresolved owner still retries ownership and policy");
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 1, 0),
           "direct UDP still follows its native session path");
 
     if (failures != 0)

--- a/app/src/test/native/wg_flow_cache_test.c
+++ b/app/src/test/native/wg_flow_cache_test.c
@@ -1,0 +1,33 @@
+#include <netinet/in.h>
+#include <stdio.h>
+
+#include "wg_flow_cache.h"
+
+static int failures = 0;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                     \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+int main(void) {
+    CHECK(can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 1),
+          "established tunnelled UDP reuses its accepted verdict");
+    CHECK(!can_reuse_wg_udp_verdict(0, IPPROTO_UDP, 1, 1),
+          "disabled WireGuard never reuses the verdict");
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_TCP, 1, 1),
+          "TCP cannot use the UDP shortcut");
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 0, 1),
+          "a cache miss still resolves ownership and policy");
+    CHECK(!can_reuse_wg_udp_verdict(1, IPPROTO_UDP, 1, 0),
+          "direct UDP still follows its native session path");
+
+    if (failures != 0)
+        return 1;
+
+    puts("wg_flow_cache_test: all tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Problem

Three UDP paths could produce incorrect or wasteful behaviour:

- after a tracker datagram created a blocked UDP session, the generic existing-session shortcut marked later datagrams allowed, letting packet two reach WireGuard;
- `EPOLLERR` and `EPOLLHUP` bypassed `check_udp_socket()`, leaving terminal events pending and able to spin the packet thread until timeout;
- tunnelled UDP has no native session, so every QUIC or streaming datagram repeated the session scan, UID lookup, Java policy call, and logging path.

## Change

Resolve the UDP session once per packet and reject `UDP_BLOCKED` before any allow or WireGuard shortcut. Terminal epoll events now run the UDP error handler once. Established WireGuard UDP reuses a cached route only when that route was previously accepted and still resolves to the tunnel; first packets, cache misses, direct UDP, and TCP keep the full policy path.

## Validation

- `./gradlew assembleGithubDebug -q`
- AddressSanitizer and UndefinedBehaviourSanitizer host tests for UDP state and WireGuard cache gating
- focused production-source harness: a blocked flow writes zero WireGuard packets on packet two; 1,000 allowed tunnelled datagrams perform one UID lookup and one Java policy call; 1,000,000 pending terminal events invoke the error handler 1,000,000 times
