### PR TITLE
Bound the Secure DNS request backlog

### DIFF
--- a/HOTPATH_BUG_AUDIT.md
+++ b/HOTPATH_BUG_AUDIT.md
@@ -566,7 +566,7 @@ All findings in this audit are implemented across the stacked pull requests.
 
 - Two Robolectric audit classes passed three tests against the real service,
   database and tracker-list code.
-- The Rust workspace passed 85 tests across six suites.
+- The Rust workspace passed 95 tests across six suites on the final stack.
 - Two additional extracted DNS/WireGuard tests passed.
 - Native DNS-frame, IPv6-extension, DHCP-option, UDP-state and WireGuard
   flow-cache suites passed under ASan/UBSan.
@@ -594,6 +594,11 @@ All findings in this audit are implemented across the stacked pull requests.
   cross-family, invalid-address, original-tuple and response-tuple cases.
 - The bounded DoH queue branch passed `DnsProxyServerTest` after stacking,
   including deterministic admission and stopped-executor rejection cases.
+- The final stacked branch passed the complete `testGithubDebugUnitTest` suite,
+  the 95-test Rust workspace, and `assembleGithubDebug`. The first integrated
+  Android build exposed an incorrect JNI array-length type; after correcting
+  it, the rerun passed and the APK contained both `libnetguard.so` and
+  `libwgbridge.so` for arm64-v8a, armeabi-v7a, x86 and x86_64.
 
 ## Limits
 

--- a/HOTPATH_BUG_AUDIT.md
+++ b/HOTPATH_BUG_AUDIT.md
@@ -33,7 +33,7 @@ availability or battery impact.
 | 13 | One WireGuard DNS-over-TCP gap permanently disables detection | Detection coverage, DNS reliability | **Medium** | Hard | **Fixed** | Reproduced |
 | 14 | WireGuard TUN write failures remain invisible to its watchdog | Recovery, connectivity, observability | **Medium** | Medium | **Fixed** | Source-proven |
 | 15 | UDP redirects apply only to the first datagram | DNS routing, Secure DNS, privacy | **Medium** | Easy–Medium | **Fixed** | Reproduced |
-| 16 | The DoH proxy has an unbounded request queue | Battery, memory, availability, Secure DNS | **Medium** | Medium | Open | Source-proven |
+| 16 | The DoH proxy has an unbounded request queue | Battery, memory, availability, Secure DNS | **Medium** | Medium | **Fixed** | Source-proven |
 | 17 | Screen-off DoH repeatedly schedules connection-pool eviction | Battery, CPU, Secure DNS | **Low–Medium** | Easy | **Fixed** | Source-proven |
 | 18 | Zero-length UDP datagrams are treated as EOF | Protocol correctness, compatibility | **Low** | Easy | **Fixed** | Reproduced |
 
@@ -42,9 +42,9 @@ also affect battery when the advanced Secure DNS feature is enabled.
 
 ## Fix status
 
-The easy fixes are implemented on `codex/fix-easy-hotpath`. The remaining
-high-severity fixes are implemented on `codex/fix-high-hotpath`, stacked on
-that branch:
+The easy fixes are implemented on `codex/fix-easy-hotpath`. The high-severity,
+TCP, WireGuard, UDP and Secure DNS fixes are implemented in successive stacked
+branches:
 
 | Finding | Status | Implementation |
 |---:|---|---|
@@ -65,9 +65,9 @@ that branch:
 | #13 | **Fixed** | SYN-established DNS-over-TCP framing survives gaps and idle periods; bounded first-seen reassembly recovers only from sequence-valid bytes. |
 | #14 | **Fixed** | Native TUN write totals and streaks reach the watchdog, which recovers only after at least eight consecutive failures continue across five seconds of advancing samples. |
 | #15 | **Fixed** | Each admitted UDP session stores its resolved address family, address and network-order port, so every later datagram uses the same redirect. |
+| #16 | **Fixed** | Secure DNS uses 16 workers and a bounded 64-request backlog; overload receives an immediate UDP `SERVFAIL` or a closed TCP socket. |
 
-Finding #16 remains open. All eight high-severity findings and every native C,
-TCP, UDP and WireGuard finding are fixed across the stacked branches.
+All 18 findings are fixed across the stacked branches.
 
 ## Detailed findings
 
@@ -497,6 +497,11 @@ the session lifetime.
 **Fix difficulty:** Medium
 **Confidence:** High
 
