### PR TITLE
Guard SCREEN_OFF/package-change receivers against RejectedExecutionException

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -3296,41 +3296,48 @@ public class ServiceSinkhole extends VpnService {
             Log.i(TAG, "Received " + intent);
             Util.logExtras(intent);
 
-            executor.submit(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        last_interactive = Intent.ACTION_SCREEN_ON.equals(intent.getAction());
-                        InteractiveStatePolicy.onScreenStateChanged(
-                                last_interactive,
-                                Util.isInteractive(ServiceSinkhole.this),
-                                new InteractiveStatePolicy.Callbacks() {
-                                    @Override
-                                    public void onWireGuardInteractiveStateChanged(boolean interactive) {
-                                        updateWireGuardInteractiveState(interactive);
-                                    }
+            try {
+                executor.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            last_interactive = Intent.ACTION_SCREEN_ON.equals(intent.getAction());
+                            InteractiveStatePolicy.onScreenStateChanged(
+                                    last_interactive,
+                                    Util.isInteractive(ServiceSinkhole.this),
+                                    new InteractiveStatePolicy.Callbacks() {
+                                        @Override
+                                        public void onWireGuardInteractiveStateChanged(boolean interactive) {
+                                            updateWireGuardInteractiveState(interactive);
+                                        }
 
-                                    @Override
-                                    public void onStatsInteractiveStateChanged(boolean interactive) {
-                                        statsHandler.sendEmptyMessage(interactive ? MSG_STATS_START : MSG_STATS_STOP);
-                                    }
-                                });
+                                        @Override
+                                        public void onStatsInteractiveStateChanged(boolean interactive) {
+                                            statsHandler.sendEmptyMessage(interactive ? MSG_STATS_START : MSG_STATS_STOP);
+                                        }
+                                    });
 
-                        // Screen state gates the DoH battery policy: while the
-                        // screen is off the proxy drops retries and idle
-                        // keep-alive sockets so a server-side reset during doze
-                        // can't wake the radio.
-                        net.kollnig.missioncontrol.dns.DnsProxyServer
-                                .getInstance(ServiceSinkhole.this)
-                                .onScreenStateChanged(last_interactive);
+                            // Screen state gates the DoH battery policy: while the
+                            // screen is off the proxy drops retries and idle
+                            // keep-alive sockets so a server-side reset during doze
+                            // can't wake the radio.
+                            net.kollnig.missioncontrol.dns.DnsProxyServer
+                                    .getInstance(ServiceSinkhole.this)
+                                    .onScreenStateChanged(last_interactive);
 
-                        if (last_interactive)
-                            recheckNetworkValidation();
-                    } catch (Throwable ex) {
-                        Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                            if (last_interactive)
+                                recheckNetworkValidation();
+                        } catch (Throwable ex) {
+                            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                        }
                     }
-                }
-            });
+                });
+            } catch (RejectedExecutionException ex) {
+                // Service is tearing down: the receiver can already be
+                // unregistered while this broadcast is still in-flight to the
+                // main Handler, racing executor.shutdownNow() in onDestroy().
+                Log.e(TAG, ex.toString());
+            }
         }
     };
 
@@ -3580,18 +3587,26 @@ public class ServiceSinkhole extends VpnService {
             // seconds while building rules via slow PackageManager IPC. Doing this
             // work on the main thread blocks input dispatching and causes an ANR.
             final BroadcastReceiver.PendingResult result = goAsync();
-            executor.submit(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        handlePackageChanged(context, intent);
-                    } catch (Throwable ex) {
-                        Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-                    } finally {
-                        result.finish();
+            try {
+                executor.submit(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            handlePackageChanged(context, intent);
+                        } catch (Throwable ex) {
+                            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                        } finally {
+                            result.finish();
+                        }
                     }
-                }
-            });
+                });
+            } catch (RejectedExecutionException ex) {
+                // Service is tearing down: the receiver can already be
+                // unregistered while this broadcast is still in-flight to the
+                // main Handler, racing executor.shutdownNow() in onDestroy().
+                Log.e(TAG, ex.toString());
+                result.finish();
+            }
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes a crash reported via ACRA (stack trace hash `af2144d4`):

```
java.lang.RuntimeException: Error receiving broadcast Intent { act=android.intent.action.SCREEN_OFF ... } in eu.faircode.netguard.ServiceSinkhole$2
Caused by: java.util.concurrent.RejectedExecutionException: ... rejected from ThreadPoolExecutor@...[Terminated, pool size = 0, ...]
	at eu.faircode.netguard.ServiceSinkhole$2.onReceive
```

`ServiceSinkhole.onDestroy()` unregisters `interactiveStateReceiver` and then calls `executor.shutdownNow()`. Unregistering a receiver doesn't cancel a broadcast that's already queued for delivery on the main `Handler`, so a `SCREEN_OFF`/`SCREEN_ON` intent in flight when the service tears down can still reach `onReceive()` after the executor is shut down. The un-caught `RejectedExecutionException` from `executor.submit()` then propagates out of `onReceive()` and crashes the app.

The same race exists in `packageChangedReceiver`. A third call site (the network-validation callback) already wraps its `executor.submit()` in a `try/catch (RejectedExecutionException)` — this PR brings the other two `executor.submit()` sites in `ServiceSinkhole` in line with that existing pattern.

- `interactiveStateReceiver`: wrap `executor.submit()` in `try/catch (RejectedExecutionException)`, logging instead of crashing.
- `packageChangedReceiver`: same guard, and call `result.finish()` on the `goAsync()` `PendingResult` in the catch block so it isn't leaked when the submit is rejected.

## Test plan

- [x] Manual code inspection against the existing guarded call site (network-validation `executor.submit`) to match the pattern.
- [ ] `./gradlew :app:compileGithubDebugJavaWithJavac` — not run in this environment (no Android SDK available); the change is a mechanical try/catch wrap with no new imports needed (`RejectedExecutionException` is already imported), so it should compile without changes.

Claude-Session: https://claude.ai/code/session_01GM9qWQ9etUyxx5yicdN4ze

---
_Generated by [Claude Code](https://claude.ai/code/session_01GM9qWQ9etUyxx5yicdN4ze)_