### PR TITLE
Fix mixed tracker evidence expiry

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3124,6 +3124,7 @@ public class ServiceSinkhole extends VpnService {
             boolean sawFirstRow = false;
             boolean sawTrackerEvidence = false;
             boolean sawNonTrackerEvidence = false;
+            long latestNonTrackerExpiry = -1;
             // Blocking evidence, classified against the DuckDuckGo-only map.
             // Detection above uses the full map in every mode, so the blocking
             // verdict has to be tracked separately to stay DDG-compatible.
@@ -3131,6 +3132,7 @@ public class ServiceSinkhole extends VpnService {
             boolean sawMinimalCategory = false;
             boolean sawMinimalTrackerEvidence = false;
             boolean sawNonMinimalTrackerEvidence = false;
+            long latestNonMinimalExpiry = -1;
             // Expiry of the DNS record minimalCategory was derived from,
             // tracked separately from chosenTime/chosenTtl: the DDG row that
             // supplies minimalCategory need not be the same row that
@@ -3190,8 +3192,11 @@ public class ServiceSinkhole extends VpnService {
                                 minimalChosenTime = rowTime;
                                 minimalChosenTtl = rowTtl;
                             }
-                        } else if (qname != null || aname != null)
+                        } else if (qname != null || aname != null) {
+                            latestNonMinimalExpiry = Math.max(latestNonMinimalExpiry,
+                                    TrackerEvidenceExpiry.at(rowTime, rowTtl));
                             sawNonMinimalTrackerEvidence = true;
+                        }
 
                         if (candidateTracker != null) {
                             sawTrackerEvidence = true;
@@ -3204,19 +3209,25 @@ public class ServiceSinkhole extends VpnService {
                                 chosenTime = rowTime;
                                 chosenTtl = rowTtl;
                             }
-                        } else if (qname != null || aname != null)
+                        } else if (qname != null || aname != null) {
+                            latestNonTrackerExpiry = Math.max(latestNonTrackerExpiry,
+                                    TrackerEvidenceExpiry.at(rowTime, rowTtl));
                             sawNonTrackerEvidence = true;
+                        }
                     }
                 }
             }
 
