### PR TITLE
Consolidate bounded DNS and native socket fixes

### DIFF
--- a/app/src/androidTest/java/net/kollnig/missioncontrol/dns/StackDeviceTest.java
+++ b/app/src/androidTest/java/net/kollnig/missioncontrol/dns/StackDeviceTest.java
@@ -1,0 +1,112 @@
+package net.kollnig.missioncontrol.dns;
+
+import static org.junit.Assert.*;
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.SharedPreferences;
+import androidx.preference.PreferenceManager;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.*;
+import java.io.*;
+import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/** Live loopback sockets; isolated preferences keep the device configuration intact. */
+@RunWith(AndroidJUnit4.class)
+public class StackDeviceTest {
+    private static Object field(Object object, String name) throws Exception {
+        Field f = object.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(object);
+    }
+
+    private static void awaitPool(ThreadPoolExecutor pool, int active, int queued) throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3);
+        while (System.nanoTime() < deadline) {
+            if (pool.getActiveCount() == active && pool.getQueue().size() == queued) return;
+            Thread.sleep(10);
+        }
+        assertEquals("active workers", active, pool.getActiveCount());
+        assertEquals("queued requests", queued, pool.getQueue().size());
+    }
+
+    private static Socket tcp() throws IOException {
+        Socket s = new Socket();
+        s.connect(new InetSocketAddress("127.0.0.1", 5353), 1000);
+        s.setSoTimeout(1000);
+        return s;
+    }
+
+    private static void servfail() throws Exception {
+        byte[] query = {0x12,0x34,1,0,0,0,0,0,0,0,0,0};
+        try (DatagramSocket socket = new DatagramSocket()) {
+            socket.setSoTimeout(2000);
+            socket.send(new DatagramPacket(query, query.length, InetAddress.getByName("127.0.0.1"), 5353));
+            DatagramPacket reply = new DatagramPacket(new byte[512],512);
+            socket.receive(reply);
+            assertEquals(12, reply.getLength());
+            assertEquals(0x12, reply.getData()[0]);
+            assertEquals(0x34, reply.getData()[1]);
+            assertEquals(2, reply.getData()[3] & 15);
+            assertTrue((reply.getData()[2] & 128) != 0);
+        }
+    }
+
+    @Test public void liveOverloadRejectsAndRestartRecovers() throws Exception {
+        Context base = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        Context isolated = new ContextWrapper(base) {
+            @Override public Context getApplicationContext() { return this; }
+            @Override public SharedPreferences getSharedPreferences(String name, int mode) {
+                return super.getSharedPreferences("stack_device_test_" + name, mode);
+            }
+        };
+        SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(isolated);
+        prefs.edit().clear().putBoolean("doh_enabled",true)
+                .putBoolean("doh_dns_fallback",false).commit();
+        Constructor<DnsProxyServer> constructor = DnsProxyServer.class.getDeclaredConstructor(Context.class);
+        constructor.setAccessible(true);
+        DnsProxyServer proxy = constructor.newInstance(isolated);
+        List<Socket> clients = new ArrayList<>();
+        try {
+            proxy.start();
+            ThreadPoolExecutor pool = (ThreadPoolExecutor)field(proxy,"executor");
+            assertNotNull(pool);
+            for (int i=0;i<16;i++) clients.add(tcp());
+            awaitPool(pool,16,0);
+            for (int i=0;i<64;i++) clients.add(tcp());
+            awaitPool(pool,16,64);
+            try (Socket rejected = tcp()) {
+                assertEquals("81st TCP request is closed",-1,rejected.getInputStream().read());
+            }
+            servfail();
+            assertEquals(16,pool.getPoolSize());
+            assertEquals(64,pool.getQueue().size());
+            proxy.stop();
+            for (int i=16;i<80;i++)
+                assertEquals("queued socket closed at stop",-1,clients.get(i).getInputStream().read());
+            assertTrue("old workers finish after client timeout",pool.awaitTermination(12,TimeUnit.SECONDS));
+            for (int i=0;i<16;i++)
+                assertEquals("active socket closed after worker timeout",-1,clients.get(i).getInputStream().read());
+            for (Socket client : clients) client.close();
+            for(int i=0;i<5;i++) {
+                proxy.start();
+                Field circuit = DnsProxyServer.class.getDeclaredField("circuitOpenUntil");
+                circuit.setAccessible(true);
+                circuit.setLong(proxy,System.currentTimeMillis()+60000);
+                servfail();
+                proxy.stop();
+            }
+        } finally {
+            for(Socket client:clients) client.close();
+            proxy.stop();
+            prefs.edit().clear().commit();
+        }
+    }
+}

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -108,7 +108,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URL;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
@@ -221,7 +220,6 @@ public class ServiceSinkhole extends VpnService {
     // Whether any app is routed around the tunnel, which is what makes the
     // extra per-query DNS cost worth paying.
     private boolean anyDirectRouting = false;
-    private final Map<IPKey, Map<InetAddress, IPRule>> mapUidIPFilters = new HashMap<>();
     private Map<Integer, Forward> mapForward = new HashMap<>();
     public static ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
 
@@ -2175,7 +2173,6 @@ public class ServiceSinkhole extends VpnService {
         // Prepare rules
         prepareUidAllowed(listAllowed, listRule);
         prepareHostsBlocked(ServiceSinkhole.this);
-        prepareUidIPFilters(null);
         prepareForwarding();
 
         int prio = Integer.parseInt(prefs.getString("loglevel", Integer.toString(Log.WARN)));
@@ -2345,7 +2342,6 @@ public class ServiceSinkhole extends VpnService {
         mapUidAllowed.clear();
         mapUidKnown.clear();
         mapHostsBlocked.clear();
-        mapUidIPFilters.clear();
         mapForward.clear();
         lock.writeLock().unlock();
     }
@@ -2552,78 +2548,6 @@ public class ServiceSinkhole extends VpnService {
         // Reload TrackerList to ensure it stays in sync with updated hosts
         TrackerList.reloadTrackerData(c);
         clearTrackerCaches();
-    }
-
-    private void prepareUidIPFilters(String dname) {
-        lock.writeLock().lock();
-        try {
-
-        if (dname == null) // reset mechanism, called from startNative()
-            mapUidIPFilters.clear();
-
-        try (Cursor cursor = DatabaseHelper.getInstance(ServiceSinkhole.this).getAccessDns(dname)) {
-            int colUid = cursor.getColumnIndex("uid");
-            int colVersion = cursor.getColumnIndex("version");
-            int colProtocol = cursor.getColumnIndex("protocol");
-            int colDAddr = cursor.getColumnIndex("daddr");
-            int colResource = cursor.getColumnIndex("resource");
-            int colDPort = cursor.getColumnIndex("dport");
-            int colBlock = cursor.getColumnIndex("block");
-            int colTime = cursor.getColumnIndex("time");
-            int colTTL = cursor.getColumnIndex("ttl");
-            while (cursor.moveToNext()) {
-                int uid = cursor.getInt(colUid);
-                int version = cursor.getInt(colVersion);
-                int protocol = cursor.getInt(colProtocol);
-                String daddr = cursor.getString(colDAddr);
-                String dresource = (cursor.isNull(colResource) ? null : cursor.getString(colResource));
-                int dport = cursor.getInt(colDPort);
-                boolean block = (cursor.getInt(colBlock) > 0);
-                long time = (cursor.isNull(colTime) ? new Date().getTime() : cursor.getLong(colTime));
-                long ttl = (cursor.isNull(colTTL) ? 7 * 24 * 3600 * 1000L : cursor.getLong(colTTL));
-
-                IPKey key = new IPKey(version, protocol, dport, uid);
-                synchronized (mapUidIPFilters) {
-                    if (!mapUidIPFilters.containsKey(key))
-                        mapUidIPFilters.put(key, new HashMap());
-
-                    try {
-                        String name = (dresource == null ? daddr : dresource);
-
-                        // Firewall operates on IP layer, so we need numeric IP
-                        if (Util.isNumericAddress(name)) {
-                            InetAddress iname = InetAddress.getByName(name);
-                            if (version == 4 && !(iname instanceof Inet4Address))
-                                continue;
-                            if (version == 6 && !(iname instanceof Inet6Address))
-                                continue;
-
-                            boolean exists = mapUidIPFilters.get(key).containsKey(iname);
-                            if (!exists || !mapUidIPFilters.get(key).get(iname).isBlocked()) {
-                                IPRule rule = new IPRule(key, name + "/" + iname, block, time, ttl);
-                                mapUidIPFilters.get(key).put(iname, rule);
-                                if (exists)
-                                    Log.w(TAG, "Address conflict " + key + " " + daddr + "/" + dresource);
-                            } else if (exists) {
-                                mapUidIPFilters.get(key).get(iname).updateExpires(time, ttl);
-                                if (dname != null && ttl > 60 * 1000L)
-                                    Log.w(TAG, "Address updated " + key + " " + daddr + "/" + dresource);
-                            } else {
-                                if (dname != null)
-                                    Log.i(TAG, "Ignored " + key + " " + daddr + "/" + dresource + "=" + block);
-                            }
-                        } else
-                            Log.w(TAG, "Address not numeric " + name);
-                    } catch (UnknownHostException ex) {
-                        Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-                    }
-                }
-            }
-        }
-
-        } finally {
-            lock.writeLock().unlock();
-        }
     }
 
     // mapForward is keyed by protocol and port together, not port alone: a
@@ -2867,8 +2791,6 @@ public class ServiceSinkhole extends VpnService {
             if (outcome == DatabaseHelper.DnsInsertOutcome.INSERTED) {
                 Log.i(TAG, "New IP " + rr);
             }
-            prepareUidIPFilters(rr.QName);
-
             invalidateTrackerCacheAfterDnsInsert(outcome, rr.Resource,
                     Util.isNumericAddress(rr.Resource));
         }
@@ -5038,86 +4960,6 @@ public class ServiceSinkhole extends VpnService {
                     return false;
 
             return true;
-        }
-    }
-
-    private class IPKey {
-        int version;
-        int protocol;
-        int dport;
-        int uid;
-
-        public IPKey(int version, int protocol, int dport, int uid) {
-            this.version = version;
-            this.protocol = protocol;
-            // Only TCP (6) and UDP (17) have port numbers
-            this.dport = (protocol == 6 || protocol == 17 ? dport : 0);
-            this.uid = uid;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            if (!(obj instanceof IPKey))
-                return false;
-            IPKey other = (IPKey) obj;
-            return (this.version == other.version &&
-                    this.protocol == other.protocol &&
-                    this.dport == other.dport &&
-                    this.uid == other.uid);
-        }
-
-        @Override
-        public int hashCode() {
-            // The previous (version << 40) | (protocol << 32) shifts wrapped
-            // mod 32 and collapsed fields onto each other.
-            return Objects.hash(version, protocol, dport, uid);
-        }
-
-        @Override
-        public String toString() {
-            return "v" + version + " p" + protocol + " port=" + dport + " uid=" + uid;
-        }
-    }
-
-    private class IPRule {
-        private IPKey key;
-        private String name;
-        private boolean block;
-        private long time;
-        private long ttl;
-
-        public IPRule(IPKey key, String name, boolean block, long time, long ttl) {
-            this.key = key;
-            this.name = name;
-            this.block = block;
-            this.time = time;
-            this.ttl = ttl;
-        }
-
-        public boolean isBlocked() {
-            return this.block;
-        }
-
-        public boolean isExpired() {
-            return System.currentTimeMillis() > (this.time + this.ttl);
-        }
-
-        public void updateExpires(long time, long ttl) {
-            this.time = time;
-            this.ttl = ttl;
-        }
-
-        @Override
-        public boolean equals(Object obj) {
-            IPRule other = (IPRule) obj;
-            return (this.block == other.block &&
-                    this.time == other.time &&
-                    this.ttl == other.ttl);
-        }
-
-        @Override
-        public String toString() {
-            return this.key + " " + this.name;
         }
     }
 

--- a/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionWriter.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/AppProtectionWriter.java
@@ -82,9 +82,11 @@ public final class AppProtectionWriter {
         SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
         SharedPreferences trackerProtect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
         SharedPreferences minimalOnlyPrefs = context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
+        InternetBlocklist internetBlocklist = InternetBlocklist.getInstance(context);
 
         boolean applyBefore = apply.getBoolean(packageName, true);
         boolean protectBefore = BlockingMode.isTrackerProtectionEnabled(context, trackerProtect, packageName);
+        boolean internetBefore = internetBlocklist.blockedInternet(uid);
 
         apply.edit().putBoolean(packageName, applyValue).apply();
         if (applyValue)
@@ -95,13 +97,12 @@ public final class AppProtectionWriter {
         if (minimalOnlyValue != null)
             minimalOnlyPrefs.edit().putBoolean(packageName, minimalOnlyValue).apply();
 
-        InternetBlocklist.getInstance(context).apply(context, uid, internetBlocked);
+        internetBlocklist.apply(context, uid, internetBlocked);
 
         // The service reads this per-package flag through the live preferences
         // handle, so changing it alone needs no service reload.
-        boolean needsReload = applyValue != applyBefore
-                || (trackerProtectValue != null && trackerProtectValue != protectBefore);
-        if (!needsReload)
+        if (!shouldReloadAfterChange(applyValue, applyBefore, trackerProtectValue,
+                protectBefore, internetBlocked, internetBefore))
             return;
 
         AsyncTask.execute(() -> {
@@ -115,5 +116,13 @@ public final class AppProtectionWriter {
             Rule.clearCache(context);
             ServiceSinkhole.reload("app protection changed", context, false);
         });
+    }
+
+    static boolean shouldReloadAfterChange(boolean applyValue, boolean applyBefore,
+            Boolean trackerProtectValue, boolean protectBefore, Boolean internetBlocked,
+            boolean internetBefore) {
+        return applyValue != applyBefore
+                || (trackerProtectValue != null && trackerProtectValue != protectBefore)
+                || (internetBlocked != null && internetBlocked != internetBefore);
     }
 }

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClient.java
@@ -32,6 +32,7 @@ import java.net.InetAddress;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +76,7 @@ public class DnsOverHttpsClient {
         thread.setDaemon(true);
         return thread;
     });
+    private static volatile Executor evictionExecutor = SHUTDOWN_EXECUTOR;
     private static DnsOverHttpsClient instance;
     private static Cache responseCache;
     // Screen-off DoH battery policy: while the device is dozing we skip retries
@@ -164,7 +166,11 @@ public class DnsOverHttpsClient {
     }
 
     private void evictIdle() {
-        SHUTDOWN_EXECUTOR.execute(() -> client.connectionPool().evictAll());
+        evictionExecutor.execute(() -> client.connectionPool().evictAll());
+    }
+
+    static void setEvictionExecutorForTests(@Nullable Executor executor) {
+        evictionExecutor = executor == null ? SHUTDOWN_EXECUTOR : executor;
     }
 
     /**
@@ -245,8 +251,10 @@ public class DnsOverHttpsClient {
             }
 
             Call call = client.newCall(request);
+            boolean networkAttempted = false;
             try {
                 try (Response response = call.execute()) {
+                    networkAttempted = response.networkResponse() != null;
                     if (!response.isSuccessful()) {
                         Log.w(TAG, "DoH request failed with code: " + response.code());
                         // 408 is a transient upstream timeout, not a client error.
@@ -305,13 +313,14 @@ public class DnsOverHttpsClient {
                     Log.d(TAG, "DoH request canceled (client shutdown), not counted as a failure");
                     return null;
                 }
+                networkAttempted = true;
                 Log.e(TAG, "DoH request failed: " + e.getMessage());
                 reportFailedAttempt(onFailedAttempt);
             } finally {
                 // Screen off: never leave an idle keep-alive socket behind — a
-                // server-side reset during doze would wake the radio. Cache
-                // hits are unaffected (no connection is created for them).
-                if (screenOff) {
+                // server-side reset during doze would wake the radio. Cache hits
+                // are unaffected (no connection is created for them).
+                if (screenOff && networkAttempted) {
                     evictIdle();
                 }
             }

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -31,8 +31,9 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -56,12 +57,15 @@ public class DnsProxyServer {
     private final AtomicBoolean running = new AtomicBoolean(false);
     private DatagramSocket serverSocket;
     private ServerSocket tcpServerSocket;
-    private ExecutorService executor;
+    private ThreadPoolExecutor executor;
     // Tracked so stop() can wait for the listeners to actually exit, rather
     // than just closing their sockets and returning immediately.
     private Thread udpListenerThread;
     private Thread tcpListenerThread;
     private static final long LISTENER_JOIN_TIMEOUT_MS = 2000;
+    private static final int REQUEST_WORKERS = 16;
+    private static final int REQUEST_QUEUE_CAPACITY = 64;
+    private final AtomicInteger overloadDrops = new AtomicInteger(0);
     private final AtomicInteger dohFailures = new AtomicInteger(0);
     // Trips after this many consecutive failed network attempts (not queries):
     // a single failing resolve burns up to three full timeout budgets, so a
@@ -120,8 +124,11 @@ public class DnsProxyServer {
             running.set(true);
 
             // Handlers block on network I/O (worst case ~15s per DoH resolve),
-            // so a pool of 4 collapsed resolution throughput under packet loss
-            executor = Executors.newFixedThreadPool(16);
+            // so a pool of 4 collapsed resolution throughput under packet loss.
+            // Bound the waiting work as well: a dead endpoint must not retain
+            // an unlimited number of DNS packets and accepted TCP sockets.
+            executor = createRequestExecutor(REQUEST_WORKERS, REQUEST_QUEUE_CAPACITY);
+            overloadDrops.set(0);
 
             // Start the main listener thread
             udpListenerThread = new Thread(this::runServer, "DnsProxyServer");
@@ -185,7 +192,11 @@ public class DnsProxyServer {
         tcpListenerThread = null;
 
         if (executor != null) {
-            executor.shutdownNow();
+            List<Runnable> pending = executor.shutdownNow();
+            for (Runnable task : pending)
+                if (task instanceof TcpConnectionTask)
+                    ((TcpConnectionTask) task).discard();
+            executor = null;
         }
 
         // Also reset the DoH client to close idle HTTPS connections
@@ -271,14 +282,52 @@ public class DnsProxyServer {
                 final InetAddress clientAddress = request.getAddress();
                 final int clientPort = request.getPort();
 
-                // Handle the query in a separate thread
-                executor.submit(() -> handleQuery(queryData, clientAddress, clientPort));
+                // Handle the query in a separate thread. Overload gets an
+                // immediate SERVFAIL instead of retaining stale work while
+                // every worker waits on the same failed DoH endpoint.
+                if (!tryExecute(executor,
+                        () -> handleQuery(queryData, clientAddress, clientPort)))
+                    rejectUdpQuery(queryData, clientAddress, clientPort);
 
             } catch (IOException e) {
                 if (running.get()) {
                     Log.e(TAG, "Error receiving DNS query: " + e.getMessage());
                 }
             }
+        }
+    }
+
+    static ThreadPoolExecutor createRequestExecutor(int workers, int queueCapacity) {
+        if (workers <= 0 || queueCapacity <= 0)
+            throw new IllegalArgumentException("workers and queueCapacity must be positive");
+        return new ThreadPoolExecutor(
+                workers, workers, 0L, TimeUnit.MILLISECONDS,
+                new ArrayBlockingQueue<>(queueCapacity));
+    }
+
+    static boolean tryExecute(@Nullable ThreadPoolExecutor target, Runnable task) {
+        if (target == null)
+            return false;
+        try {
+            target.execute(task);
+            return true;
+        } catch (RejectedExecutionException ignored) {
+            return false;
+        }
+    }
+
+    private void logOverload(String transport) {
+        int dropped = overloadDrops.incrementAndGet();
+        if ((dropped & 255) == 1)
+            Log.w(TAG, "DNS " + transport + " overload, rejected " + dropped + " request(s)");
+    }
+
+    private void rejectUdpQuery(byte[] queryData, InetAddress clientAddress, int clientPort) {
+        logOverload("UDP");
+        try {
+            sendServFailResponse(queryData, clientAddress, clientPort);
+        } catch (IOException e) {
+            Log.d(TAG, "Unable to send overload SERVFAIL: " + e.getMessage());
         }
     }
 
@@ -418,11 +467,35 @@ public class DnsProxyServer {
             try {
                 Socket clientSocket = tcpServerSocket.accept();
                 clientSocket.setSoTimeout(10000); // 10s timeout
-                executor.submit(() -> handleTcpConnection(clientSocket));
+                TcpConnectionTask task = new TcpConnectionTask(clientSocket);
+                if (!tryExecute(executor, task)) {
+                    logOverload("TCP");
+                    task.discard();
+                }
             } catch (IOException e) {
                 if (running.get()) {
                     Log.e(TAG, "Error accepting TCP connection: " + e.getMessage());
                 }
+            }
+        }
+    }
+
+    private final class TcpConnectionTask implements Runnable {
+        private final Socket client;
+
+        private TcpConnectionTask(Socket client) {
+            this.client = client;
+        }
+
+        @Override
+        public void run() {
+            handleTcpConnection(client);
+        }
+
+        private void discard() {
+            try {
+                client.close();
+            } catch (IOException ignored) {
             }
         }
     }

--- a/app/src/main/jni/netguard/icmp.c
+++ b/app/src/main/jni/netguard/icmp.c
@@ -295,8 +295,19 @@ int open_icmp_socket(const struct arguments *args, const struct icmp_session *cu
     }
 
     // Protect socket
-    if (protect_socket(args, sock) < 0)
+    if (protect_socket(args, sock) < 0) {
+        close(sock);
         return -1;
+    }
+
+    // Set non blocking so epoll handlers never stall the VPN thread.
+    int flags = fcntl(sock, F_GETFL, 0);
+    if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
+        log_android(ANDROID_LOG_ERROR, "fcntl socket O_NONBLOCK error %d: %s",
+                    errno, strerror(errno));
+        close(sock);
+        return -1;
+    }
 
     return sock;
 }

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -380,8 +380,8 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1socks5(JNIEnv *env, jobject insta
         (int) sizeof(socks5_password))
         log_android(ANDROID_LOG_WARN, "SOCKS5 password truncated");
 
-    log_android(ANDROID_LOG_WARN, "SOCKS5 %s:%d user=%s",
-                socks5_addr, socks5_port, socks5_username);
+    log_android(ANDROID_LOG_WARN, "SOCKS5 %s:%d configured",
+                socks5_addr, socks5_port);
 
     (*env)->ReleaseStringUTFChars(env, addr_, addr);
     (*env)->ReleaseStringUTFChars(env, username_, username);

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -71,6 +71,7 @@
 #define UDP_TIMEOUT_53 15 // seconds
 #define UDP_TIMEOUT_ANY 300 // seconds
 #define UDP_KEEP_TIMEOUT 60 // seconds
+#define UDP_BLOCKED_MAX 256 // bounded negative cache, separate from active sockets
 #define UDP_YIELD 10 // packets
 
 #define TCP_INIT_TIMEOUT 20 // seconds ~net.inet.tcp.keepinit
@@ -161,6 +162,13 @@ struct udp_session {
     jint uid;
     int version;
     uint16_t mss;
+
+    int resolved_version;
+    union {
+        __be32 ip4;
+        struct in6_addr ip6;
+    } resolved_addr;
+    __be16 resolved_port;
 
     uint64_t sent;
     uint64_t received;
@@ -474,7 +482,7 @@ void queue_tcp(const struct arguments *args,
 int open_icmp_socket(const struct arguments *args, const struct icmp_session *cur);
 
 int open_udp_socket(const struct arguments *args,
-                    const struct udp_session *cur, const struct allowed *redirect);
+                    const struct udp_session *cur);
 
 int open_tcp_socket(const struct arguments *args,
                     const struct tcp_session *cur, const struct allowed *redirect);

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -36,6 +36,7 @@ void clear_tcp_data(struct tcp_session *cur) {
         ng_free(p->data, __FILE__, __LINE__);
         ng_free(p, __FILE__, __LINE__);
     }
+    cur->forward = NULL;
     if (cur->tls_data != NULL) {
         ng_free(cur->tls_data, __FILE__, __LINE__);
         cur->tls_data = NULL;
@@ -104,7 +105,7 @@ int check_tcp_session(const struct arguments *args, struct ng_session *s,
 
         s->tcp.time = time(NULL);
         s->tcp.state = TCP_CLOSE;
-        dns_frame_reset(&s->tcp.dns_stream);
+        clear_tcp_data(&s->tcp);
     }
 
     if ((s->tcp.state == TCP_CLOSING || s->tcp.state == TCP_CLOSE) &&
@@ -175,11 +176,7 @@ int monitor_tcp_session(const struct arguments *args, struct ng_session *s, int 
 }
 
 uint32_t get_send_window(const struct tcp_session *cur) {
-    uint32_t behind;
-    if (cur->acked <= cur->local_seq)
-        behind = (cur->local_seq - cur->acked);
-    else
-        behind = (0x10000 + cur->local_seq - cur->acked);
+    uint32_t behind = cur->local_seq - cur->acked;
     behind += (cur->unconfirmed + 1) * 40; // Maximum header size
 
     uint32_t total = (behind < cur->send_window ? cur->send_window - behind : 0);

--- a/app/src/main/jni/netguard/udp.c
+++ b/app/src/main/jni/netguard/udp.c
@@ -116,12 +116,8 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
 
                 if (errno != EINTR && errno != EAGAIN)
                     s->udp.state = UDP_FINISHING;
-            } else if (bytes == 0) {
-                log_android(ANDROID_LOG_WARN, "UDP recv eof");
-                s->udp.state = UDP_FINISHING;
-
             } else {
-                // Socket read data
+                // A zero-length datagram is valid SOCK_DGRAM data, not EOF.
                 char dest[INET6_ADDRSTRLEN + 1];
                 if (s->udp.version == 4)
                     inet_ntop(AF_INET, &s->udp.daddr.ip4, dest, sizeof(dest));
@@ -133,7 +129,7 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
                 s->udp.received += bytes;
 
                 // Process DNS response
-                if (ntohs(s->udp.dest) == 53) {
+                if (ntohs(s->udp.dest) == 53 && bytes > 0) {
                     size_t dlen = (size_t) bytes;
                     parse_dns_response(args, s, buffer, &dlen);
                     bytes = (ssize_t) dlen;
@@ -142,11 +138,6 @@ void check_udp_socket(const struct arguments *args, const struct epoll_event *ev
                 // Forward to tun
                 if (write_udp(args, &s->udp, buffer, (size_t) bytes) < 0)
                     s->udp.state = UDP_FINISHING;
-                else {
-                    // Prevent too many open files
-                    if (ntohs(s->udp.dest) == 53)
-                        s->udp.state = UDP_FINISHING;
-                }
             }
             ng_free(buffer, __FILE__, __LINE__);
         }
@@ -209,6 +200,33 @@ void block_udp(const struct arguments *args,
     log_android(ANDROID_LOG_INFO, "UDP blocked session from %s/%u to %s/%u",
                 source, ntohs(udphdr->source), dest, ntohs(udphdr->dest));
 
+    // UDP_BLOCKED entries are negative cache nodes, not active sockets, so
+    // they are excluded from the descriptor/session admission count. Keep a
+    // separate cap and evict the oldest blocked node only; active sessions
+    // therefore remain available even during sustained blocked-port churn.
+    int blocked = 0;
+    struct ng_session *oldest = NULL;
+    struct ng_session *oldest_prev = NULL;
+    struct ng_session *prev = NULL;
+    for (struct ng_session *cur = args->ctx->ng_session;
+         cur != NULL; cur = cur->next) {
+        if (cur->protocol == IPPROTO_UDP && cur->udp.state == UDP_BLOCKED) {
+            blocked++;
+            if (oldest == NULL || cur->udp.time <= oldest->udp.time) {
+                oldest = cur;
+                oldest_prev = prev;
+            }
+        }
+        prev = cur;
+    }
+    if (blocked >= UDP_BLOCKED_MAX && oldest != NULL) {
+        if (oldest_prev == NULL)
+            args->ctx->ng_session = oldest->next;
+        else
+            oldest_prev->next = oldest->next;
+        ng_free(oldest, __FILE__, __LINE__);
+    }
+
     // Register session
     struct ng_session *s = ng_malloc(sizeof(struct ng_session), "udp session block");
     s->protocol = IPPROTO_UDP;
@@ -248,6 +266,7 @@ jboolean handle_udp(const struct arguments *args,
     const size_t datalen = length - (data - pkt);
 
     // Search session
+    struct ng_session *prev = NULL;
     struct ng_session *cur = args->ctx->ng_session;
     while (cur != NULL &&
            !(cur->protocol == IPPROTO_UDP &&
@@ -256,8 +275,10 @@ jboolean handle_udp(const struct arguments *args,
              (version == 4 ? cur->udp.saddr.ip4 == ip4->saddr &&
                              cur->udp.daddr.ip4 == ip4->daddr
                            : memcmp(&cur->udp.saddr.ip6, &ip6->ip6_src, 16) == 0 &&
-                             memcmp(&cur->udp.daddr.ip6, &ip6->ip6_dst, 16) == 0)))
+                             memcmp(&cur->udp.daddr.ip6, &ip6->ip6_dst, 16) == 0))) {
+        prev = cur;
         cur = cur->next;
+    }
 
     char source[INET6_ADDRSTRLEN + 1];
     char dest[INET6_ADDRSTRLEN + 1];
@@ -270,9 +291,32 @@ jboolean handle_udp(const struct arguments *args,
     }
 
     if (cur != NULL && cur->udp.state != UDP_ACTIVE) {
-        log_android(ANDROID_LOG_INFO, "UDP ignore session from %s/%u to %s/%u state %d",
-                    source, ntohs(udphdr->source), dest, ntohs(udphdr->dest), cur->udp.state);
-        return 0;
+        if (cur->udp.state == UDP_CLOSED && ntohs(cur->udp.dest) == 53) {
+            // check_udp_session normally accounts a closed mapping before it
+            // reaches the retention period. Flush any counters still present
+            // here as well, then discard the inert tuple so a new query can
+            // open a fresh socket immediately after the 15-second DNS idle
+            // timeout. UDP_BLOCKED remains a negative-cache hit below.
+            if (cur->udp.sent || cur->udp.received) {
+                account_usage(args, cur->udp.version, IPPROTO_UDP,
+                              dest, ntohs(cur->udp.dest), cur->udp.uid,
+                              cur->udp.sent, cur->udp.received);
+                cur->udp.sent = 0;
+                cur->udp.received = 0;
+            }
+            if (prev == NULL)
+                args->ctx->ng_session = cur->next;
+            else
+                prev->next = cur->next;
+            ng_free(cur, __FILE__, __LINE__);
+            cur = NULL;
+        } else {
+            log_android(ANDROID_LOG_INFO,
+                        "UDP ignore session from %s/%u to %s/%u state %d",
+                        source, ntohs(udphdr->source), dest, ntohs(udphdr->dest),
+                        cur->udp.state);
+            return 0;
+        }
     }
 
     // Create new session if needed
@@ -288,13 +332,6 @@ jboolean handle_udp(const struct arguments *args,
         s->udp.uid = uid;
         s->udp.version = version;
 
-        int rversion;
-        if (redirect == NULL)
-            rversion = s->udp.version;
-        else
-            rversion = (strstr(redirect->raddr, ":") == NULL ? 4 : 6);
-        s->udp.mss = (uint16_t) (rversion == 4 ? UDP4_MAXMSG : UDP6_MAXMSG);
-
         s->udp.sent = 0;
         s->udp.received = 0;
 
@@ -308,11 +345,36 @@ jboolean handle_udp(const struct arguments *args,
 
         s->udp.source = udphdr->source;
         s->udp.dest = udphdr->dest;
+
+        // Resolve the endpoint once when the tuple is admitted. The Java
+        // Allowed object is packet-scoped, so retaining or re-reading it
+        // would let later policy results change the family or destination of
+        // an already-open socket.
+        s->udp.resolved_version = version;
+        s->udp.resolved_port = udphdr->dest;
+        if (redirect == NULL) {
+            if (version == 4)
+                s->udp.resolved_addr.ip4 = (__be32) ip4->daddr;
+            else
+                memcpy(&s->udp.resolved_addr.ip6, &ip6->ip6_dst, 16);
+        } else {
+            s->udp.resolved_version = (strchr(redirect->raddr, ':') == NULL ? 4 : 6);
+            int parsed = inet_pton(s->udp.resolved_version == 4 ? AF_INET : AF_INET6,
+                                   redirect->raddr, &s->udp.resolved_addr);
+            if (parsed != 1) {
+                log_android(ANDROID_LOG_ERROR, "UDP invalid redirect address %s",
+                            redirect->raddr);
+                ng_free(s, __FILE__, __LINE__);
+                return 0;
+            }
+            s->udp.resolved_port = htons(redirect->rport);
+        }
+        s->udp.mss = (uint16_t) (s->udp.resolved_version == 4 ? UDP4_MAXMSG : UDP6_MAXMSG);
         s->udp.state = UDP_ACTIVE;
         s->next = NULL;
 
         // Open UDP socket
-        s->socket = open_udp_socket(args, &s->udp, redirect);
+        s->socket = open_udp_socket(args, &s->udp);
         if (s->socket < 0) {
             ng_free(s, __FILE__, __LINE__);
             return 0;
@@ -348,34 +410,17 @@ jboolean handle_udp(const struct arguments *args,
 
     cur->udp.time = time(NULL);
 
-    int rversion;
+    int rversion = cur->udp.resolved_version;
     struct sockaddr_in addr4 = {0};
     struct sockaddr_in6 addr6 = {0};
-    if (redirect == NULL) {
-        rversion = cur->udp.version;
-        if (cur->udp.version == 4) {
-            addr4.sin_family = AF_INET;
-            addr4.sin_addr.s_addr = (__be32) cur->udp.daddr.ip4;
-            addr4.sin_port = cur->udp.dest;
-        } else {
-            addr6.sin6_family = AF_INET6;
-            memcpy(&addr6.sin6_addr, &cur->udp.daddr.ip6, 16);
-            addr6.sin6_port = cur->udp.dest;
-        }
+    if (rversion == 4) {
+        addr4.sin_family = AF_INET;
+        addr4.sin_addr.s_addr = (__be32) cur->udp.resolved_addr.ip4;
+        addr4.sin_port = cur->udp.resolved_port;
     } else {
-        rversion = (strstr(redirect->raddr, ":") == NULL ? 4 : 6);
-        log_android(ANDROID_LOG_WARN, "UDP%d redirect to %s/%u",
-                    rversion, redirect->raddr, redirect->rport);
-
-        if (rversion == 4) {
-            addr4.sin_family = AF_INET;
-            inet_pton(AF_INET, redirect->raddr, &addr4.sin_addr);
-            addr4.sin_port = htons(redirect->rport);
-        } else {
-            addr6.sin6_family = AF_INET6;
-            inet_pton(AF_INET6, redirect->raddr, &addr6.sin6_addr);
-            addr6.sin6_port = htons(redirect->rport);
-        }
+        addr6.sin6_family = AF_INET6;
+        memcpy(&addr6.sin6_addr, &cur->udp.resolved_addr.ip6, 16);
+        addr6.sin6_port = cur->udp.resolved_port;
     }
 
     if (sendto(cur->socket, data, (socklen_t) datalen, MSG_NOSIGNAL,
@@ -394,13 +439,9 @@ jboolean handle_udp(const struct arguments *args,
 }
 
 int open_udp_socket(const struct arguments *args,
-                    const struct udp_session *cur, const struct allowed *redirect) {
+                    const struct udp_session *cur) {
     int sock;
-    int version;
-    if (redirect == NULL)
-        version = cur->version;
-    else
-        version = (strstr(redirect->raddr, ":") == NULL ? 4 : 6);
+    int version = cur->resolved_version;
 
     // Get UDP socket
     sock = socket(version == 4 ? PF_INET : PF_INET6, SOCK_DGRAM, IPPROTO_UDP);
@@ -410,8 +451,19 @@ int open_udp_socket(const struct arguments *args,
     }
 
     // Protect socket
-    if (protect_socket(args, sock) < 0)
+    if (protect_socket(args, sock) < 0) {
+        close(sock);
         return -1;
+    }
+
+    // Set non blocking so epoll handlers never stall the VPN thread.
+    int flags = fcntl(sock, F_GETFL, 0);
+    if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
+        log_android(ANDROID_LOG_ERROR, "fcntl socket O_NONBLOCK error %d: %s",
+                    errno, strerror(errno));
+        close(sock);
+        return -1;
+    }
 
     // Check for broadcast/multicast
     if (cur->version == 4) {

--- a/app/src/test/java/net/kollnig/missioncontrol/data/PausedAppsTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/data/PausedAppsTest.java
@@ -28,6 +28,7 @@ public class PausedAppsTest {
     private SharedPreferences apply;
     private SharedPreferences trackerProtect;
     private SharedPreferences minimalOnlyPrefs;
+    private InternetBlocklist internetBlocklist;
 
     @Before
     public void setUp() {
@@ -36,10 +37,12 @@ public class PausedAppsTest {
         apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
         trackerProtect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);
         minimalOnlyPrefs = context.getSharedPreferences("tracker_essential", Context.MODE_PRIVATE);
+        internetBlocklist = InternetBlocklist.getInstance(null);
         paused.edit().clear().commit();
         apply.edit().clear().commit();
         trackerProtect.edit().clear().commit();
         minimalOnlyPrefs.edit().clear().commit();
+        internetBlocklist.clear();
     }
 
     @Test
@@ -103,6 +106,55 @@ public class PausedAppsTest {
         AppProtectionWriter.applyScheduled(context, "com.example.app", 0, false);
 
         assertTrue(paused.contains("com.example.app"));
+    }
+
+    @Test
+    public void protectedToNoInternetRequestsReload() {
+        String packageName = "com.example.app";
+        int uid = 10001;
+        apply.edit().putBoolean(packageName, true).commit();
+        trackerProtect.edit().putBoolean(packageName, true).commit();
+
+        assertTrue(AppProtectionWriter.shouldReloadAfterChange(
+                true, true, null, true, Boolean.TRUE, false));
+
+        AppProtectionWriter.applyManual(context, packageName, uid,
+                AppProtectionState.of(AppProtectionState.NO_INTERNET));
+
+        assertTrue(internetBlocklist.blockedInternet(uid));
+    }
+
+    @Test
+    public void noOpInternetWriteDoesNotReloadService() {
+        String packageName = "com.example.app";
+        int uid = 10002;
+        apply.edit().putBoolean(packageName, true).commit();
+        trackerProtect.edit().putBoolean(packageName, true).commit();
+        internetBlocklist.block(context, uid);
+
+        assertFalse(AppProtectionWriter.shouldReloadAfterChange(
+                true, true, null, true, Boolean.TRUE, true));
+
+        AppProtectionWriter.applyManual(context, packageName, uid,
+                AppProtectionState.of(AppProtectionState.NO_INTERNET));
+
+        assertTrue(internetBlocklist.blockedInternet(uid));
+    }
+
+    @Test
+    public void nullInternetWriteLeavesBlockAndDoesNotReloadService() {
+        String packageName = "com.example.app";
+        int uid = 10003;
+        apply.edit().putBoolean(packageName, true).commit();
+        trackerProtect.edit().putBoolean(packageName, true).commit();
+        internetBlocklist.block(context, uid);
+
+        assertFalse(AppProtectionWriter.shouldReloadAfterChange(
+                true, true, null, true, null, true));
+
+        AppProtectionWriter.applyScheduled(context, packageName, uid, true);
+
+        assertTrue(internetBlocklist.blockedInternet(uid));
     }
 
     @Test

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsOverHttpsClientTest.java
@@ -44,11 +44,16 @@ public class DnsOverHttpsClientTest {
     };
 
     private MockWebServer server;
+    private final AtomicInteger idleEvictions = new AtomicInteger();
 
     @Before
     public void setUp() throws IOException {
         DnsOverHttpsClient.setScreenOff(false);
         DnsOverHttpsClient.resetInstance();
+        DnsOverHttpsClient.setEvictionExecutorForTests(command -> {
+            idleEvictions.incrementAndGet();
+            command.run();
+        });
         server = new MockWebServer();
         server.start();
     }
@@ -57,6 +62,7 @@ public class DnsOverHttpsClientTest {
     public void tearDown() throws IOException {
         DnsOverHttpsClient.setScreenOff(false);
         DnsOverHttpsClient.resetInstance();
+        DnsOverHttpsClient.setEvictionExecutorForTests(null);
         server.close();
     }
 
@@ -119,6 +125,35 @@ public class DnsOverHttpsClientTest {
         } finally {
             DnsOverHttpsClient.setScreenOff(false);
         }
+    }
+
+    @Test
+    public void resolveDoesNotEvictAfterScreenOffHttpCacheHit() {
+        server.enqueue(cacheableDnsResponse(RESPONSE));
+        DnsOverHttpsClient client = client();
+
+        assertArrayEquals(RESPONSE, client.resolve(QUERY));
+        assertEquals(1, server.getRequestCount());
+
+        DnsOverHttpsClient.setScreenOff(true);
+        int evictionsAfterScreenOff = idleEvictions.get();
+        assertArrayEquals(RESPONSE, client.resolve(QUERY));
+
+        assertEquals(evictionsAfterScreenOff, idleEvictions.get());
+        assertEquals(1, server.getRequestCount());
+    }
+
+    @Test
+    public void resolveEvictsAfterScreenOffNetworkResponse() {
+        server.enqueue(dnsResponse(200, RESPONSE));
+        DnsOverHttpsClient client = client();
+
+        DnsOverHttpsClient.setScreenOff(true);
+        int evictionsAfterScreenOff = idleEvictions.get();
+        assertArrayEquals(RESPONSE, client.resolve(QUERY));
+
+        assertEquals(evictionsAfterScreenOff + 1, idleEvictions.get());
+        assertEquals(1, server.getRequestCount());
     }
 
     @Test
@@ -385,6 +420,15 @@ public class DnsOverHttpsClientTest {
         return new MockResponse.Builder()
                 .code(status)
                 .addHeader("Content-Type", "application/dns-message")
+                .body(new Buffer().write(body))
+                .build();
+    }
+
+    private static MockResponse cacheableDnsResponse(byte[] body) {
+        return new MockResponse.Builder()
+                .code(200)
+                .addHeader("Content-Type", "application/dns-message")
+                .addHeader("Cache-Control", "max-age=60")
                 .body(new Buffer().write(body))
                 .build();
     }

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
@@ -1,6 +1,7 @@
 package net.kollnig.missioncontrol.dns;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -9,6 +10,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Only covers the query plausibility gate and the SERVFAIL header builder;
@@ -65,5 +70,39 @@ public class DnsProxyServerTest {
         // RCODE (low nibble of byte 3) is SERVFAIL (2).
         assertTrue((response[3] & 0x0F) == 0x02);
         assertTrue(response.length == query.length);
+    }
+
+    @Test
+    public void requestExecutorRejectsWorkBeyondWorkerAndQueueBound() throws Exception {
+        ThreadPoolExecutor executor = DnsProxyServer.createRequestExecutor(1, 1);
+        CountDownLatch started = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        try {
+            assertTrue(DnsProxyServer.tryExecute(executor, () -> {
+                started.countDown();
+                try {
+                    release.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+            assertTrue(started.await(2, TimeUnit.SECONDS));
+
+            assertTrue(DnsProxyServer.tryExecute(executor, () -> { }));
+            assertEquals(1, executor.getQueue().size());
+            assertFalse(DnsProxyServer.tryExecute(executor, () -> { }));
+        } finally {
+            release.countDown();
+            executor.shutdownNow();
+            assertTrue(executor.awaitTermination(2, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void stoppedRequestExecutorRejectsNewWork() {
+        ThreadPoolExecutor executor = DnsProxyServer.createRequestExecutor(1, 1);
+        executor.shutdownNow();
+        assertFalse(DnsProxyServer.tryExecute(executor, () -> { }));
     }
 }

--- a/app/src/test/native/icmp_socket_test.c
+++ b/app/src/test/native/icmp_socket_test.c
@@ -1,0 +1,286 @@
+/* Host regression tests for ICMP socket admission and nonblocking setup. */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netguard.h"
+
+static int failures;
+static int protect_result;
+static int epoll_result;
+static int fcntl_flags;
+static int fcntl_calls;
+static int fcntl_fail_get;
+static int fcntl_fail_set;
+static int socket_calls;
+static int close_calls;
+static int sendto_calls;
+static int last_sendto_family;
+static struct sockaddr_storage last_sendto_address;
+
+FILE *pcap_file;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                     \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+    (void) format;
+}
+
+void *ng_malloc(size_t size, const char *tag) {
+    (void) tag;
+    void *pointer = calloc(1, size);
+    if (pointer == NULL)
+        abort();
+    return pointer;
+}
+
+void ng_free(void *pointer, const char *file, int line) {
+    (void) file;
+    (void) line;
+    free(pointer);
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+}
+
+int protect_socket(const struct arguments *args, int socket) {
+    (void) args;
+    (void) socket;
+    return protect_result;
+}
+
+int __wrap_socket(int domain, int type, int protocol) {
+    (void) domain;
+    (void) type;
+    (void) protocol;
+    socket_calls++;
+    return 100 + socket_calls;
+}
+
+int __wrap_close(int file_descriptor) {
+    (void) file_descriptor;
+    close_calls++;
+    return 0;
+}
+
+int __wrap_fcntl(int file_descriptor, int command, ...) {
+    (void) file_descriptor;
+    fcntl_calls++;
+    if (command == F_GETFL) {
+        if (fcntl_fail_get) {
+            errno = EBADF;
+            return -1;
+        }
+        return fcntl_flags;
+    }
+
+    if (command == F_SETFL) {
+        va_list args;
+        va_start(args, command);
+        int flags = va_arg(args, int);
+        va_end(args);
+        if (fcntl_fail_set) {
+            errno = EIO;
+            return -1;
+        }
+        fcntl_flags = flags;
+        return 0;
+    }
+
+    errno = EINVAL;
+    return -1;
+}
+
+int epoll_ctl(int epoll_fd, int operation, int descriptor,
+              struct epoll_event *event) {
+    (void) epoll_fd;
+    (void) operation;
+    (void) descriptor;
+    (void) event;
+    return epoll_result;
+}
+
+ssize_t __wrap_sendto(int socket, const void *buffer, size_t length, int flags,
+                      const struct sockaddr *destination,
+                      socklen_t destination_length) {
+    (void) socket;
+    (void) buffer;
+    (void) flags;
+    sendto_calls++;
+    last_sendto_family = destination->sa_family;
+    memset(&last_sendto_address, 0, sizeof(last_sendto_address));
+    if (destination_length <= sizeof(last_sendto_address))
+        memcpy(&last_sendto_address, destination, destination_length);
+    return (ssize_t) length;
+}
+
+uint16_t calc_checksum(uint16_t start, const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+    return start;
+}
+
+static struct icmp_session make_session(void) {
+    struct icmp_session session = {0};
+    session.version = 4;
+    session.saddr.ip4 = inet_addr("192.0.2.1");
+    session.daddr.ip4 = inet_addr("198.51.100.1");
+    session.id = htons(0x1234);
+    return session;
+}
+
+static void test_nonblocking_socket_and_open_cleanup(void) {
+    struct arguments args = {0};
+    struct icmp_session session = make_session();
+
+    protect_result = 0;
+    fcntl_flags = 0x200;
+    fcntl_calls = 0;
+    fcntl_fail_get = 0;
+    fcntl_fail_set = 0;
+    close_calls = 0;
+    int socket = open_icmp_socket(&args, &session);
+    CHECK(socket >= 0, "ICMP socket opens when protection and nonblocking setup succeed");
+    CHECK(fcntl_calls == 2 && (fcntl_flags & O_NONBLOCK) != 0,
+          "ICMP socket is configured O_NONBLOCK");
+    close(socket);
+
+    protect_result = -1;
+    close_calls = 0;
+    socket = open_icmp_socket(&args, &session);
+    CHECK(socket < 0 && close_calls == 1,
+          "ICMP protection failure closes the newly opened descriptor");
+
+    protect_result = 0;
+    fcntl_fail_set = 1;
+    close_calls = 0;
+    socket = open_icmp_socket(&args, &session);
+    CHECK(socket < 0 && close_calls == 1,
+          "ICMP nonblocking failure closes the newly opened descriptor");
+    fcntl_fail_set = 0;
+}
+
+static size_t make_echo_packet(uint8_t *packet) {
+    memset(packet, 0, sizeof(struct iphdr) + ICMP_MINLEN);
+    struct iphdr *ip4 = (struct iphdr *) packet;
+    ip4->version = 4;
+    ip4->ihl = sizeof(struct iphdr) >> 2;
+    ip4->protocol = IPPROTO_ICMP;
+    ip4->saddr = inet_addr("192.0.2.1");
+    ip4->daddr = inet_addr("198.51.100.1");
+
+    struct icmp *icmp = (struct icmp *) (packet + sizeof(struct iphdr));
+    icmp->icmp_type = ICMP_ECHO;
+    icmp->icmp_id = htons(0x1234);
+    return sizeof(struct iphdr) + ICMP_MINLEN;
+}
+
+static size_t make_echo_packet6(uint8_t *packet) {
+    memset(packet, 0, sizeof(struct ip6_hdr) + ICMP_MINLEN);
+    struct ip6_hdr *ip6 = (struct ip6_hdr *) packet;
+    ip6->ip6_ctlun.ip6_un2_vfc = IPV6_VERSION;
+    ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt = IPPROTO_ICMPV6;
+    ip6->ip6_ctlun.ip6_un1.ip6_un1_plen = htons(ICMP_MINLEN);
+    inet_pton(AF_INET6, "2001:db8::1", &ip6->ip6_src);
+    inet_pton(AF_INET6, "2001:db8::2", &ip6->ip6_dst);
+
+    struct icmp *icmp = (struct icmp *) (packet + sizeof(struct ip6_hdr));
+    icmp->icmp_type = ICMP6_ECHO_REQUEST;
+    icmp->icmp_id = htons(0x2345);
+    return sizeof(struct ip6_hdr) + ICMP_MINLEN;
+}
+
+static void test_epoll_add_failure_does_not_retain_session(void) {
+    _Alignas(struct iphdr) uint8_t packet[sizeof(struct iphdr) + sizeof(struct icmp)];
+    size_t length = make_echo_packet(packet);
+    struct context context = {0};
+    struct arguments args = {0};
+    args.ctx = &context;
+    protect_result = 0;
+    epoll_result = -1;
+    close_calls = 0;
+    sendto_calls = 0;
+
+    CHECK(handle_icmp(&args, packet, length,
+                      packet + sizeof(struct iphdr), 10001, 99) == 0,
+          "ICMP rejects a session when epoll admission fails");
+    CHECK(context.ng_session == NULL && close_calls == 1 && sendto_calls == 0,
+          "ICMP epoll failure closes and frees the session before linking it");
+    epoll_result = 0;
+}
+
+static void test_icmp_send_address_is_zero_initialised(void) {
+    _Alignas(struct ip6_hdr) uint8_t packet[(sizeof(struct ip6_hdr) > sizeof(struct iphdr)
+                    ? sizeof(struct ip6_hdr) : sizeof(struct iphdr)) + sizeof(struct icmp)];
+    size_t length = make_echo_packet(packet);
+    struct context context = {0};
+    struct arguments args = {0};
+    args.ctx = &context;
+    protect_result = 0;
+    epoll_result = 0;
+    sendto_calls = 0;
+
+    CHECK(handle_icmp(&args, packet, length,
+                      packet + sizeof(struct iphdr), 10001, 99) == 1,
+          "ICMP echo is sent after successful session admission");
+    CHECK(sendto_calls == 1 && last_sendto_family == AF_INET,
+          "ICMP send uses an IPv4 sockaddr");
+    if (last_sendto_family == AF_INET) {
+        const struct sockaddr_in *address =
+                (const struct sockaddr_in *) &last_sendto_address;
+        CHECK(address->sin_addr.s_addr == inet_addr("198.51.100.1"),
+              "ICMP send preserves the IPv4 destination");
+        CHECK(address->sin_zero[0] == 0 &&
+                      address->sin_zero[sizeof(address->sin_zero) - 1] == 0,
+              "ICMP send zero-initialises IPv4 sockaddr padding");
+    }
+
+    struct ng_session *session = context.ng_session;
+    if (session != NULL)
+        ng_free(session, __FILE__, __LINE__);
+    context.ng_session = NULL;
+
+    length = make_echo_packet6(packet);
+    context.ng_session = NULL;
+    sendto_calls = 0;
+    CHECK(handle_icmp(&args, packet, length,
+                      packet + sizeof(struct ip6_hdr), 10001, 99) == 1,
+          "IPv6 ICMP echo is sent after successful session admission");
+    CHECK(sendto_calls == 1 && last_sendto_family == AF_INET6,
+          "ICMP send uses an IPv6 sockaddr");
+    if (last_sendto_family == AF_INET6) {
+        const struct sockaddr_in6 *address6 =
+                (const struct sockaddr_in6 *) &last_sendto_address;
+        CHECK(address6->sin6_flowinfo == 0 && address6->sin6_scope_id == 0,
+              "ICMP send zero-initialises IPv6 sockaddr fields");
+    }
+    session = context.ng_session;
+    if (session != NULL)
+        ng_free(session, __FILE__, __LINE__);
+    context.ng_session = NULL;
+}
+
+int main(void) {
+    test_nonblocking_socket_and_open_cleanup();
+    test_epoll_add_failure_does_not_retain_session();
+    test_icmp_send_address_is_zero_initialised();
+
+    if (failures != 0)
+        return 1;
+    puts("icmp_socket_test: all tests passed");
+    return 0;
+}