+**Status: Fixed in the bounded DoH queue pull request.** The 16 workers now
+share a bounded 64-request queue. When both are full, UDP receives an immediate
+`SERVFAIL` and TCP connections are closed; overload logging is rate-limited.
+Shutdown also closes accepted TCP sockets that were still queued.
+
 The proxy creates a fixed pool of 16 worker threads, backed by an unbounded
 queue
 ([`DnsProxyServer.java`](app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java),
@@ -553,12 +558,9 @@ For `SOCK_DGRAM`, zero is a successful zero-length message rather than stream
 EOF. It should be handled as data, subject to whether the TUN packet builder
 can represent it.
 
-## Suggested repair order
+## Repair status
 
-All high-severity, native C, TCP, UDP and WireGuard items are complete. The
-remaining order is:
-
-1. Bound the advanced DoH request queue (#16).
+All findings in this audit are implemented across the stacked pull requests.
 
 ## Validation performed
 
@@ -590,6 +592,8 @@ remaining order is:
 - The UDP redirect branch passed its production-backed socket suite under
   ASan/UBSan after stacking, covering repeated, unredirected, IPv4, IPv6,
   cross-family, invalid-address, original-tuple and response-tuple cases.
+- The bounded DoH queue branch passed `DnsProxyServerTest` after stacking,
+  including deterministic admission and stopped-executor rejection cases.
 
 ## Limits
 

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -31,8 +31,9 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,12 +57,15 @@ public class DnsProxyServer {
     private final AtomicBoolean running = new AtomicBoolean(false);
     private DatagramSocket serverSocket;
     private ServerSocket tcpServerSocket;
-    private ExecutorService executor;
+    private ThreadPoolExecutor executor;
     // Tracked so stop() can wait for the listeners to actually exit, rather
     // than just closing their sockets and returning immediately.
     private Thread udpListenerThread;
     private Thread tcpListenerThread;
     private static final long LISTENER_JOIN_TIMEOUT_MS = 2000;
+    private static final int REQUEST_WORKERS = 16;
+    private static final int REQUEST_QUEUE_CAPACITY = 64;
+    private final AtomicInteger overloadDrops = new AtomicInteger(0);
     private final AtomicInteger dohFailures = new AtomicInteger(0);
     // Trips after this many consecutive failed network attempts (not queries):
     // a single failing resolve burns up to three full timeout budgets, so a
@@ -120,8 +124,11 @@ public class DnsProxyServer {
             running.set(true);
 
             // Handlers block on network I/O (worst case ~15s per DoH resolve),
-            // so a pool of 4 collapsed resolution throughput under packet loss
-            executor = Executors.newFixedThreadPool(16);
+            // so a pool of 4 collapsed resolution throughput under packet loss.
+            // Bound the waiting work as well: a dead endpoint must not retain
+            // an unlimited number of DNS packets and accepted TCP sockets.
+            executor = createRequestExecutor(REQUEST_WORKERS, REQUEST_QUEUE_CAPACITY);
+            overloadDrops.set(0);
 
             // Start the main listener thread
             udpListenerThread = new Thread(this::runServer, "DnsProxyServer");
@@ -185,7 +192,11 @@ public class DnsProxyServer {
         tcpListenerThread = null;
 
         if (executor != null) {
-            executor.shutdownNow();
+            List<Runnable> pending = executor.shutdownNow();
+            for (Runnable task : pending)
+                if (task instanceof TcpConnectionTask)
+                    ((TcpConnectionTask) task).discard();
+            executor = null;
         }
 
         // Also reset the DoH client to close idle HTTPS connections
@@ -271,14 +282,52 @@ public class DnsProxyServer {
                 final InetAddress clientAddress = request.getAddress();
                 final int clientPort = request.getPort();
 
-                // Handle the query in a separate thread
-                executor.submit(() -> handleQuery(queryData, clientAddress, clientPort));
+                // Handle the query in a separate thread. Overload gets an
+                // immediate SERVFAIL instead of retaining stale work while
+                // every worker waits on the same failed DoH endpoint.
+                if (!tryExecute(executor,
+                        () -> handleQuery(queryData, clientAddress, clientPort)))
+                    rejectUdpQuery(queryData, clientAddress, clientPort);
 
             } catch (IOException e) {
                 if (running.get()) {
                     Log.e(TAG, "Error receiving DNS query: " + e.getMessage());
                 }
             }
+        }
+    }
+
+    static ThreadPoolExecutor createRequestExecutor(int workers, int queueCapacity) {
+        if (workers <= 0 || queueCapacity <= 0)
+            throw new IllegalArgumentException("workers and queueCapacity must be positive");
+        return new ThreadPoolExecutor(
+                workers, workers, 0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(queueCapacity));
+    }
+
+    static boolean tryExecute(@Nullable ThreadPoolExecutor target, Runnable task) {
+        if (target == null)
+            return false;
+        try {
+            target.execute(task);
+            return true;
+        } catch (RejectedExecutionException ignored) {
+            return false;
+        }
+    }
+
+    private void logOverload(String transport) {
+        int dropped = overloadDrops.incrementAndGet();
+        if ((dropped & 255) == 1)
+            Log.w(TAG, "DNS " + transport + " overload, rejected " + dropped + " request(s)");
+    }
+
+    private void rejectUdpQuery(byte[] queryData, InetAddress clientAddress, int clientPort) {
+        logOverload("UDP");
+        try {
+            sendServFailResponse(queryData, clientAddress, clientPort);
+        } catch (IOException e) {
+            Log.d(TAG, "Unable to send overload SERVFAIL: " + e.getMessage());
         }
     }
 
@@ -418,11 +467,35 @@ public class DnsProxyServer {
             try {
                 Socket clientSocket = tcpServerSocket.accept();
                 clientSocket.setSoTimeout(10000); // 10s timeout
-                executor.submit(() -> handleTcpConnection(clientSocket));
+                TcpConnectionTask task = new TcpConnectionTask(clientSocket);
+                if (!tryExecute(executor, task)) {
+                    logOverload("TCP");
+                    task.discard();
+                }
             } catch (IOException e) {
                 if (running.get()) {
                     Log.e(TAG, "Error accepting TCP connection: " + e.getMessage());
                 }
+            }
+        }
+    }
+
+    private final class TcpConnectionTask implements Runnable {
+        private final Socket client;
+
+        private TcpConnectionTask(Socket client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            handleTcpConnection(client);
+        }
+
+        private void discard() {
+            try {
+                client.close();
+            } catch (IOException ignored) {
             }
         }
     }

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
@@ -1,6 +1,7 @@
 package net.kollnig.missioncontrol.dns;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -9,6 +10,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Only covers the query plausibility gate and the SERVFAIL header builder;
@@ -65,5 +70,39 @@ public class DnsProxyServerTest {
         // RCODE (low nibble of byte 3) is SERVFAIL (2).
         assertTrue((response[3] & 0x0F) == 0x02);
         assertTrue(response.length == query.length);
+    }
+
+    @Test
+    public void requestExecutorRejectsWorkBeyondWorkerAndQueueBound() throws Exception {
+        ThreadPoolExecutor executor = DnsProxyServer.createRequestExecutor(1, 1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        try {
+            assertTrue(DnsProxyServer.tryExecute(executor, () -> {
+                started.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+            assertTrue(started.await(2, TimeUnit.SECONDS));
+
+            assertTrue(DnsProxyServer.tryExecute(executor, () -> { }));
+            assertEquals(1, executor.getQueue().size());
+            assertFalse(DnsProxyServer.tryExecute(executor, () -> { }));
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void stoppedRequestExecutorRejectsNewWork() {
+        ThreadPoolExecutor executor = DnsProxyServer.createRequestExecutor(1, 1);
+        executor.shutdownNow();
+        assertFalse(DnsProxyServer.tryExecute(executor, () -> { }));
     }
 }


### PR DESCRIPTION
When a Secure DNS endpoint stalled, 16 blocked workers fed an unbounded executor queue. Sustained DNS demand could retain stale UDP packets, accepted TCP sockets and request objects without limit.

The proxy now uses 16 workers with a bounded 64-request backlog. Overload receives an immediate UDP `SERVFAIL` or a closed TCP socket, logging is rate-limited, and shutdown closes accepted TCP sockets that remained queued.

Validation:
- focused `DnsProxyServerTest`, including deterministic admission and stopped-executor rejection
- complete `:app:testGithubDebugUnitTest`
- final `assembleGithubDebug` build with `libnetguard.so` and `libwgbridge.so` present for all four ABIs

Stacked on #917.