-            if (sawTrackerEvidence && sawNonTrackerEvidence && !blockAmbiguousTrackers) {
+            boolean mixedTrackerEvidence = sawTrackerEvidence && sawNonTrackerEvidence
+                    && !blockAmbiguousTrackers;
+            if (mixedTrackerEvidence) {
                 Log.d(TAG, "Allowing mixed tracker evidence for " + daddr);
                 tracker = NO_TRACKER;
             }
 
-            if (sawMinimalTrackerEvidence && sawNonMinimalTrackerEvidence
-                    && !blockAmbiguousTrackers)
+            boolean mixedMinimalEvidence = sawMinimalTrackerEvidence && sawNonMinimalTrackerEvidence
+                    && !blockAmbiguousTrackers;
+            if (mixedMinimalEvidence)
                 minimalCategory = null;
 
             // No success in finding dname or tracker?
@@ -3235,22 +3246,38 @@ public class ServiceSinkhole extends VpnService {
                 // the full DNS TTL (up to 7 days), which would keep any
                 // tracker traffic to this IP invisible and unblocked until
                 // then.
-                expiry = now + NEGATIVE_TRACKER_CACHE_TTL_MS;
+                expiry = TrackerEvidenceExpiry.at(now, NEGATIVE_TRACKER_CACHE_TTL_MS);
             } else {
                 // DNS evidence exists (tracker or confident non-tracker);
                 // expire with the record the decision was derived from, not
                 // whatever row happened to be read last.
                 expiry = (chosenTime >= 0)
-                        ? chosenTime + chosenTtl
-                        : firstTime + firstTtl;
+                        ? TrackerEvidenceExpiry.at(chosenTime, chosenTtl)
+                        : TrackerEvidenceExpiry.at(firstTime, firstTtl);
+                // An ambiguous standard-mode verdict depends on both the
+                // selected tracker row and the last fresh non-tracker row.
+                // Re-read when either side can have changed, so a benign row
+                // expiring cannot leave an allow verdict cached until the
+                // tracker's unrelated TTL expires.
+                if (mixedTrackerEvidence)
+                    expiry = Math.min(expiry, TrackerEvidenceExpiry.mixed(
+                            TrackerEvidenceExpiry.at(chosenTime, chosenTtl),
+                            latestNonTrackerExpiry));
                 // The minimal (DDG) verdict can be derived from a
                 // different row than the broader-map tracker above; expire
                 // with whichever evidence goes stale first so a blocking
                 // verdict never outlives the record it came from.
                 if (minimalCategory != null && minimalChosenTime >= 0) {
-                    long minimalExpiry = minimalChosenTime + minimalChosenTtl;
+                    long minimalExpiry = TrackerEvidenceExpiry.at(
+                            minimalChosenTime, minimalChosenTtl);
                     expiry = Math.min(expiry, minimalExpiry);
                 }
+                // A mixed Minimal/DDG verdict likewise depends on the selected
+                // DDG tracker and the last fresh non-DDG row.
+                if (mixedMinimalEvidence)
+                    expiry = Math.min(expiry, TrackerEvidenceExpiry.mixed(
+                            TrackerEvidenceExpiry.at(minimalChosenTime, minimalChosenTtl),
+                            latestNonMinimalExpiry));
             }
 
             // Save dname and tracker, but only if no concurrent

--- a/app/src/main/java/eu/faircode/netguard/TrackerEvidenceExpiry.java
+++ b/app/src/main/java/eu/faircode/netguard/TrackerEvidenceExpiry.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of TrackerControl.
+ *
+ * TrackerControl is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+package eu.faircode.netguard;
+
+/** Expiry arithmetic for DNS evidence-backed tracker verdicts. */
+final class TrackerEvidenceExpiry {
+    private TrackerEvidenceExpiry() {
+    }
+
+    /** Add a DNS TTL without allowing malformed or extreme input to wrap. */
+    static long at(long timeMs, long ttlMs) {
+        if (ttlMs > 0 && timeMs > Long.MAX_VALUE - ttlMs)
+            return Long.MAX_VALUE;
+        if (ttlMs < 0 && timeMs < Long.MIN_VALUE - ttlMs)
+            return Long.MIN_VALUE;
+        return timeMs + ttlMs;
+    }
+
+    /** A mixed verdict is valid only while both kinds of evidence remain fresh. */
+    static long mixed(long selectedTrackerExpiry, long lastOtherExpiry) {
+        return Math.min(selectedTrackerExpiry, lastOtherExpiry);
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/TrackerEvidenceExpiryTest.java
+++ b/app/src/test/java/eu/faircode/netguard/TrackerEvidenceExpiryTest.java
@@ -1,0 +1,44 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class TrackerEvidenceExpiryTest {
+    @Test
+    public void mixedVerdictExpiresWhenBenignEvidenceExpiresFirst() {
+        long selectedTrackerExpiry = TrackerEvidenceExpiry.at(1_000L, 5_000L);
+        long benignExpiry = TrackerEvidenceExpiry.at(900L, 1_000L);
+
+        assertEquals(1_900L,
+                TrackerEvidenceExpiry.mixed(selectedTrackerExpiry, benignExpiry));
+    }
+
+    @Test
+    public void mixedVerdictUsesLastFreshBenignRow() {
+        long selectedTrackerExpiry = TrackerEvidenceExpiry.at(1_000L, 5_000L);
+        long firstBenignExpiry = TrackerEvidenceExpiry.at(900L, 500L);
+        long lastBenignExpiry = TrackerEvidenceExpiry.at(950L, 2_000L);
+
+        assertEquals(2_950L,
+                TrackerEvidenceExpiry.mixed(selectedTrackerExpiry,
+                        Math.max(firstBenignExpiry, lastBenignExpiry)));
+    }
+
+    @Test
+    public void minimalMixedVerdictUsesTheSameEvidenceRule() {
+        long selectedMinimalExpiry = TrackerEvidenceExpiry.at(4_000L, 2_000L);
+        long lastNonMinimalExpiry = TrackerEvidenceExpiry.at(3_500L, 100L);
+
+        assertEquals(3_600L,
+                TrackerEvidenceExpiry.mixed(selectedMinimalExpiry, lastNonMinimalExpiry));
+    }
+
+    @Test
+    public void expiryArithmeticSaturatesAtLongBounds() {
+        assertEquals(Long.MAX_VALUE,
+                TrackerEvidenceExpiry.at(Long.MAX_VALUE - 1L, 2L));
+        assertEquals(Long.MIN_VALUE,
+                TrackerEvidenceExpiry.at(Long.MIN_VALUE + 1L, -2L));
+    }
+}


### PR DESCRIPTION
## Problem

A standard-mode mixed tracker/non-tracker allow verdict used only the selected tracker row's expiry. When its benign evidence expired first, the cached allow remained active and tracker traffic could stay allowed until an unrelated, longer tracker TTL elapsed. The DDG/minimal mixed verdict had the same lifetime mismatch.

## Change

Mixed verdicts now expire at the earlier of the selected tracker evidence and the last opposing evidence row. Multiple benign rows continue to justify ambiguity until the last one expires. Expiry addition saturates instead of overflowing.

## Validation

- `./gradlew :app:testGithubDebugUnitTest -q`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`
- focused tests cover early benign expiry, multiple benign rows, DDG/minimal evidence, and `long` bounds