--- a/app/src/test/native/run_defensive_tests.sh
+++ b/app/src/test/native/run_defensive_tests.sh
@@ -30,3 +30,12 @@ compile icmp_defensive_test app/src/test/native/icmp_defensive_test.c \
     -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=sendto -Wl,--wrap=socket
 compile ip_header_test app/src/test/native/ip_header_test.c \
     app/src/test/native/ip_header_failfast.c app/src/main/jni/netguard/ip.c
+compile tcp_window_test app/src/test/native/tcp_window_test.c \
+    app/src/main/jni/netguard/tcp.c
+compile udp_socket_test app/src/test/native/udp_socket_test.c \
+    app/src/main/jni/netguard/udp.c \
+    -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=recv \
+    -Wl,--wrap=sendto -Wl,--wrap=socket -Wl,--wrap=write
+compile icmp_socket_test app/src/test/native/icmp_socket_test.c \
+    app/src/main/jni/netguard/icmp.c \
+    -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=sendto -Wl,--wrap=socket

--- a/app/src/test/native/tcp_defensive_test.c
+++ b/app/src/test/native/tcp_defensive_test.c
@@ -338,7 +338,22 @@ static void test_authentication_does_not_log_credentials(void) {
     close(pair[0]); close(pair[1]);
 }
 
