### PR TITLE
Fix Linux native regression test portability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,13 @@ on:
     branches: [ master, main ]
 
 jobs:
+  native_defensive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Run native defensive regression tests
+        run: bash app/src/test/native/run_defensive_tests.sh
+
   test:
     runs-on: ubuntu-latest
 
@@ -71,9 +78,6 @@ jobs:
             -o /tmp/dns_frame_test \
             app/src/test/native/dns_frame_test.c app/src/main/jni/netguard/dns_frame.c
           /tmp/dns_frame_test
-
-      - name: Run native defensive regression tests
-        run: bash app/src/test/native/run_defensive_tests.sh
 
       - name: Run IPv6 extension header walk host tests
         run: |

--- a/app/src/test/native/host_compat/linux_test.h
+++ b/app/src/test/native/host_compat/linux_test.h
@@ -1,0 +1,21 @@
+#ifndef TRACKERCONTROL_NATIVE_TEST_LINUX_H
+#define TRACKERCONTROL_NATIVE_TEST_LINUX_H
+
+/* Keep the real Linux protocol headers. Supply only Android/BSD declarations
+ * absent from glibc; Android's bionic already provides these declarations. */
+#if defined(__linux__) && !defined(__ANDROID__)
+#include <stdint.h>
+#include <netinet/in.h>
+#include <linux/sockios.h>
+
+struct ippseudo {
+    struct in_addr ippseudo_src;
+    struct in_addr ippseudo_dst;
+    uint8_t ippseudo_pad;
+    uint8_t ippseudo_p;
+    uint16_t ippseudo_len;
+};
+_Static_assert(sizeof(struct ippseudo) == 12, "IPv4 pseudo-header wire size");
+#endif
+
+#endif

--- a/app/src/test/native/host_compat/linux_test.h
+++ b/app/src/test/native/host_compat/linux_test.h
@@ -7,6 +7,14 @@
 #include <stdint.h>
 #include <netinet/in.h>
 #include <linux/sockios.h>
+#include <netinet/ip6.h>
+
+#ifndef IPV6_VERSION
+#define IPV6_VERSION 0x60
+#endif
+#ifndef IPV6_MAXPACKET
+#define IPV6_MAXPACKET 65535
+#endif
 
 struct ippseudo {
     struct in_addr ippseudo_src;

--- a/app/src/test/native/run_defensive_tests.sh
+++ b/app/src/test/native/run_defensive_tests.sh
@@ -10,6 +10,7 @@ COMMON=(-D_GNU_SOURCE -O1 -g -Wall -Wextra -Wno-unused-parameter
         -Wno-sign-compare -fsanitize="${SANITIZERS:-address,undefined}"
         -fno-sanitize-recover=all -fno-omit-frame-pointer
         -ffunction-sections -fdata-sections -Wl,--gc-sections
+        -include app/src/test/native/host_compat/linux_test.h
         -idirafter app/src/test/native/host_compat -Iapp/src/main/jni/netguard)
 compile() {
     local name=$1


### PR DESCRIPTION
The new native test runner failed on Ubuntu because glibc lacks Android/BSD's `struct ippseudo`, and `SIOCOUTQ` needs `<linux/sockios.h>`. Supply those declarations in a Linux-only test header while retaining the real system protocol headers. Android builds are unaffected.

Run these small sanitizer suites in a separate CI job so compile/test failures are reported without waiting for Rust and Gradle setup. Android NDK UBSan compilation of all four suites passed. Linux execution is delegated to this CI job; no production source changes.
