### PR TITLE
Preserve DNS question provenance and refresh blocking evidence

### DIFF
--- a/app/src/androidTest/java/eu/faircode/netguard/StackPolicyDeviceTest.java
+++ b/app/src/androidTest/java/eu/faircode/netguard/StackPolicyDeviceTest.java
@@ -1,0 +1,99 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.*;
+import android.content.*;
+import android.database.DatabaseErrorHandler;
+import android.database.sqlite.SQLiteDatabase;
+import androidx.preference.PreferenceManager;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import net.kollnig.missioncontrol.data.*;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import java.io.File;
+import java.lang.reflect.*;
+
+/** Runs the production classifier on Android with a separate database and preferences. */
+@RunWith(AndroidJUnit4.class)
+public class StackPolicyDeviceTest {
+    private static final String IP="203.0.113.211";
+    private static final int UID=54321;
+    private static class AttachedService extends ServiceSinkhole {
+        void attach(Context c) { attachBaseContext(c); }
+    }
+    private static Field accessible(Class<?> type,String name) throws Exception {
+        Field f=type.getDeclaredField(name); f.setAccessible(true); return f;
+    }
+    private static void answer(Method dns, ServiceSinkhole service,String q,String a,int ttl) throws Exception {
+        ResourceRecord rr=new ResourceRecord();
+        rr.Time=System.currentTimeMillis(); rr.QName=q; rr.AName=a; rr.Resource=IP; rr.TTL=ttl;
+        dns.invoke(service,rr);
+    }
+    @Test public void blockingModesArrivalOrderExpiryAndRefresh() throws Exception {
+        Context base=InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Context isolated=new ContextWrapper(base) {
+            @Override public Context getApplicationContext() { return this; }
+            @Override public SharedPreferences getSharedPreferences(String n,int m) {
+                return super.getSharedPreferences("stack_policy_test_"+n,m);
+            }
+            @Override public File getDatabasePath(String n) { return super.getDatabasePath("stack_policy_test_"+n); }
+            @Override public SQLiteDatabase openOrCreateDatabase(String n,int m,SQLiteDatabase.CursorFactory f) {
+                return super.openOrCreateDatabase("stack_policy_test_"+n,m,f);
+            }
+            @Override public SQLiteDatabase openOrCreateDatabase(String n,int m,SQLiteDatabase.CursorFactory f,DatabaseErrorHandler h) {
+                return super.openOrCreateDatabase("stack_policy_test_"+n,m,f,h);
+            }
+        };
+        Field dbField=accessible(DatabaseHelper.class,"dh");
+        Field blockField=accessible(TrackerBlocklist.class,"instance");
+        Object oldDb=dbField.get(null),oldBlock=blockField.get(null);
+        dbField.set(null,null); blockField.set(null,null);
+        SharedPreferences prefs=PreferenceManager.getDefaultSharedPreferences(isolated);
+        DatabaseHelper db=null;
+        try {
+            prefs.edit().clear().putString("ttl","0").commit();
+            db=DatabaseHelper.getInstance(isolated);
+            assertTrue(db.getDatabaseName()!=null);
+            assertTrue("test database must be isolated",db.getWritableDatabase().getPath().contains("stack_policy_test_"));
+            assertTrue(TrackerList.getInstance(isolated).loadTrackers(isolated));
+            assertNotNull(TrackerList.findMinimalTracker("doubleclick.net"));
+            Method block=ServiceSinkhole.class.getDeclaredMethod("blockKnownTracker",String.class,int.class);
+            block.setAccessible(true);
+            Method dns=ServiceSinkhole.class.getDeclaredMethod("dnsResolved",ResourceRecord.class);
+            dns.setAccessible(true);
+            for(String mode:new String[]{"minimal","standard","strict"}) {
+                prefs.edit().putString("blocking_mode",mode).commit();
+                assertTrue(TrackerList.getInstance(isolated).loadTrackers(isolated));
+                assertEquals(mode,TrackerList.getBlockingMode(isolated));
+                TrackerBlocklist.getInstance(isolated).ensureDefaults(UID,mode.equals("strict"));
+                for(String benignQuestion:new String[]{"terminal.test", "edge.test"}) {
+                for(boolean benignFirst:new boolean[]{false,true}) {
+                    db.clearDns(); ServiceSinkhole.clearTrackerCaches();
+                    AttachedService service=new AttachedService(); service.attach(isolated);
+                    if(benignFirst) answer(dns,service,benignQuestion,"terminal.test",1);
+                    answer(dns,service,"front.test","doubleclick.net",300);
+                    answer(dns,service,"front.test","edge.test",300);
+                    answer(dns,service,"front.test","terminal.test",300);
+                    if(!benignFirst) {
+                        assertTrue(mode+" connected chain blocks",(Boolean)block.invoke(service,IP,UID));
+                        answer(dns,service,benignQuestion,"terminal.test",1);
+                    }
+                    assertEquals(mode+" shared IP, benignFirst="+benignFirst,
+                            mode.equals("strict"),(Boolean)block.invoke(service,IP,UID));
+                    Thread.sleep(1200);
+                    assertTrue(mode+" expired benign evidence blocks",(Boolean)block.invoke(service,IP,UID));
+                    answer(dns,service,benignQuestion,"terminal.test",300);
+                    assertEquals(mode+" revived benign evidence updates cached verdict",
+                            mode.equals("strict"),(Boolean)block.invoke(service,IP,UID));
+                }
+                }
+            }
+        } finally {
+            if(db!=null) { db.clearDns(); db.getWritableDatabase().close(); }
+            ServiceSinkhole.clearTrackerCaches();
+            dbField.set(null,oldDb); blockField.set(null,oldBlock);
+            TrackerList.getInstance(base).loadTrackers(base);
+            prefs.edit().clear().commit();
+        }
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
+++ b/app/src/main/java/eu/faircode/netguard/DatabaseHelper.java
@@ -1281,7 +1281,7 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     }
 
     /**
-     * DNS evidence for an IP, freshest qname first, one row per qname.
+     * DNS evidence for an IP, freshest observation first, one row per question/target pair.
      *
      * <p>Expired rows are always excluded. Both callers — the runtime
      * blocking decision in {@code blockKnownTracker()} and the UI
@@ -1300,26 +1300,15 @@ public class DatabaseHelper extends SQLiteOpenHelper {
             SQLiteDatabase db = readableDb;
             String escapedIp = ip.replace("'", "''");
             String aliveFilter = " AND (d.time IS NULL OR d.time + d.ttl >= " + now + ")";
-            // There is a segmented index on resource. A shared IP can carry
-            // DNS evidence for several qnames; keep only the most recently
-            // observed row per qname (dedup) and order qnames by recency, so
-            // the freshest resolution — most likely tied to the connection
-            // that's actually being made now — is attributed first instead
-            // of an alphabetically-first but possibly stale one.
-            //
-            // The dedup deliberately uses a single MAX(time) aggregate: with
-            // exactly one min/max aggregate, SQLite takes the bare columns
-            // from the row that supplied the maximum, so this is one index
-            // range scan over the IP's rows. A correlated per-row subquery
-            // here re-scans the IP's rows once per candidate row — O(n²) —
-            // and this query runs for every new connection (log() and
-            // blockKnownTracker()), where it grows with DNS history until
-            // it shows up as battery drain and heat.
+            // Preserve every fresh CNAME target under its original question.
+            // Grouping by question alone discarded intermediate tracker names.
+            // One MAX aggregate keeps this a single resource-index range scan,
+            // without a correlated subquery per candidate.
             String query = "SELECT d.qname, d.aname, d.time, d.ttl, MAX(d.time)" +
                     " FROM dns AS d" +
                     " WHERE d.resource = '" + escapedIp + "'" +
                     aliveFilter +
-                    " GROUP BY d.qname" +
+                    " GROUP BY d.qname, d.aname" +
                     " ORDER BY d.time DESC, d.ID DESC";
             return db.rawQuery(query, new String[] {});
         } finally {

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -1194,9 +1194,10 @@ public class ServiceSinkhole extends VpnService {
             int uncertain = DatabaseHelper.ACCESS_UNCERTAIN_NONE;
             boolean isTracker = false;
             try (Cursor lookup = dh.getQAName(packet.uid, packet.daddr)) {
-                uncertain = (lookup != null
-                        && lookup.getCount() > 1) ? DatabaseHelper.ACCESS_UNCERTAIN_SHARED_IP
-                                : DatabaseHelper.ACCESS_UNCERTAIN_NONE;
+                DnsEvidence evidence = DnsEvidence.read(lookup);
+                uncertain = evidence.questions.size() > 1
+                        ? DatabaseHelper.ACCESS_UNCERTAIN_SHARED_IP
+                        : DatabaseHelper.ACCESS_UNCERTAIN_NONE;
 
                 // Loop until we find tracker or reach last entry
                 if (lookup != null) {
@@ -1222,7 +1223,8 @@ public class ServiceSinkhole extends VpnService {
                                     && p.first != null
                                     && !Objects.equals(foundTracker.first.name, p.first.name)) {
                                 sawDifferentTrackerEvidence = true;
-                            } else if (p.first == null) {
+                            } else if (p.first == null
+                                    && !evidence.trackerQuestions.contains(dname)) {
                                 sawNonTrackerEvidence = true;
                             }
                         }
@@ -2867,17 +2869,49 @@ public class ServiceSinkhole extends VpnService {
             }
             prepareUidIPFilters(rr.QName);
 
-            if (outcome == DatabaseHelper.DnsInsertOutcome.INSERTED) {
-                if (Util.isNumericAddress(rr.Resource)) { // make sure correct format
-                    trackerCache.invalidate(rr.Resource);
-                    // Pure refreshes deliberately skip invalidation: the cached
-                    // entry simply expires on the earlier deadline it was stored
-                    // with and is re-read then, so a stale-put race with a
-                    // refresh is harmless. The atomic cache generation guard
-                    // remains for new mappings, where the verdict can change.
-                }
-            }
+            invalidateTrackerCacheAfterDnsInsert(outcome, rr.Resource,
+                    Util.isNumericAddress(rr.Resource));
         }
+    }
+
+    static final class DnsEvidence {
+        final Set<String> questions = new HashSet<>();
+        final Set<String> trackerQuestions = new HashSet<>();
+        final Set<String> minimalTrackerQuestions = new HashSet<>();
+
+        static DnsEvidence read(Cursor cursor) {
+            DnsEvidence result = new DnsEvidence();
+            if (cursor == null)
+                return result;
+            int questionColumn = cursor.getColumnIndexOrThrow("qname");
+            int targetColumn = cursor.getColumnIndexOrThrow("aname");
+            while (cursor.moveToNext()) {
+                String question = cursor.getString(questionColumn);
+                String target = cursor.getString(targetColumn);
+                if (question == null)
+                    continue;
+                result.questions.add(question);
+                // All targets from a resolution retain its original question.
+                // A benign target within it is not an independent shared host.
+                if (TrackerList.findTracker(question) != null
+                        || (target != null && TrackerList.findTracker(target) != null))
+                    result.trackerQuestions.add(question);
+                if (TrackerList.findMinimalTracker(question) != null
+                        || (target != null && TrackerList.findMinimalTracker(target) != null))
+                    result.minimalTrackerQuestions.add(question);
+            }
+            cursor.moveToPosition(-1);
+            return result;
+        }
+    }
+
+    static void invalidateTrackerCacheAfterDnsInsert(
+            DatabaseHelper.DnsInsertOutcome outcome, String resource,
+            boolean numericResource) {
+        if ((outcome == DatabaseHelper.DnsInsertOutcome.INSERTED
+                || outcome == DatabaseHelper.DnsInsertOutcome.REFRESHED)
+                && numericResource)
+            trackerCache.invalidate(resource);
     }
 
     // Called from WireGuard bridge for passive DNS response mapping.
@@ -3144,6 +3178,7 @@ public class ServiceSinkhole extends VpnService {
                 // Loop through all fresh DNS candidates for this IP and only fail closed
                 // when ambiguous tracker blocking is enabled or the evidence is tracker-only.
                 if (lookup != null) {
+                    DnsEvidence evidence = DnsEvidence.read(lookup);
                     while (lookup.moveToNext()) {
                         // Get DNS expiry details for this candidate row
                         int colTime = lookup.getColumnIndex("time");
@@ -3192,7 +3227,8 @@ public class ServiceSinkhole extends VpnService {
                                 minimalChosenTime = rowTime;
                                 minimalChosenTtl = rowTtl;
                             }
-                        } else if (qname != null || aname != null) {
+                        } else if (!evidence.minimalTrackerQuestions.contains(qname)
+                                && (qname != null || aname != null)) {
                             latestNonMinimalExpiry = Math.max(latestNonMinimalExpiry,
                                     TrackerEvidenceExpiry.at(rowTime, rowTtl));
                             sawNonMinimalTrackerEvidence = true;
@@ -3209,7 +3245,8 @@ public class ServiceSinkhole extends VpnService {
                                 chosenTime = rowTime;
                                 chosenTtl = rowTtl;
                             }
-                        } else if (qname != null || aname != null) {
+                        } else if (!evidence.trackerQuestions.contains(qname)
+                                && (qname != null || aname != null)) {
                             latestNonTrackerExpiry = Math.max(latestNonTrackerExpiry,
                                     TrackerEvidenceExpiry.at(rowTime, rowTtl));
                             sawNonTrackerEvidence = true;

--- a/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
+++ b/app/src/test/java/eu/faircode/netguard/DatabaseHelperDnsAttributionTest.java
@@ -14,8 +14,7 @@ import org.robolectric.RuntimeEnvironment;
  * Covers getQAName's ordering: when a shared IP carries DNS evidence for
  * several qnames (see issue #655), the most recently observed qname should
  * be attributed first rather than the alphabetically-first one, and a qname
- * with several observed rows (e.g. distinct CNAME targets) should collapse
- * to its single freshest row.
+ * with several CNAME targets must retain each fresh target.
  */
 @RunWith(RobolectricTestRunner.class)
 public class DatabaseHelperDnsAttributionTest {
@@ -78,7 +77,7 @@ public class DatabaseHelperDnsAttributionTest {
     }
 
     @Test
-    public void repeatedObservationsOfSameQnameCollapseToFreshestRow() {
+    public void distinctTargetsOfSameQuestionRemainVisible() {
         DatabaseHelper dh = DatabaseHelper.getInstance(RuntimeEnvironment.getApplication());
         dh.clearDns();
 
@@ -88,7 +87,7 @@ public class DatabaseHelperDnsAttributionTest {
         dh.insertDns(rr(NOW - 1_000L, "tracker.example.com", "new-cname.example.com", ip, 3600));
 
         try (Cursor c = dh.getQAName(-1, ip)) {
-            assertEquals("duplicate rows for the same qname must collapse to one", 1, c.getCount());
+            assertEquals("distinct targets must remain visible", 2, c.getCount());
             assertTrue(c.moveToFirst());
             assertEquals("tracker.example.com", c.getString(c.getColumnIndexOrThrow("qname")));
             assertEquals("the freshest row's aname should win",

--- a/app/src/test/java/eu/faircode/netguard/ServiceSinkholeCnameEvidenceTest.java
+++ b/app/src/test/java/eu/faircode/netguard/ServiceSinkholeCnameEvidenceTest.java
@@ -1,0 +1,89 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+
+import androidx.preference.PreferenceManager;
+
+import net.kollnig.missioncontrol.data.BlockingMode;
+import net.kollnig.missioncontrol.data.TrackerBlocklist;
+import net.kollnig.missioncontrol.data.TrackerList;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+
+import java.lang.reflect.Method;
+
+@RunWith(RobolectricTestRunner.class)
+public class ServiceSinkholeCnameEvidenceTest {
+    private static final String IP = "203.0.113.211";
+    private static final int UID = 54321;
+
+    private static class TestService extends ServiceSinkhole {
+        void attach(Context context) {
+            attachBaseContext(context);
+        }
+    }
+
+    @Test
+    public void chainContinuationDoesNotCreateFalseSharedIpEvidence() throws Exception {
+        Context context = RuntimeEnvironment.getApplication();
+        PreferenceManager.getDefaultSharedPreferences(context).edit()
+                .putString(BlockingMode.PREF_BLOCKING_MODE, BlockingMode.MODE_STANDARD)
+                .commit();
+        assertTrue(TrackerList.getInstance(context).loadTrackers(context));
+        assertNotNull(TrackerList.findTracker("doubleclick.net"));
+        assertNull(TrackerList.findTracker("front.audit-example.test"));
+        TrackerBlocklist.getInstance(context).ensureDefaults(UID, false);
+
+        DatabaseHelper database = DatabaseHelper.getInstance(context);
+        database.clearDns();
+        insert(database, "front.audit-example.test", "doubleclick.net");
+        insert(database, "front.audit-example.test", "edge.audit-example.test");
+        insert(database, "front.audit-example.test", "address.audit-example.test");
+
+        TestService service = new TestService();
+        service.attach(context);
+        Method block = ServiceSinkhole.class.getDeclaredMethod(
+                "blockKnownTracker", String.class, int.class);
+        block.setAccessible(true);
+        ServiceSinkhole.clearTrackerCaches();
+        assertTrue("one connected CNAME chain keeps its tracker evidence",
+                (Boolean) block.invoke(service, IP, UID));
+
+        try (android.database.Cursor cursor = database.getQAName(UID, IP)) {
+            assertTrue("all chain targets survive lookup", cursor.getCount() == 3);
+            ServiceSinkhole.DnsEvidence evidence = ServiceSinkhole.DnsEvidence.read(cursor);
+            assertTrue("one question is not a shared host", evidence.questions.size() == 1);
+        }
+        insert(database, "edge.audit-example.test", "address.audit-example.test");
+        ServiceSinkhole.clearTrackerCaches();
+        assertFalse("an independently queried alias is benign evidence",
+                (Boolean) block.invoke(service, IP, UID));
+
+        // The terminal name can also be resolved independently. Its direct
+        // answer is benign shared-IP evidence, despite the same qname having
+        // appeared as a target in the chain above.
+        insert(database, "address.audit-example.test",
+                "address.audit-example.test");
+        ServiceSinkhole.clearTrackerCaches();
+        assertFalse("an independent benign owner still marks the IP as shared",
+                (Boolean) block.invoke(service, IP, UID));
+    }
+
+    private static void insert(DatabaseHelper database, String qname, String aname) {
+        ResourceRecord record = new ResourceRecord();
+        record.Time = System.currentTimeMillis();
+        record.QName = qname;
+        record.AName = aname;
+        record.Resource = IP;
+        record.TTL = 300;
+        assertTrue(database.insertDns(record) != DatabaseHelper.DnsInsertOutcome.FAILED);
+    }
+}

--- a/app/src/test/java/eu/faircode/netguard/ServiceSinkholeDnsCacheInvalidationTest.java
+++ b/app/src/test/java/eu/faircode/netguard/ServiceSinkholeDnsCacheInvalidationTest.java
@@ -1,0 +1,41 @@
+package eu.faircode.netguard;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import net.kollnig.missioncontrol.data.Tracker;
+
+import org.junit.Test;
+
+public class ServiceSinkholeDnsCacheInvalidationTest {
+    private static final String ADDRESS = "203.0.113.200";
+
+    @Test
+    public void refreshedDnsInsertInvalidatesResourceCache() {
+        ServiceSinkhole.clearTrackerCaches();
+        long generation = ServiceSinkhole.trackerCache.generation();
+        assertTrue(ServiceSinkhole.trackerCache.putIfGeneration(ADDRESS,
+                new TrackerCache.Entry("tracker.example", new Tracker("Example", "Advertising", 0),
+                        null, Long.MAX_VALUE), generation));
+
+        ServiceSinkhole.invalidateTrackerCacheAfterDnsInsert(
+                DatabaseHelper.DnsInsertOutcome.REFRESHED, ADDRESS, true);
+
+        assertNull(ServiceSinkhole.trackerCache.get(ADDRESS, System.currentTimeMillis()));
+    }
+
+    @Test
+    public void failedDnsInsertKeepsResourceCache() {
+        ServiceSinkhole.clearTrackerCaches();
+        long generation = ServiceSinkhole.trackerCache.generation();
+        assertTrue(ServiceSinkhole.trackerCache.putIfGeneration(ADDRESS,
+                new TrackerCache.Entry("tracker.example", new Tracker("Example", "Advertising", 0),
+                        null, Long.MAX_VALUE), generation));
+
+        ServiceSinkhole.invalidateTrackerCacheAfterDnsInsert(
+                DatabaseHelper.DnsInsertOutcome.FAILED, ADDRESS, true);
+
+        assertNotNull(ServiceSinkhole.trackerCache.get(ADDRESS, System.currentTimeMillis()));
+    }
+}

--- a/wgbridge-rs/tc-dns/src/lib.rs
+++ b/wgbridge-rs/tc-dns/src/lib.rs
@@ -25,9 +25,11 @@ pub enum Outcome {
     },
 }
 
-/// Records valid A and AAAA answers from a DNS response. Malformed input is
-/// ignored. A sink must not panic; this function deliberately does not catch
-/// panics because the Android release profile uses `panic = "abort"`.
+/// Records valid A and AAAA answers from a DNS response. CNAME chains are
+/// followed from the question by owner/target name; each validated target is
+/// emitted with the original question and the minimum TTL of the complete path. Malformed input is ignored. A
+/// sink must not panic; this function deliberately does not catch panics
+/// because the Android release profile uses `panic = "abort"`.
 pub fn record_answers(msg: &[u8], policy: &dyn DnsPolicy) {
     let _ = message::parse_answers_incrementally(msg, |answer| {
         policy.record_answer(&answer.qname, &answer.aname, &answer.resource, answer.ttl);

--- a/wgbridge-rs/tc-dns/src/message.rs
+++ b/wgbridge-rs/tc-dns/src/message.rs
@@ -1,7 +1,9 @@
+use std::collections::{HashMap, HashSet};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 pub(crate) const DNS_TYPE_A: u16 = 1;
 pub(crate) const DNS_TYPE_AAAA: u16 = 28;
+pub(crate) const DNS_TYPE_CNAME: u16 = 5;
 pub(crate) const DNS_CLASS_IN: u16 = 1;
 pub(crate) const DNS_TYPE_SVCB: u16 = 64;
 pub(crate) const DNS_TYPE_HTTPS: u16 = 65;
@@ -9,6 +11,8 @@ pub(crate) const DNS_HEADER_LEN: usize = 12;
 const MAX_NAME_DEPTH: u32 = 8;
 const MAX_NAME_LABELS: usize = 128;
 const MAX_NAME_OCTETS: usize = 255;
+const MAX_CNAME_CHAIN_DEPTH: usize = 8;
+const MAX_CNAME_TRAVERSAL_WORK: usize = 4096;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct DnsAnswer {
@@ -16,6 +20,26 @@ pub(crate) struct DnsAnswer {
     pub(crate) aname: String,
     pub(crate) resource: String,
     pub(crate) ttl: i32,
+}
+
+#[derive(Debug, Clone)]
+enum ParsedAnswer {
+    Cname(CnameRecord),
+    Address(AddressRecord),
+}
+
+#[derive(Debug, Clone)]
+struct CnameRecord {
+    owner: String,
+    target: String,
+    ttl: i32,
+}
+
+#[derive(Debug, Clone)]
+struct AddressRecord {
+    owner: String,
+    resource: String,
+    ttl: i32,
 }
 
 #[derive(Debug)]
@@ -74,7 +98,7 @@ pub(crate) fn read_question_layout(msg: &[u8]) -> Option<QuestionLayout> {
             return None;
         }
         if question == 0 {
-            qname = Some(name);
+            qname = Some(canonicalize_name(&name));
             qtype = read_u16(msg, name_end)?;
         }
         offset = question_end;
@@ -93,7 +117,7 @@ pub(crate) fn parse_message(msg: &[u8]) -> Option<DnsMessage> {
     let mut offset = layout.answer_offset;
     let mut contains_svcb = false;
     for _ in 0..layout.ancount {
-        let (answer, answer_end, is_svcb) = parse_answer(msg, offset, &layout.qname)?;
+        let (answer, answer_end, is_svcb) = parse_answer(msg, offset)?;
         contains_svcb |= is_svcb;
         let _ = answer;
         offset = answer_end;
@@ -130,13 +154,22 @@ pub(crate) fn parse_answers_incrementally(
     }
     let mut offset = layout.answer_offset;
     let mut contains_svcb = false;
+    let mut records = Vec::new();
+    let mut complete = true;
     for _ in 0..layout.ancount {
-        let (answer, answer_end, is_svcb) = parse_answer(msg, offset, &layout.qname)?;
+        let Some((answer, answer_end, is_svcb)) = parse_answer(msg, offset) else {
+            complete = false;
+            break;
+        };
         contains_svcb |= is_svcb;
         if let Some(answer) = answer {
-            on_answer(&answer);
+            records.push(answer);
         }
         offset = answer_end;
+    }
+    emit_answers(&layout.qname, &records, &mut on_answer);
+    if !complete {
+        return None;
     }
     Some(DnsMessage {
         qname: layout.qname,
@@ -146,12 +179,9 @@ pub(crate) fn parse_answers_incrementally(
     })
 }
 
-fn parse_answer(
-    msg: &[u8],
-    offset: usize,
-    qname: &str,
-) -> Option<(Option<DnsAnswer>, usize, bool)> {
+fn parse_answer(msg: &[u8], offset: usize) -> Option<(Option<ParsedAnswer>, usize, bool)> {
     let (aname, name_end) = read_dns_name(msg, offset, 0)?;
+    let aname = canonicalize_name(&aname);
     let fixed_end = name_end.checked_add(10)?;
     if fixed_end > msg.len() {
         return None;
@@ -170,9 +200,8 @@ fn parse_answer(
         None
     } else {
         match typ {
-            DNS_TYPE_A if rdlen == 4 => Some(DnsAnswer {
-                qname: qname.to_owned(),
-                aname,
+            DNS_TYPE_A if rdlen == 4 => Some(ParsedAnswer::Address(AddressRecord {
+                owner: aname,
                 resource: Ipv4Addr::new(
                     *rdata.first()?,
                     *rdata.get(1)?,
@@ -181,21 +210,216 @@ fn parse_answer(
                 )
                 .to_string(),
                 ttl: clamp_ttl(ttl),
-            }),
+            })),
             DNS_TYPE_AAAA if rdlen == 16 => {
                 let mut ip = [0u8; 16];
                 ip.copy_from_slice(rdata);
-                Some(DnsAnswer {
-                    qname: qname.to_owned(),
-                    aname,
+                Some(ParsedAnswer::Address(AddressRecord {
+                    owner: aname,
                     resource: Ipv6Addr::from(ip).to_string(),
                     ttl: clamp_ttl(ttl),
-                })
+                }))
+            }
+            DNS_TYPE_CNAME => {
+                let Some((target, target_end)) = read_dns_name(msg, fixed_end, 0) else {
+                    return Some((None, rdata_end, is_svcb));
+                };
+                if target_end != rdata_end {
+                    return Some((None, rdata_end, is_svcb));
+                }
+                Some(ParsedAnswer::Cname(CnameRecord {
+                    owner: aname,
+                    target: canonicalize_name(&target),
+                    ttl: clamp_ttl(ttl),
+                }))
             }
             _ => None,
         }
     };
     Some((answer, rdata_end, is_svcb))
+}
+
+fn emit_answers(qname: &str, records: &[ParsedAnswer], mut on_answer: impl FnMut(&DnsAnswer)) {
+    let mut cname_links: HashMap<String, Vec<CnameRecord>> = HashMap::new();
+    let mut addresses_by_owner: HashMap<String, Vec<AddressRecord>> = HashMap::new();
+    let mut addresses = Vec::new();
+    for record in records {
+        match record {
+            ParsedAnswer::Cname(link) => {
+                cname_links
+                    .entry(link.owner.clone())
+                    .or_default()
+                    .push(link.clone());
+            }
+            ParsedAnswer::Address(address) => {
+                addresses.push(address.clone());
+                addresses_by_owner
+                    .entry(address.owner.clone())
+                    .or_default()
+                    .push(address.clone());
+            }
+        }
+    }
+
+    let mut answers = Vec::new();
+    let mut indexes = HashMap::new();
+    if cname_links.is_empty() {
+        // Keep the historic behaviour for an ordinary response: every valid
+        // address answer is attributed to the question, even if its owner is
+        // an unusual (but syntactically valid) name.
+        for address in addresses {
+            push_answer(
+                &mut answers,
+                &mut indexes,
+                qname,
+                &address.owner,
+                &address.resource,
+                address.ttl,
+            );
+        }
+    } else {
+        // Once CNAMEs are present, only a path rooted at the question can
+        // attribute an address. This keeps unrelated answer-section records
+        // from being attached to the original question.
+        let mut path = Vec::new();
+        let mut visited = HashSet::new();
+        let mut budget = MAX_CNAME_TRAVERSAL_WORK;
+        collect_chain(
+            qname,
+            qname,
+            0,
+            &mut path,
+            &mut visited,
+            &cname_links,
+            &addresses_by_owner,
+            &mut answers,
+            &mut indexes,
+            &mut budget,
+        );
+    }
+
+    for answer in answers {
+        on_answer(&answer);
+    }
+}
+
+fn collect_chain(
+    question: &str,
+    name: &str,
+    depth: usize,
+    path: &mut Vec<CnameRecord>,
+    visited: &mut HashSet<String>,
+    cname_links: &HashMap<String, Vec<CnameRecord>>,
+    addresses_by_owner: &HashMap<String, Vec<AddressRecord>>,
+    answers: &mut Vec<DnsAnswer>,
+    indexes: &mut HashMap<(String, String, String), usize>,
+    budget: &mut usize,
+) {
+    // A bounded depth alone does not bound work when the answer section
+    // contains repeated or branching CNAME links. Charge every visited owner
+    // and every edge/address examined so a hostile graph cannot multiply the
+    // recursive walk exponentially.
+    if *budget == 0 {
+        return;
+    }
+    *budget -= 1;
+
+    if !visited.insert(name.to_owned()) {
+        return;
+    }
+
+    // An address is terminal only when this owner has no further CNAME hop.
+    // Treating an address and an outgoing CNAME at the same owner as a
+    // terminal would make malformed loops look like validated chains.
+    if !cname_links.contains_key(name) {
+        if let Some(addresses) = addresses_by_owner.get(name) {
+            for address in addresses {
+                if *budget == 0 {
+                    break;
+                }
+                *budget -= 1;
+                if path.is_empty() {
+                    // No CNAME path means this is the historic direct
+                    // qname/aname attribution, even when another answer
+                    // carries an unrelated CNAME.
+                    push_answer(answers, indexes, name, name, &address.resource, address.ttl);
+                } else {
+                    // Preserve the original question as provenance for every
+                    // target. All mappings depend on the complete path to the
+                    // address, so none may outlive its shortest-lived link.
+                    let ttl = path.iter().fold(address.ttl, |ttl, link| ttl.min(link.ttl));
+                    for link in path.iter() {
+                        push_answer(
+                            answers,
+                            indexes,
+                            question,
+                            &link.target,
+                            &address.resource,
+                            ttl,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    if depth < MAX_CNAME_CHAIN_DEPTH {
+        if let Some(links) = cname_links.get(name) {
+            for link in links {
+                if *budget == 0 {
+                    break;
+                }
+                *budget -= 1;
+                path.push(link.clone());
+                collect_chain(
+                    question,
+                    &link.target,
+                    depth + 1,
+                    path,
+                    visited,
+                    cname_links,
+                    addresses_by_owner,
+                    answers,
+                    indexes,
+                    budget,
+                );
+                let _ = path.pop();
+            }
+        }
+    }
+    visited.remove(name);
+}
+
+fn push_answer(
+    answers: &mut Vec<DnsAnswer>,
+    indexes: &mut HashMap<(String, String, String), usize>,
+    qname: &str,
+    aname: &str,
+    resource: &str,
+    ttl: i32,
+) {
+    if qname.is_empty() || aname.is_empty() {
+        return;
+    }
+    let key = (qname.to_owned(), aname.to_owned(), resource.to_owned());
+    if let Some(index) = indexes.get(&key).copied() {
+        if let Some(answer) = answers.get_mut(index) {
+            answer.ttl = answer.ttl.min(ttl);
+        }
+        return;
+    }
+    let index = answers.len();
+    answers.push(DnsAnswer {
+        qname: key.0.clone(),
+        aname: key.1.clone(),
+        resource: key.2.clone(),
+        ttl,
+    });
+    indexes.insert(key, index);
+}
+
+fn canonicalize_name(name: &str) -> String {
+    name.to_ascii_lowercase()
 }
 
 fn clamp_ttl(ttl: u32) -> i32 {

--- a/wgbridge-rs/tc-dns/tests/message.rs
+++ b/wgbridge-rs/tc-dns/tests/message.rs
@@ -90,6 +90,22 @@ fn a_answer(encoded_name: &[u8]) -> Vec<u8> {
     answer(encoded_name, TYPE_A, 300, &[203, 0, 113, 7])
 }
 
+fn cname_answer(owner: &str, target: &str, ttl: u32) -> Vec<u8> {
+    let owner = name(owner);
+    let target = name(target);
+    answer(&owner, TYPE_CNAME, ttl, &target)
+}
+
+fn named_a_answer(owner: &str, ttl: u32, address: [u8; 4]) -> Vec<u8> {
+    let owner = name(owner);
+    answer(&owner, TYPE_A, ttl, &address)
+}
+
+fn named_aaaa_answer(owner: &str, ttl: u32, address: [u8; 16]) -> Vec<u8> {
+    let owner = name(owner);
+    answer(&owner, TYPE_AAAA, ttl, &address)
+}
+
 /// Encodes a compression pointer to `offset` in the message.
 fn ptr(offset: usize) -> [u8; 2] {
     [0xc0 | ((offset >> 8) as u8), (offset & 0xff) as u8]
@@ -566,11 +582,11 @@ fn over_long_uncompressed_answer_owner_name_is_still_rejected() {
 /// A CDN-fronted tracker's typical response shape: qname CNAME intermediate,
 /// intermediate CNAME target, target A <ip>. Each owner name after the
 /// question is a compression pointer into the previous record's RDATA, the
-/// way real resolvers encode chains. Only the terminal A is recorded, and it
-/// carries the *original question* qname (not the intermediate CNAME names)
-/// alongside its own owner name as `aname`.
+/// way real resolvers encode chains. Every validated target is
+/// recorded against the terminal address under the original question qname,
+/// without inventing independent queries for intermediate aliases.
 #[test]
-fn cname_chain_records_final_a_with_question_qname_and_answer_owner_aname() {
+fn cname_chain_records_each_a_alias_with_question_qname() {
     let qname_encoded = name("chain.example");
     let question_bytes = question(&qname_encoded, TYPE_A);
     let question_end = 12 + question_bytes.len();
@@ -602,14 +618,24 @@ fn cname_chain_records_final_a_with_question_qname_and_answer_owner_aname() {
     let policy = TestPolicy::default();
     record_answers(&message, &policy);
     let records = policy.records.borrow();
-    assert_eq!(records.len(), 1, "the two CNAMEs must not be recorded");
-    assert_eq!(records[0].0, "chain.example", "qname is the question name");
+    assert_eq!(records.len(), 2);
     assert_eq!(
-        records[0].1, "cdn.example",
-        "aname is the A record's own owner"
+        records.as_slice(),
+        [
+            (
+                "chain.example".to_owned(),
+                "mid.chain.example".to_owned(),
+                "203.0.113.7".to_owned(),
+                300,
+            ),
+            (
+                "chain.example".to_owned(),
+                "cdn.example".to_owned(),
+                "203.0.113.7".to_owned(),
+                300,
+            ),
+        ]
     );
-    assert_eq!(records[0].2, "203.0.113.7");
-    assert_eq!(records[0].3, 300);
     drop(records);
 
     let mut blanked = message;
@@ -628,7 +654,7 @@ fn cname_chain_records_final_a_with_question_qname_and_answer_owner_aname() {
 /// Same CNAME-chain shape as above, but the chain terminates in an AAAA
 /// record instead of A.
 #[test]
-fn cname_chain_ending_in_aaaa_records_final_answer_with_question_qname() {
+fn cname_chain_ending_in_aaaa_records_each_alias_with_question_qname() {
     let qname_encoded = name("chain6.example");
     let question_bytes = question(&qname_encoded, TYPE_AAAA);
     let question_end = 12 + question_bytes.len();
@@ -653,10 +679,24 @@ fn cname_chain_ending_in_aaaa_records_final_answer_with_question_qname() {
     let policy = TestPolicy::default();
     record_answers(&message, &policy);
     let records = policy.records.borrow();
-    assert_eq!(records.len(), 1, "the two CNAMEs must not be recorded");
-    assert_eq!(records[0].0, "chain6.example");
-    assert_eq!(records[0].1, "cdn6.example");
-    assert_eq!(records[0].2, "2001:db8::2");
+    assert_eq!(records.len(), 2);
+    assert_eq!(
+        records.as_slice(),
+        [
+            (
+                "chain6.example".to_owned(),
+                "mid.chain6.example".to_owned(),
+                "2001:db8::2".to_owned(),
+                300,
+            ),
+            (
+                "chain6.example".to_owned(),
+                "cdn6.example".to_owned(),
+                "2001:db8::2".to_owned(),
+                300,
+            ),
+        ]
+    );
     drop(records);
 
     let mut blanked = message;
@@ -670,6 +710,175 @@ fn cname_chain_ending_in_aaaa_records_final_answer_with_question_qname() {
         Outcome::Blanked { new_len, qtype: TYPE_AAAA, .. } if new_len == question_end
     ));
     assert_eq!(&blanked[6..12], &[0, 0, 0, 0, 0, 0]);
+}
+
+/// CNAME links are a graph, rather than an ordered list. The intermediate
+/// name retains the original question, so independent queries stay distinct
+/// while the classifier can still find a tracker at any target.
+#[test]
+fn cname_chain_is_order_independent_and_canonicalises_names() {
+    let qname = name("SAFE.EXAMPLE");
+    let question_bytes = question(&qname, TYPE_A);
+    let message = response(
+        std::slice::from_ref(&question_bytes),
+        &[
+            named_a_answer("FINAL.EXAMPLE", 70, [203, 0, 113, 8]),
+            cname_answer("INTERMEDIATE.TRACKER.EXAMPLE", "FINAL.EXAMPLE", 40),
+            cname_answer("SAFE.EXAMPLE", "INTERMEDIATE.TRACKER.EXAMPLE", 90),
+        ],
+    );
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    let records = policy.records.borrow();
+    assert_eq!(
+        records.as_slice(),
+        [
+            (
+                "safe.example".to_owned(),
+                "intermediate.tracker.example".to_owned(),
+                "203.0.113.8".to_owned(),
+                40,
+            ),
+            (
+                "safe.example".to_owned(),
+                "final.example".to_owned(),
+                "203.0.113.8".to_owned(),
+                40,
+            ),
+        ]
+    );
+    assert!(records
+        .iter()
+        .any(|record| record.1 == "intermediate.tracker.example"));
+    assert!(!records
+        .iter()
+        .any(|record| record.0 == "final.example" && record.1 == "final.example"));
+}
+
+#[test]
+fn multiple_a_and_aaaa_records_are_deduplicated_and_keep_ttl_minima() {
+    let qname = name("alias.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let ipv6 = [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9];
+    let message = response(
+        std::slice::from_ref(&question_bytes),
+        &[
+            cname_answer("alias.example", "terminal.example", 600),
+            named_a_answer("terminal.example", 300, [203, 0, 113, 9]),
+            named_a_answer("terminal.example", 100, [203, 0, 113, 9]),
+            named_a_answer("terminal.example", 500, [198, 51, 100, 9]),
+            named_aaaa_answer("terminal.example", 60, ipv6),
+        ],
+    );
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    let records = policy.records.borrow();
+    assert_eq!(records.len(), 3);
+    for resource in ["203.0.113.9", "198.51.100.9", "2001:db8::9"] {
+        let alias = records
+            .iter()
+            .find(|record| record.0 == "alias.example" && record.2 == resource)
+            .expect("alias mapping present");
+        assert_eq!(alias.1, "terminal.example");
+        let expected_ttl = match resource {
+            "203.0.113.9" => 100,
+            "198.51.100.9" => 500,
+            _ => 60,
+        };
+        assert_eq!(alias.3, expected_ttl);
+    }
+    assert!(!records
+        .iter()
+        .any(|record| record.0 == "terminal.example" && record.1 == "terminal.example"));
+}
+
+#[test]
+fn unrelated_cname_and_address_are_not_attributed_to_the_question() {
+    let qname = name("requested.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let message = response(
+        std::slice::from_ref(&question_bytes),
+        &[
+            cname_answer("unrelated.example", "unrelated.cdn.example", 300),
+            named_a_answer("unrelated.cdn.example", 300, [203, 0, 113, 10]),
+        ],
+    );
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    assert!(policy.records.borrow().is_empty());
+}
+
+#[test]
+fn cname_loop_stops_without_an_address_mapping() {
+    let qname = name("loop-a.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let message = response(
+        std::slice::from_ref(&question_bytes),
+        &[
+            cname_answer("loop-a.example", "loop-b.example", 300),
+            cname_answer("loop-b.example", "loop-a.example", 300),
+            named_a_answer("loop-b.example", 300, [203, 0, 113, 13]),
+        ],
+    );
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    assert!(policy.records.borrow().is_empty());
+}
+
+#[test]
+fn cname_chain_depth_bound_stops_before_an_unbounded_terminal() {
+    let qname = name("depth-0.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let mut answers = Vec::new();
+    for index in 0..10 {
+        answers.push(cname_answer(
+            &format!("depth-{index}.example"),
+            &format!("depth-{}.example", index + 1),
+            300,
+        ));
+    }
+    answers.push(named_a_answer("depth-10.example", 300, [203, 0, 113, 11]));
+    let message = response(std::slice::from_ref(&question_bytes), &answers);
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    assert!(policy.records.borrow().is_empty());
+}
+
+#[test]
+fn repeated_branching_cname_links_have_bounded_total_traversal() {
+    let qname = name("budget-0.example");
+    let question_bytes = question(&qname, TYPE_A);
+    let mut answers = Vec::new();
+
+    // Repeating each edge creates an exponentially large number of paths for
+    // a depth-bounded recursive walk, despite only a few hundred wire records.
+    // The first path remains valid and must still reach the terminal address.
+    for index in 0..8 {
+        for _ in 0..32 {
+            answers.push(cname_answer(
+                &format!("budget-{index}.example"),
+                &format!("budget-{}.example", index + 1),
+                300,
+            ));
+        }
+    }
+    answers.push(named_a_answer("budget-8.example", 300, [203, 0, 113, 12]));
+    let message = response(std::slice::from_ref(&question_bytes), &answers);
+
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    let records = policy.records.borrow();
+    assert_eq!(records.len(), 8);
+    assert!(records.iter().all(|record| record.2 == "203.0.113.12"));
+    assert_eq!(records[0].0, "budget-0.example");
+    assert_eq!(records[0].1, "budget-1.example");
+    assert_eq!(records[7].0, "budget-0.example");
+    assert_eq!(records[7].1, "budget-8.example");
 }
 
 /// The parser only ever walks `ancount` answers; it never inspects nscount
@@ -903,4 +1112,34 @@ fn partial_response_cannot_detect_svcb_past_the_truncation_point() {
         Outcome::Unchanged
     );
     assert_eq!(message, original);
+}
+
+#[test]
+fn all_targets_keep_root_provenance_and_shortest_path_ttl() {
+    let q = question(&name("root.example"), TYPE_A);
+    let message = response(
+        &[q],
+        &[
+            cname_answer("root.example", "tracker.example", 5),
+            cname_answer("tracker.example", "edge.example", 90),
+            cname_answer("edge.example", "terminal.example", 300),
+            named_a_answer("terminal.example", 600, [203, 0, 113, 11]),
+        ],
+    );
+    let policy = TestPolicy::default();
+    record_answers(&message, &policy);
+    let records = policy.records.borrow();
+    assert_eq!(records.len(), 3);
+    assert!(records.iter().all(|r| r.0 == "root.example" && r.3 == 5));
+    assert!(records.iter().any(|r| r.1 == "tracker.example"));
+    drop(records);
+    let separate = response(
+        &[question(&name("edge.example"), TYPE_A)],
+        &[
+            cname_answer("edge.example", "terminal.example", 300),
+            named_a_answer("terminal.example", 600, [203, 0, 113, 11]),
+        ],
+    );
+    record_answers(&separate, &policy);
+    assert_eq!(policy.records.borrow().last().unwrap().0, "edge.example");
 }

--- a/wgbridge-rs/tests/tcdns_capi.rs
+++ b/wgbridge-rs/tests/tcdns_capi.rs
@@ -7,6 +7,7 @@ use wgbridge::tcdns_capi::{
 };
 
 const TYPE_A: u16 = 1;
+const TYPE_CNAME: u16 = 5;
 const TYPE_HTTPS: u16 = 65;
 const CLASS_IN: u16 = 1;
 
@@ -96,6 +97,12 @@ fn answer(name: &[u8], qtype: u16, rdata: &[u8]) -> Vec<u8> {
     result.extend_from_slice(&(rdata.len() as u16).to_be_bytes());
     result.extend_from_slice(rdata);
     result
+}
+
+fn cname_answer(owner: &str, target: &str) -> Vec<u8> {
+    let owner = question_name(owner);
+    let target = question_name(target);
+    answer(&owner, TYPE_CNAME, &target)
 }
 
 fn response(question_name: &[u8], answers: &[Vec<u8>]) -> Vec<u8> {
@@ -233,6 +240,52 @@ fn callbacks_receive_terminated_strings_and_new_length() {
         .iter()
         .all(|(name, _, _)| !name.as_bytes().contains(&0)));
     assert_eq!(capture.blanked, vec![("��a".to_owned(), TYPE_A, 0x0f)]);
+}
+
+#[test]
+fn capi_preserves_question_for_every_cname_target() {
+    let qname = question_name("alias.example");
+    let mut message = response(
+        &qname,
+        &[
+            answer(
+                &question_name("terminal.example"),
+                TYPE_A,
+                &[203, 0, 113, 12],
+            ),
+            cname_answer("alias.example", "tracker.example"),
+            cname_answer("tracker.example", "terminal.example"),
+        ],
+    );
+    let mut capture = Capture::default();
+    let callbacks = callbacks();
+    let result = unsafe {
+        tcdns_process_response(
+            message.as_mut_ptr(),
+            message.len(),
+            &callbacks,
+            (&mut capture as *mut Capture).cast(),
+        )
+    };
+
+    assert_eq!(result, TCDNS_UNCHANGED);
+    assert_eq!(
+        capture.records,
+        vec![
+            (
+                "alias.example".to_owned(),
+                "tracker.example".to_owned(),
+                "203.0.113.12".to_owned(),
+                300
+            ),
+            (
+                "alias.example".to_owned(),
+                "terminal.example".to_owned(),
+                "203.0.113.12".to_owned(),
+                300
+            ),
+        ]
+    );
 }
 
 #[test]


### PR DESCRIPTION
DNS refreshes can leave a cached blocking verdict stale, while intermediate CNAME tracker names can disappear from attribution or look like independent benign hosts. This fixes those cases on current master without pulling in the broader TCP, DoH or WireGuard recovery changes.

Every validated CNAME target retains the original question and the shortest TTL across its complete path to the address. The database preserves each question/target pair; blocking and traffic-log uncertainty group those targets by question. Independently queried aliases remain separate shared-IP evidence. Successful refreshes invalidate the cached verdict. Existing TTL preferences and database schema are unchanged.

Validation:

- 462 GitHub JVM tests and 87 Rust workspace tests passed, including bounded graph traversal, malformed inputs, independent aliases and expiry/refresh regressions.
- GitHub debug APK and instrumentation APK built; both native libraries verified in all four ABIs; Android lint passed.
- Backed up the Pixel 8 settings, profiles and installed APK, then updated in place. Android instrumentation passed all 12 policy combinations across Minimal/Standard/Strict, arrival order, direct/CNAME benign evidence, expiry and refresh, using isolated test storage.
- Five native C ABI tests passed on the Pixel, including multi-hop question provenance.
- Live DNS through the active WireGuard VPN passed 20 UDP queries, 20 fragmented TCP queries on one connection and two pipelined TCP queries. Original settings/profile files were preserved.

Device tests exercise the parser and production classifier separately; the live smoke test establishes transport continuity, not a controlled end-to-end tracker CNAME fixture. Older Android versions and long-duration battery/rollout coverage remain outside this validation. CI is not awaited.