+static void test_clear_tcp_data_is_idempotent(void) {
+    struct tcp_session tcp = {0};
+    tcp.forward = ng_malloc(sizeof(*tcp.forward), "test segment");
+    memset(tcp.forward, 0, sizeof(*tcp.forward));
+    tcp.forward->data = ng_malloc(8, "test payload");
+    tcp.tls_data = ng_malloc(8, "test TLS");
+    tcp.tls_len = 8;
+    clear_tcp_data(&tcp);
+    clear_tcp_data(&tcp);
+    CHECK(tcp.forward == NULL && tcp.tls_data == NULL && tcp.tls_len == 0,
+          "cleanup resets all owned data");
+    CHECK(live_allocations == 0, "repeated cleanup releases each allocation once");
+}
+
 int main(void) {
+    test_clear_tcp_data_is_idempotent();
     test_authentication_does_not_log_credentials();
     test_tcp_epoll_add_failure_does_not_retain_session();
     test_tcp_connect_address_is_zero_initialised();

--- a/app/src/test/native/tcp_window_test.c
+++ b/app/src/test/native/tcp_window_test.c
@@ -1,0 +1,55 @@
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "netguard.h"
+
+static int failures;
+static uint32_t logged_behind;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                      \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+
+    if (strcmp(format, "Send window behind %u window %u total %u") == 0) {
+        va_list args;
+        va_start(args, format);
+        logged_behind = va_arg(args, unsigned int);
+        va_end(args);
+    }
+}
+
+static void check_window(uint32_t local_seq, uint32_t acked, uint32_t expected_behind,
+                         uint32_t expected_total, const char *message) {
+    struct tcp_session session = {0};
+    session.local_seq = local_seq;
+    session.acked = acked;
+    session.unconfirmed = 0;
+    session.send_window = 0x10080;
+    logged_behind = 0;
+
+    uint32_t total = get_send_window(&session);
+    CHECK(logged_behind == expected_behind, message);
+    CHECK(total == expected_total, message);
+}
+
+int main(void) {
+    check_window(0x00000020, 0xfffffff0, 0x58, 0x10028,
+                 "wrapped sequence distance keeps the 0x30-byte gap");
+    check_window(0x00001030, 0x00001000, 0x58, 0x10028,
+                 "non-wrapped sequence distance remains unchanged");
+
+    if (failures != 0)
+        return 1;
+
+    puts("tcp_window_test: all tests passed");
+    return 0;
+}

--- a/app/src/test/native/udp_socket_test.c
+++ b/app/src/test/native/udp_socket_test.c
@@ -1,0 +1,763 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netguard.h"
+
+static int failures;
+static int write_calls;
+static size_t written_length;
+_Alignas(struct iphdr) static uint8_t written_packet[2048];
+static int parse_calls;
+static int close_calls;
+static ssize_t recv_result;
+static int sendto_calls;
+static int socket_calls;
+static int last_socket_domain;
+static int protect_result;
+static int epoll_result;
+static int fcntl_flags;
+static int fcntl_calls;
+static int fcntl_fail_get;
+static int fcntl_fail_set;
+static int last_sendto_family;
+static struct in_addr last_sendto_addr4;
+static struct in6_addr last_sendto_addr6;
+static uint16_t last_sendto_port;
+
+#define IPV4_HEADER_SIZE 20u
+#define UDP_HEADER_SIZE 8u
+
+FILE *pcap_file;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                      \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+    (void) format;
+}
+
+void *ng_malloc(size_t byte_count, const char *tag) {
+    (void) tag;
+    return calloc(1, byte_count);
+}
+
+void ng_free(void *pointer, const char *file, int line) {
+    (void) file;
+    (void) line;
+    free(pointer);
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+}
+
+void parse_dns_response(const struct arguments *args, const struct ng_session *session,
+                        uint8_t *data, size_t *data_length) {
+    (void) args;
+    (void) session;
+    (void) data;
+    (void) data_length;
+    parse_calls++;
+}
+
+ssize_t __wrap_recv(int socket, void *buffer, size_t length, int flags) {
+    (void) socket;
+    (void) buffer;
+    (void) length;
+    (void) flags;
+    if (recv_result > 0 && (size_t) recv_result <= length)
+        memset(buffer, 0, (size_t) recv_result);
+    return recv_result;
+}
+
+ssize_t __wrap_write(int file_descriptor, const void *buffer, size_t length) {
+    (void) file_descriptor;
+    if (length <= sizeof(written_packet))
+        memcpy(written_packet, buffer, length);
+    write_calls++;
+    written_length = length;
+    return (ssize_t) length;
+}
+
+int __wrap_close(int file_descriptor) {
+    (void) file_descriptor;
+    close_calls++;
+    return 0;
+}
+
+int protect_socket(const struct arguments *args, int socket) {
+    (void) args;
+    (void) socket;
+    return protect_result;
+}
+
+int __wrap_socket(int domain, int type, int protocol) {
+    (void) type;
+    (void) protocol;
+    socket_calls++;
+    last_socket_domain = domain;
+    return 100 + socket_calls;
+}
+
+int __wrap_fcntl(int file_descriptor, int command, ...) {
+    (void) file_descriptor;
+    fcntl_calls++;
+    if (command == F_GETFL) {
+        if (fcntl_fail_get) {
+            errno = EBADF;
+            return -1;
+        }
+        return fcntl_flags;
+    }
+
+    if (command == F_SETFL) {
+        va_list args;
+        va_start(args, command);
+        int flags = va_arg(args, int);
+        va_end(args);
+        if (fcntl_fail_set) {
+            errno = EIO;
+            return -1;
+        }
+        fcntl_flags = flags;
+        return 0;
+    }
+
+    errno = EINVAL;
+    return -1;
+}
+
+int check_dhcp(const struct arguments *args, const struct udp_session *session,
+               const uint8_t *data, const size_t data_length) {
+    (void) args;
+    (void) session;
+    (void) data;
+    (void) data_length;
+    return -1;
+}
+
+int epoll_ctl(int epoll_fd, int operation, int descriptor,
+              struct epoll_event *event) {
+    (void) epoll_fd;
+    (void) operation;
+    (void) descriptor;
+    (void) event;
+    return epoll_result;
+}
+
+ssize_t __wrap_sendto(int socket, const void *buffer, size_t length, int flags,
+                      const struct sockaddr *destination, socklen_t destination_length) {
+    (void) socket;
+    (void) buffer;
+    (void) flags;
+    sendto_calls++;
+    last_sendto_family = destination->sa_family;
+    if (destination->sa_family == AF_INET && destination_length >= sizeof(struct sockaddr_in)) {
+        const struct sockaddr_in *addr4 = (const struct sockaddr_in *) destination;
+        last_sendto_addr4 = addr4->sin_addr;
+        last_sendto_port = addr4->sin_port;
+    } else if (destination->sa_family == AF_INET6 &&
+               destination_length >= sizeof(struct sockaddr_in6)) {
+        const struct sockaddr_in6 *addr6 = (const struct sockaddr_in6 *) destination;
+        last_sendto_addr6 = addr6->sin6_addr;
+        last_sendto_port = addr6->sin6_port;
+    }
+    return (ssize_t) length;
+}
+
+void account_usage(const struct arguments *args, jint version, jint protocol,
+                   const char *destination, jint port, jint uid,
+                   jlong sent, jlong received) {
+    (void) args;
+    (void) version;
+    (void) protocol;
+    (void) destination;
+    (void) port;
+    (void) uid;
+    (void) sent;
+    (void) received;
+}
+
+uint16_t calc_checksum(uint16_t start, const uint8_t *buffer, size_t length) {
+    (void) start;
+    (void) buffer;
+    (void) length;
+    return 0;
+}
+
+static void check_zero_length_datagram(uint16_t destination, uint8_t expected_state,
+                                       int expected_parse_calls, const char *message) {
+    struct ng_session session = {0};
+    session.socket = 42;
+    session.udp.version = 4;
+    session.udp.mss = 64;
+    session.udp.saddr.ip4 = inet_addr("192.0.2.1");
+    session.udp.daddr.ip4 = inet_addr("198.51.100.1");
+    session.udp.source = htons(40000);
+    session.udp.dest = htons(destination);
+    session.udp.state = UDP_ACTIVE;
+
+    struct epoll_event event = {0};
+    event.events = EPOLLIN;
+    event.data.ptr = &session;
+
+    struct arguments args = {0};
+    args.tun = 17;
+
+    write_calls = 0;
+    written_length = SIZE_MAX;
+    parse_calls = 0;
+    close_calls = 0;
+    recv_result = 0;
+    check_udp_socket(&args, &event);
+
+    // A DNS datagram must leave the mapping active so a second query/reply on
+    // the same five-tuple can use the existing socket.
+    if (destination == 53)
+        check_udp_socket(&args, &event);
+
+    CHECK(session.udp.state == expected_state, message);
+    CHECK(write_calls == (destination == 53 ? 2 : 1), message);
+    CHECK(close_calls == 0, message);
+    CHECK(written_length == IPV4_HEADER_SIZE + UDP_HEADER_SIZE, message);
+    CHECK(parse_calls == expected_parse_calls, message);
+
+    uint16_t ip_length;
+    uint16_t udp_length;
+    uint16_t udp_source;
+    uint16_t udp_destination;
+    memcpy(&ip_length, written_packet + 2, sizeof(ip_length));
+    memcpy(&udp_length, written_packet + IPV4_HEADER_SIZE + 4, sizeof(udp_length));
+    memcpy(&udp_source, written_packet + IPV4_HEADER_SIZE, sizeof(udp_source));
+    memcpy(&udp_destination, written_packet + IPV4_HEADER_SIZE + 2,
+           sizeof(udp_destination));
+    CHECK(ntohs(ip_length) == written_length, message);
+    CHECK(ntohs(udp_length) == UDP_HEADER_SIZE, message);
+    CHECK(udp_source == session.udp.dest, message);
+    CHECK(udp_destination == session.udp.source, message);
+}
+
+static void test_dns_tuple_reuse(void) {
+    struct ng_session session = {0};
+    session.socket = 42;
+    session.udp.version = 4;
+    session.udp.mss = 64;
+    session.udp.saddr.ip4 = inet_addr("192.0.2.1");
+    session.udp.daddr.ip4 = inet_addr("198.51.100.1");
+    session.udp.source = htons(40000);
+    session.udp.dest = htons(53);
+    session.udp.state = UDP_ACTIVE;
+
+    struct epoll_event event = {0};
+    event.events = EPOLLIN;
+    event.data.ptr = &session;
+    struct arguments args = {0};
+    args.tun = 17;
+
+    write_calls = 0;
+    parse_calls = 0;
+    close_calls = 0;
+    recv_result = 4;
+    check_udp_socket(&args, &event);
+    check_udp_socket(&args, &event);
+
+    CHECK(session.udp.state == UDP_ACTIVE,
+          "a DNS reply leaves the tuple active for another outstanding query");
+    CHECK(write_calls == 2 && written_length == IPV4_HEADER_SIZE + UDP_HEADER_SIZE + 4,
+          "two DNS replies on one tuple reach the tun");
+    CHECK(parse_calls == 2,
+          "each DNS reply is parsed while the socket remains reusable");
+    CHECK(close_calls == 0,
+          "reusable DNS mapping does not close its socket after the first reply");
+    recv_result = 0;
+}
+
+static size_t make_udp_packet4(uint8_t *packet, const char *source_address,
+                               const char *destination_address,
+                               uint16_t source, uint16_t destination) {
+    memset(packet, 0, IPV4_HEADER_SIZE + UDP_HEADER_SIZE);
+    struct iphdr *ip4 = (struct iphdr *) packet;
+    ip4->version = 4;
+    ip4->ihl = IPV4_HEADER_SIZE >> 2;
+    ip4->protocol = IPPROTO_UDP;
+    ip4->saddr = inet_addr(source_address);
+    ip4->daddr = inet_addr(destination_address);
+
+    struct udphdr *udp = (struct udphdr *) (packet + IPV4_HEADER_SIZE);
+    udp->source = htons(source);
+    udp->dest = htons(destination);
+    udp->len = htons(UDP_HEADER_SIZE);
+    return IPV4_HEADER_SIZE + UDP_HEADER_SIZE;
+}
+
+static size_t make_udp_packet(uint8_t *packet, uint16_t source, uint16_t destination) {
+    return make_udp_packet4(packet, "192.0.2.1", "198.51.100.1", source, destination);
+}
+
+static size_t make_udp_packet6(uint8_t *packet, const char *source_address,
+                               const char *destination_address,
+                               uint16_t source, uint16_t destination) {
+    memset(packet, 0, sizeof(struct ip6_hdr) + UDP_HEADER_SIZE);
+    struct ip6_hdr *ip6 = (struct ip6_hdr *) packet;
+    ip6->ip6_vfc = 0x60;
+    ip6->ip6_nxt = IPPROTO_UDP;
+    ip6->ip6_plen = htons(UDP_HEADER_SIZE);
+    inet_pton(AF_INET6, source_address, &ip6->ip6_src);
+    inet_pton(AF_INET6, destination_address, &ip6->ip6_dst);
+
+    struct udphdr *udp = (struct udphdr *) (packet + sizeof(struct ip6_hdr));
+    udp->source = htons(source);
+    udp->dest = htons(destination);
+    udp->len = htons(UDP_HEADER_SIZE);
+    return sizeof(struct ip6_hdr) + UDP_HEADER_SIZE;
+}
+
+static void reset_sendto_capture(void) {
+    socket_calls = 0;
+    last_socket_domain = AF_UNSPEC;
+    sendto_calls = 0;
+    last_sendto_family = AF_UNSPEC;
+    memset(&last_sendto_addr4, 0, sizeof(last_sendto_addr4));
+    memset(&last_sendto_addr6, 0, sizeof(last_sendto_addr6));
+    last_sendto_port = 0;
+}
+
+static void check_last_sendto_ipv4(const char *address, uint16_t port,
+                                   const char *message) {
+    CHECK(last_sendto_family == AF_INET, message);
+    CHECK(last_sendto_addr4.s_addr == inet_addr(address), message);
+    CHECK(last_sendto_port == htons(port), message);
+}
+
+static void check_last_sendto_ipv6(const char *address, uint16_t port,
+                                   const char *message) {
+    struct in6_addr expected;
+    memset(&expected, 0, sizeof(expected));
+    inet_pton(AF_INET6, address, &expected);
+    CHECK(last_sendto_family == AF_INET6, message);
+    CHECK(memcmp(&last_sendto_addr6, &expected, sizeof(expected)) == 0, message);
+    CHECK(last_sendto_port == htons(port), message);
+}
+
+static struct allowed make_redirect(const char *address, uint16_t port) {
+    struct allowed redirect = {0};
+    strncpy(redirect.raddr, address, sizeof(redirect.raddr) - 1);
+    redirect.rport = port;
+    return redirect;
+}
+
+static jboolean send_test_packet(struct context *ctx, const uint8_t *packet,
+                                 size_t length, struct allowed *redirect) {
+    struct arguments args = {0};
+    args.ctx = ctx;
+    return handle_udp(&args, packet, length,
+                      packet + (packet[0] >> 4 == 4 ? IPV4_HEADER_SIZE
+                                                   : sizeof(struct ip6_hdr)),
+                      10001, redirect, 99);
+}
+
+static int count_sessions(const struct context *ctx, int state) {
+    int count = 0;
+    for (const struct ng_session *s = ctx->ng_session; s != NULL; s = s->next)
+        if (s->protocol == IPPROTO_UDP && (state < 0 || s->udp.state == state))
+            count++;
+    return count;
+}
+
+static int contains_session(const struct context *ctx, const struct ng_session *needle) {
+    for (const struct ng_session *s = ctx->ng_session; s != NULL; s = s->next)
+        if (s == needle)
+            return 1;
+    return 0;
+}
+
+static void free_test_sessions(struct context *ctx, struct ng_session *active) {
+    struct ng_session *s = ctx->ng_session;
+    while (s != NULL) {
+        struct ng_session *next = s->next;
+        if (s != active)
+            ng_free(s, __FILE__, __LINE__);
+        s = next;
+    }
+    ctx->ng_session = NULL;
+}
+
+static void free_all_sessions(struct context *ctx) {
+    struct ng_session *s = ctx->ng_session;
+    while (s != NULL) {
+        struct ng_session *next = s->next;
+        ng_free(s, __FILE__, __LINE__);
+        s = next;
+    }
+    ctx->ng_session = NULL;
+}
+
+static void test_blocked_cap_and_active_preservation(void) {
+    struct context ctx = {0};
+    struct arguments args = {0};
+    args.ctx = &ctx;
+
+    struct ng_session active = {0};
+    active.protocol = IPPROTO_UDP;
+    active.udp.version = 4;
+    active.udp.state = UDP_ACTIVE;
+    active.next = NULL;
+    ctx.ng_session = &active;
+
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet(packet, 41000, 12345);
+    block_udp(&args, packet, packet_length,
+              packet + IPV4_HEADER_SIZE, 10001);
+    CHECK(get_udp_session_state(&args, packet, packet + IPV4_HEADER_SIZE) == UDP_BLOCKED,
+          "repeated blocked five-tuple hits the retained negative entry");
+
+    // Churn more unique blocked ports than the cap. Only blocked nodes may be
+    // evicted; the active session must remain linked and usable.
+    for (int i = 0; i < UDP_BLOCKED_MAX + 8; i++) {
+        packet_length = make_udp_packet(packet, (uint16_t) (42000 + i), 12345);
+        block_udp(&args, packet, packet_length,
+                  packet + IPV4_HEADER_SIZE, 10001);
+    }
+
+    CHECK(count_sessions(&ctx, UDP_BLOCKED) == UDP_BLOCKED_MAX,
+          "blocked UDP retention is independently capped");
+    CHECK(count_sessions(&ctx, UDP_ACTIVE) == 1,
+          "blocked eviction preserves active UDP sessions");
+    CHECK(contains_session(&ctx, &active),
+          "active UDP session remains in the linked list");
+
+    free_test_sessions(&ctx, &active);
+}
+
+static void test_closed_dns_tuple_reopens(void) {
+    struct context ctx = {0};
+    struct arguments args = {0};
+    args.ctx = &ctx;
+    args.fwd53 = 1;
+
+    struct ng_session *closed = ng_malloc(sizeof(struct ng_session), "closed dns");
+    closed->protocol = IPPROTO_UDP;
+    closed->socket = -1;
+    closed->udp.version = 4;
+    closed->udp.saddr.ip4 = inet_addr("192.0.2.1");
+    closed->udp.daddr.ip4 = inet_addr("198.51.100.1");
+    closed->udp.source = htons(43000);
+    closed->udp.dest = htons(53);
+    closed->udp.state = UDP_CLOSED;
+    ctx.ng_session = closed;
+
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet(packet, 43000, 53);
+    sendto_calls = 0;
+    CHECK(handle_udp(&args, packet, packet_length,
+                     packet + IPV4_HEADER_SIZE, 10001, NULL, 99) == 1,
+          "a new query can reopen a retained closed DNS tuple");
+    CHECK(ctx.ng_session != NULL && ctx.ng_session->udp.state == UDP_ACTIVE,
+          "closed DNS retention is replaced by a fresh active mapping");
+    CHECK(sendto_calls == 1,
+          "the query is sent through the fresh DNS socket");
+
+    struct ng_session *active = ctx.ng_session;
+    active->socket = -1;
+    ng_free(active, __FILE__, __LINE__);
+    ctx.ng_session = NULL;
+}
+
+static void test_persisted_ipv4_redirect(void) {
+    struct context ctx = {0};
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet4(packet, "192.0.2.10", "198.51.100.10",
+                                            44000, 6000);
+    struct allowed redirect = make_redirect("203.0.113.10", 5353);
+
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ctx, packet, packet_length, &redirect) == 1,
+          "an IPv4 redirect opens a UDP session");
+    struct ng_session *session = ctx.ng_session;
+    CHECK(session != NULL && session->udp.resolved_version == 4,
+          "the IPv4 redirect family is persisted on the session");
+    CHECK(last_socket_domain == PF_INET,
+          "the IPv4 redirect opens an IPv4 socket");
+    check_last_sendto_ipv4("203.0.113.10", 5353,
+                           "the first IPv4 redirect reaches sendto");
+
+    // A subsequent packet has no Java redirect result. It must reuse the
+    // endpoint selected for the first packet.
+    CHECK(send_test_packet(&ctx, packet, packet_length, NULL) == 1,
+          "a later IPv4 packet uses the existing session");
+    CHECK(sendto_calls == 2, "the repeated IPv4 packet is forwarded");
+    check_last_sendto_ipv4("203.0.113.10", 5353,
+                           "the IPv4 endpoint survives a NULL redirect");
+
+    // A changed policy result must not retarget the already-open socket.
+    struct allowed changed = make_redirect("203.0.113.11", 5354);
+    CHECK(send_test_packet(&ctx, packet, packet_length, &changed) == 1,
+          "a later IPv4 packet remains on the existing session");
+    CHECK(sendto_calls == 3, "the changed-policy packet is forwarded");
+    check_last_sendto_ipv4("203.0.113.10", 5353,
+                           "a later redirect cannot retarget the session");
+    CHECK(ctx.ng_session == session, "the original IPv4 session is reused");
+
+    free_all_sessions(&ctx);
+}
+
+static void test_persisted_ipv6_redirect(void) {
+    struct context ctx = {0};
+    uint8_t packet[sizeof(struct ip6_hdr) + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet6(packet, "2001:db8::10", "2001:db8::11",
+                                            44001, 6001);
+    struct allowed redirect = make_redirect("2001:db8::20", 5355);
+
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ctx, packet, packet_length, &redirect) == 1,
+          "an IPv6 redirect opens a UDP session");
+    struct ng_session *session = ctx.ng_session;
+    CHECK(session != NULL && session->udp.resolved_version == 6,
+          "the IPv6 redirect family is persisted on the session");
+    CHECK(last_socket_domain == PF_INET6,
+          "the IPv6 redirect opens an IPv6 socket");
+    check_last_sendto_ipv6("2001:db8::20", 5355,
+                           "the first IPv6 redirect reaches sendto");
+
+    CHECK(send_test_packet(&ctx, packet, packet_length, NULL) == 1,
+          "a later IPv6 packet uses the existing session");
+    CHECK(sendto_calls == 2, "the repeated IPv6 packet is forwarded");
+    check_last_sendto_ipv6("2001:db8::20", 5355,
+                           "the IPv6 endpoint survives a NULL redirect");
+    CHECK(ctx.ng_session == session, "the original IPv6 session is reused");
+
+    free_all_sessions(&ctx);
+}
+
+static void test_cross_family_redirects(void) {
+    struct context ipv4_context = {0};
+    uint8_t ipv4_packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t ipv4_length = make_udp_packet4(ipv4_packet, "192.0.2.20", "198.51.100.20",
+                                          44002, 6002);
+    struct allowed ipv6_redirect = make_redirect("2001:db8::30", 5356);
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ipv4_context, ipv4_packet, ipv4_length, &ipv6_redirect) == 1,
+          "an IPv4 packet can use an IPv6 redirect");
+    CHECK(ipv4_context.ng_session != NULL &&
+          ipv4_context.ng_session->udp.resolved_version == 6,
+          "the IPv4-to-IPv6 redirect family is persisted");
+    CHECK(last_socket_domain == PF_INET6,
+          "the IPv4-to-IPv6 redirect opens an IPv6 socket");
+    check_last_sendto_ipv6("2001:db8::30", 5356,
+                           "the IPv4-to-IPv6 redirect reaches sendto");
+    free_all_sessions(&ipv4_context);
+
+    struct context ipv6_context = {0};
+    uint8_t ipv6_packet[sizeof(struct ip6_hdr) + UDP_HEADER_SIZE];
+    size_t ipv6_length = make_udp_packet6(ipv6_packet, "2001:db8::40", "2001:db8::41",
+                                          44003, 6003);
+    struct allowed ipv4_redirect = make_redirect("203.0.113.30", 5357);
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ipv6_context, ipv6_packet, ipv6_length, &ipv4_redirect) == 1,
+          "an IPv6 packet can use an IPv4 redirect");
+    CHECK(ipv6_context.ng_session != NULL &&
+          ipv6_context.ng_session->udp.resolved_version == 4,
+          "the IPv6-to-IPv4 redirect family is persisted");
+    CHECK(last_socket_domain == PF_INET,
+          "the IPv6-to-IPv4 redirect opens an IPv4 socket");
+    check_last_sendto_ipv4("203.0.113.30", 5357,
+                           "the IPv6-to-IPv4 redirect reaches sendto");
+    free_all_sessions(&ipv6_context);
+}
+
+static void test_unredirected_reuse(void) {
+    struct context ctx = {0};
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet4(packet, "192.0.2.30", "198.51.100.30",
+                                            44004, 6004);
+
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ctx, packet, packet_length, NULL) == 1,
+          "an unredirected UDP tuple opens a session");
+    CHECK(send_test_packet(&ctx, packet, packet_length, NULL) == 1,
+          "an unredirected UDP tuple is reusable");
+    CHECK(sendto_calls == 2, "both unredirected datagrams are forwarded");
+    check_last_sendto_ipv4("198.51.100.30", 6004,
+                           "unredirected reuse keeps the original endpoint");
+    CHECK(ctx.ng_session != NULL && ctx.ng_session->udp.resolved_version == 4,
+          "unredirected reuse persists the original family");
+
+    free_all_sessions(&ctx);
+}
+
+static void test_original_tuple_lookup(void) {
+    struct context ctx = {0};
+    uint8_t first_packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    uint8_t second_packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t first_length = make_udp_packet4(first_packet, "192.0.2.40", "198.51.100.40",
+                                           44005, 6005);
+    size_t second_length = make_udp_packet4(second_packet, "192.0.2.40", "198.51.100.41",
+                                            44005, 6005);
+    struct allowed redirect = make_redirect("203.0.113.40", 5358);
+
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ctx, first_packet, first_length, &redirect) == 1,
+          "the first original tuple opens a session");
+    CHECK(send_test_packet(&ctx, second_packet, second_length, NULL) == 1,
+          "a different original destination opens its own session");
+    CHECK(count_sessions(&ctx, UDP_ACTIVE) == 2,
+          "session lookup retains the original destination tuple");
+    check_last_sendto_ipv4("198.51.100.41", 6005,
+                           "the second original tuple uses its own endpoint");
+
+    free_all_sessions(&ctx);
+}
+
+static void test_invalid_redirect_cleanup(void) {
+    struct context ctx = {0};
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet4(packet, "192.0.2.50", "198.51.100.50",
+                                            44006, 6006);
+    struct allowed invalid = make_redirect("not-an-ip-address", 5359);
+
+    reset_sendto_capture();
+    CHECK(send_test_packet(&ctx, packet, packet_length, &invalid) == 0,
+          "an invalid redirect rejects session creation");
+    CHECK(ctx.ng_session == NULL,
+          "an invalid redirect leaves no retained session");
+    CHECK(sendto_calls == 0,
+          "an invalid redirect never reaches sendto");
+}
+
+static struct udp_session make_socket_session(void) {
+    struct udp_session session = {0};
+    session.version = 4;
+    session.resolved_version = 4;
+    session.daddr.ip4 = inet_addr("198.51.100.1");
+    return session;
+}
+
+static void test_nonblocking_socket_and_open_cleanup(void) {
+    struct arguments args = {0};
+    struct udp_session session = make_socket_session();
+
+    protect_result = 0;
+    fcntl_flags = 0x200;
+    fcntl_calls = 0;
+    fcntl_fail_get = 0;
+    fcntl_fail_set = 0;
+    close_calls = 0;
+    int socket = open_udp_socket(&args, &session);
+    CHECK(socket >= 0, "UDP socket opens when protection and nonblocking setup succeed");
+    CHECK(fcntl_calls == 2 && (fcntl_flags & O_NONBLOCK) != 0,
+          "UDP socket is configured O_NONBLOCK");
+    close(socket);
+
+    protect_result = -1;
+    close_calls = 0;
+    socket = open_udp_socket(&args, &session);
+    CHECK(socket < 0 && close_calls == 1,
+          "UDP protection failure closes the newly opened descriptor");
+
+    protect_result = 0;
+    fcntl_fail_set = 1;
+    close_calls = 0;
+    socket = open_udp_socket(&args, &session);
+    CHECK(socket < 0 && close_calls == 1,
+          "UDP nonblocking failure closes the newly opened descriptor");
+    fcntl_fail_set = 0;
+}
+
+static void test_epoll_add_failure_does_not_retain_session(void) {
+    struct context ctx = {0};
+    struct arguments args = {0};
+    args.ctx = &ctx;
+    args.fwd53 = 1;
+
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet(packet, 45000, 6000);
+    protect_result = 0;
+    epoll_result = -1;
+    errno = EIO;
+    close_calls = 0;
+    sendto_calls = 0;
+
+    CHECK(send_test_packet(&ctx, packet, packet_length, NULL) == 0,
+          "UDP rejects a session when epoll admission fails");
+    CHECK(ctx.ng_session == NULL && close_calls == 1 && sendto_calls == 0,
+          "UDP epoll failure closes and frees the session before linking it");
+
+    epoll_result = 0;
+}
+
+static void test_response_original_tuple(void) {
+    struct context ctx = {0};
+    uint8_t packet[IPV4_HEADER_SIZE + UDP_HEADER_SIZE];
+    size_t packet_length = make_udp_packet4(packet, "192.0.2.60", "198.51.100.60",
+                                            44007, 6007);
+    struct allowed redirect = make_redirect("2001:db8::60", 5360);
+    CHECK(send_test_packet(&ctx, packet, packet_length, &redirect) == 1,
+          "a cross-family session opens for response reconstruction");
+    struct ng_session *session = ctx.ng_session;
+
+    struct epoll_event event = {0};
+    event.events = EPOLLIN;
+    event.data.ptr = session;
+    struct arguments args = {0};
+    args.tun = 17;
+    write_calls = 0;
+    written_length = SIZE_MAX;
+    recv_result = 4;
+    check_udp_socket(&args, &event);
+    recv_result = 0;
+
+    CHECK(write_calls == 1 && written_length == IPV4_HEADER_SIZE + UDP_HEADER_SIZE + 4,
+          "the response is reconstructed on the original IP version");
+    if (written_length >= IPV4_HEADER_SIZE + UDP_HEADER_SIZE) {
+        const struct iphdr *response_ip4 = (const struct iphdr *) written_packet;
+        const struct udphdr *response_udp =
+            (const struct udphdr *) (written_packet + IPV4_HEADER_SIZE);
+        CHECK(response_ip4->saddr == inet_addr("198.51.100.60"),
+              "the response source remains the original destination");
+        CHECK(response_ip4->daddr == inet_addr("192.0.2.60"),
+              "the response destination remains the original source");
+        CHECK(response_udp->source == htons(6007),
+              "the response source port remains the original destination port");
+        CHECK(response_udp->dest == htons(44007),
+              "the response destination port remains the original source port");
+    }
+
+    free_all_sessions(&ctx);
+}
+
+int main(void) {
+    check_zero_length_datagram(12345, UDP_ACTIVE, 0,
+                               "empty non-DNS datagram stays active and is forwarded");
+    check_zero_length_datagram(53, UDP_ACTIVE, 0,
+                               "empty DNS datagrams keep a reusable tuple active");
+    test_dns_tuple_reuse();
+    test_blocked_cap_and_active_preservation();
+    test_closed_dns_tuple_reopens();
+    test_persisted_ipv4_redirect();
+    test_persisted_ipv6_redirect();
+    test_cross_family_redirects();
+    test_unredirected_reuse();
+    test_original_tuple_lookup();
+    test_invalid_redirect_cleanup();
+    test_response_original_tuple();
+    test_nonblocking_socket_and_open_cleanup();
+    test_epoll_add_failure_does_not_retain_session();
+
+    if (failures != 0)
+        return 1;
+
+    puts("udp_socket_test: all tests passed");
+    return 0;
+}


### PR DESCRIPTION
DNS sockets can drop follow-up queries, UDP redirects can change during a session, and a stalled Secure DNS endpoint can retain an unbounded backlog. This combines the remaining bounded fixes from the hotpath stack on current master, preserving the DNS provenance and split-response fixes already merged in #924 and #925.

Included:
- Reload protection when the Internet-block bit changes; skip idle-connection eviction tasks for screen-off DoH cache hits.
- Bound DoH work to 16 workers and 64 queued requests; reject excess UDP work with SERVFAIL, close excess TCP connections, and close queued sockets at shutdown.
- Preserve UDP endpoints for each session, accept empty datagrams, reuse DNS tuples and reopen them after expiry, and cap blocked UDP entries separately from active sockets.
- Close UDP/ICMP sockets on protection or non-blocking setup failure; correct TCP sequence-wrap window arithmetic and make early buffer cleanup idempotent.
- Remove the remaining SOCKS5 username log and unused DNS filter-cache maintenance.

Validation:
- 469 GitHub JVM tests across 65 suites passed; GitHub lint passed.
- GitHub debug and instrumentation APKs built. Packaged native ELF architecture checked for all four ABIs.
- Seven native defensive suites passed host ASan/UBSan using macOS compilation-time equivalents of GNU linker wrappers and compatibility protocol definitions. TCP wraparound control fails against master and passes here.
- Existing DNS framing, allocation/lifetime and real C adapter/Rust parser suites passed ASan/UBSan.
- All seven native defensive suites compile with NDK UBSan. The Linux CI runner now includes the three newly extracted suites.
- Connected Pixel 8: all seven native UBSan suites and both isolated instrumentation tests passed. Live UDP DNS, reuse after 17 seconds idle, 20 fragmented TCP frames and two pipelined frames passed. The first idle UDP attempt timed out; two complete repeats passed, so this is recorded as a transient live-network observation rather than hidden.
- Settings and installed APK backed up; a refreshed pre-install backup was taken after reconnection. All 14 original settings/profile files are byte-identical after testing. GitHub debug was updated in place and the VPN/Wi-Fi left enabled.
- All three CI jobs passed at the snapshot; no CI waiting was required.

This batch is intended to supersede the remaining production scope of #912, #917 and #918 after merge. TCP state-machine/SOCKS5 stream changes and WireGuard policy/recovery remain held in the other PRs. Existing PRs stay open until the batch lands and their residual diffs are reconciled. Connected-device validation for this batch is complete. Wider tunnel-fault, older-Android, battery and rollout gates remain outside this batch.
