### PR TITLE
Preserve app ownership across WireGuard policy reloads

### DIFF
--- a/app/src/main/jni/netguard/ip.c
+++ b/app/src/main/jni/netguard/ip.c
@@ -198,11 +198,40 @@ static jint resolve_flow_owner(const struct arguments *args, int version, int pr
                                const void *saddr, uint16_t sport,
                                const void *daddr, uint16_t dport,
                                const char *source, const char *dest,
-                               const uint8_t *pkt, const uint8_t *payload) {
-    jint route_uid = get_session_uid(args, version, protocol, pkt, payload);
-    if (route_uid < 0)
-        route_uid = get_route_uid(args, version, protocol,
-                                  saddr, sport, daddr, dport, source, dest);
+                               const uint8_t *pkt, const uint8_t *payload,
+                               int tcp_syn) {
+    // A fresh SYN must not inherit an owner from an old native session or the
+    // retained cache: its Android lookup is authoritative for the new socket.
+    jint route_uid = (protocol == IPPROTO_TCP && tcp_syn)
+            ? -1 : get_session_uid(args, version, protocol, pkt, payload);
+
+    if (route_uid >= 0) {
+        // Native session ownership is trusted, including UID 0. Preserve the
+        // existing native-first behaviour for UDP and ICMP as well.
+        if (protocol == IPPROTO_TCP)
+            tcp_owner_store(version, saddr, sport, daddr, dport, route_uid);
+        return route_uid;
+    }
+
+    if (protocol == IPPROTO_TCP && !tcp_syn &&
+        tcp_owner_lookup(version, saddr, sport, daddr, dport, &route_uid))
+        return route_uid;
+
+    route_uid = get_route_uid(args, version, protocol,
+                              saddr, sport, daddr, dport, source, dest);
+
+    if (protocol == IPPROTO_TCP) {
+        if (tcp_syn && route_uid >= 0) {
+            tcp_owner_store(version, saddr, sport, daddr, dport, route_uid);
+        } else if (!tcp_syn && route_uid > 0) {
+            // Zero from the established-flow fallback is ambiguous while a
+            // closing socket disappears; only a positive fallback owner is
+            // safe to retain here.
+            tcp_owner_store(version, saddr, sport, daddr, dport, route_uid);
+        } else if (!tcp_syn && route_uid == 0) {
+            route_uid = -1;
+        }
+    }
     return route_uid;
 }
 
@@ -221,8 +250,13 @@ static int resolve_tunnel_uid(const struct arguments *args, int version, uint8_t
                               const void *daddr, uint16_t dport,
                               const char *source, const char *dest,
                               const uint8_t *pkt, const uint8_t *payload,
-                              jint uid, jint *out_uid) {
+                              int syn, jint uid, jint *out_uid) {
     int tunnel_uid;
+    if (protocol == IPPROTO_TCP && uid > 0)
+        tcp_owner_store(version, saddr, sport, daddr, dport, uid);
+    else if (protocol == IPPROTO_TCP && syn && uid == 0)
+        tcp_owner_store(version, saddr, sport, daddr, dport, uid);
+
     if (route_uid_relevant()) {
         // A flow keeps the verdict its first packet was given. A fresh UID
         // is authoritative even when a previous flow happened to reuse the
@@ -246,7 +280,7 @@ static int resolve_tunnel_uid(const struct arguments *args, int version, uint8_t
             // unknown-system policy and per-app route for a busy flow.
             route_uid = resolve_flow_owner(args, version, protocol,
                                            saddr, sport, daddr, dport,
-                                           source, dest, pkt, payload);
+                                           source, dest, pkt, payload, syn);
 
             if (route_uid >= 0) {
                 tunnel_uid = is_tunnel_uid(route_uid);
@@ -278,7 +312,7 @@ static int resolve_tunnel_uid(const struct arguments *args, int version, uint8_t
         if (out_uid != NULL && uid < 0) {
             resolved_uid = resolve_flow_owner(args, version, protocol,
                                               saddr, sport, daddr, dport,
-                                              source, dest, pkt, payload);
+                                              source, dest, pkt, payload, syn);
             if (resolved_uid >= 0)
                 *out_uid = resolved_uid;
         }
@@ -577,8 +611,21 @@ void handle_ip(const struct arguments *args,
 
     // A reused TCP five-tuple starts with a fresh SYN. Do not let a verdict
     // from the previous connection suppress this connection's policy check.
-    if (protocol == IPPROTO_TCP && syn)
+    if (protocol == IPPROTO_TCP && syn) {
+        // The new SYN must be resolved afresh, even when the tuple is reused.
+        tcp_owner_forget(version, saddr, sport, daddr, dport);
         route_flow_clear_verdict(version, protocol, saddr, sport, daddr, dport);
+    }
+
+    // A retained owner is independent of the generation-scoped route and
+    // verdict caches. Touch it on every established WireGuard TCP packet so
+    // an active flow does not age out merely because its cached policy answer
+    // is taking the fast path.
+    jint retained_tcp_uid = -1;
+    int retained_tcp_owner = 0;
+    if (wg_is_required && protocol == IPPROTO_TCP && !syn &&
+        tcp_owner_lookup(version, saddr, sport, daddr, dport, &retained_tcp_uid))
+        retained_tcp_owner = 1;
 
     // Tunnelled TCP has no native session, so the usual established-TCP
     // shortcut cannot tell whether a policy generation has changed. Keep the
@@ -621,11 +668,13 @@ void handle_ip(const struct arguments *args,
             tcp_native_session = has_tcp_session(args, version, pkt, payload);
             if (!tcp_native_session) {
                 tcp_flow_policy_pending = 1;
+                if (retained_tcp_owner)
+                    uid = retained_tcp_uid;
                 if (!tcp_flow_route_cached) {
                     jint resolved_uid = -1;
                     tcp_flow_tunnel = resolve_tunnel_uid(
                             args, version, protocol, saddr, sport, daddr, dport,
-                            source, dest, pkt, payload, uid, &resolved_uid);
+                            source, dest, pkt, payload, syn, uid, &resolved_uid);
                     if (resolved_uid >= 0)
                         uid = resolved_uid;
                 }
@@ -637,7 +686,7 @@ void handle_ip(const struct arguments *args,
                 if (uid < 0) {
                     jint resolved_uid = resolve_flow_owner(
                             args, version, protocol, saddr, sport, daddr, dport,
-                            source, dest, pkt, payload);
+                            source, dest, pkt, payload, syn);
                     if (resolved_uid >= 0)
                         uid = resolved_uid;
                 }
@@ -693,6 +742,9 @@ void handle_ip(const struct arguments *args,
                 uid = get_uid(version, protocol, saddr, sport, daddr, dport);
             else
                 uid = get_uid_q(args, version, protocol, source, sport, dest, dport);
+
+            if (protocol == IPPROTO_TCP && syn && uid >= 0)
+                tcp_owner_store(version, saddr, sport, daddr, dport, uid);
     }
 
     // SNI research mode reassembles a ClientHello on the ng_session that
@@ -722,7 +774,7 @@ void handle_ip(const struct arguments *args,
         // of resolving it a second time.
         sni_tunnel_uid = resolve_tunnel_uid(args, version, protocol,
                                             saddr, sport, daddr, dport,
-                                            source, dest, pkt, payload, uid,
+                                            source, dest, pkt, payload, syn, uid,
                                             &sni_resolved_uid);
         sni_tunnel_uid_known = 1;
         if (route_wants_tunnel(is_local_dest(version, daddr), 0,
@@ -743,6 +795,9 @@ void handle_ip(const struct arguments *args,
             uid = get_uid(version, protocol, saddr, sport, daddr, dport);
         else
             uid = get_uid_q(args, version, protocol, source, sport, dest, dport);
+
+        if (protocol == IPPROTO_TCP && (uid > 0 || (syn && uid == 0)))
+            tcp_owner_store(version, saddr, sport, daddr, dport, uid);
     }
 
     log_android(ANDROID_LOG_DEBUG,
@@ -862,6 +917,9 @@ void handle_ip(const struct arguments *args,
                     uid = get_uid(version, protocol, saddr, sport, daddr, dport);
                 else
                     uid = get_uid_q(args, version, protocol, source, sport, dest, dport);
+
+                if (protocol == IPPROTO_TCP && uid > 0)
+                    tcp_owner_store(version, saddr, sport, daddr, dport, uid);
             }
 
             allowed = 1;
@@ -919,7 +977,7 @@ void handle_ip(const struct arguments *args,
                 ? sni_tunnel_uid
                 : resolve_tunnel_uid(args, version, protocol,
                                      saddr, sport, daddr, dport,
-                                     source, dest, pkt, payload, uid, NULL);
+                                     source, dest, pkt, payload, syn, uid, NULL);
 
         int wg_dest = route_wants_tunnel(is_local_dest(version, daddr), is_dns,
                                          tunnel_uid, route_dns_direct());
@@ -1015,7 +1073,7 @@ void handle_ip(const struct arguments *args,
             if (!tcp_flow_route_cached)
                 (void) resolve_tunnel_uid(
                         args, version, protocol, saddr, sport, daddr, dport,
-                        source, dest, pkt, payload, uid, NULL);
+                        source, dest, pkt, payload, syn, uid, NULL);
             route_flow_store_verdict(version, protocol, saddr, sport, daddr, dport,
                                      ROUTE_FLOW_VERDICT_BLOCKED);
             if (tcp_flow_policy_pending && !syn &&

--- a/app/src/main/jni/netguard/netguard.c
+++ b/app/src/main/jni/netguard/netguard.c
@@ -151,6 +151,10 @@ Java_eu_faircode_netguard_ServiceSinkhole_jni_1init(
     // Resolve the routing policy now: the packet path must never pay a dlopen,
     // and a failure should be logged while there is still something to read it.
     policy_ensure();
+    // Owner state belongs to this process-wide packet-path lifecycle. Keep it
+    // across ordinary WireGuard stop/start and route reloads, but do not carry
+    // it into a newly initialised native context.
+    tcp_owner_reset();
 
     struct context *ctx = ng_calloc(1, sizeof(struct context), "init");
     ctx->sdk = sdk;

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -637,6 +637,23 @@ void route_flow_store(int version, int protocol,
 
 void route_flow_invalidate();
 
+// Numeric owner cache for established TCP flows. This is independent of the
+// generation-scoped route/policy cache, and therefore survives policy reloads
+// and ordinary WireGuard restarts. The cache is bounded and expires idle
+// entries using CLOCK_MONOTONIC.
+int tcp_owner_lookup(int version,
+                     const void *saddr, uint16_t sport,
+                     const void *daddr, uint16_t dport,
+                     jint *uid);
+void tcp_owner_store(int version,
+                     const void *saddr, uint16_t sport,
+                     const void *daddr, uint16_t dport,
+                     jint uid);
+void tcp_owner_forget(int version,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport);
+void tcp_owner_reset();
+
 jint get_uid_q(const struct arguments *args,
                jint version,
                jint protocol,

--- a/app/src/main/jni/netguard/policy.c
+++ b/app/src/main/jni/netguard/policy.c
@@ -195,6 +195,15 @@ int route_wants_tunnel(int local_dest, int is_dns, int tunnel_uid, int dns_direc
 #define ROUTE_FLOW_SETS 256         // power of two; SETS * WAYS = 1024 entries
 #define ROUTE_FLOW_MAX_AGE 300      // seconds idle before an entry is reusable
 
+// Numeric TCP ownership is separate from the route/policy cache.  A route
+// entry only needs to remember whether its route lookup succeeded; policy
+// revalidation needs the actual owner when Android no longer reports the
+// original app UID while a closing socket is disappearing from the kernel
+// table.
+#define TCP_OWNER_WAYS 4
+#define TCP_OWNER_SETS 256         // bounded to 1024 retained TCP owners
+#define TCP_OWNER_MAX_AGE 300      // seconds idle before an owner is forgotten
+
 struct route_flow_entry {
     uint32_t gen;                   // 0 = never written
     uint8_t version;
@@ -211,6 +220,21 @@ struct route_flow_entry {
 
 static struct route_flow_entry route_flows[ROUTE_FLOW_SETS][ROUTE_FLOW_WAYS];
 static _Atomic uint32_t route_flow_gen = 1;
+
+struct tcp_owner_entry {
+    uint32_t gen;
+    uint8_t valid;
+    uint8_t version;
+    uint16_t sport;
+    uint16_t dport;
+    uint8_t saddr[16];
+    uint8_t daddr[16];
+    jint uid;
+    struct timespec last_used;
+};
+
+static struct tcp_owner_entry tcp_owners[TCP_OWNER_SETS][TCP_OWNER_WAYS];
+static _Atomic uint32_t tcp_owner_gen = 1;
 
 void route_flow_invalidate() {
     // Wrapping to 0 would make every never-written slot look current, so skip it.
@@ -238,6 +262,137 @@ static size_t route_flow_set(int version, int protocol,
     h = (h ^ (uint8_t) (dport & 0xff)) * 16777619u;
     h = (h ^ (uint8_t) (dport >> 8)) * 16777619u;
     return (size_t) (h & (ROUTE_FLOW_SETS - 1));
+}
+
+static int tcp_owner_now(struct timespec *now) {
+    return clock_gettime(CLOCK_MONOTONIC, now) == 0;
+}
+
+static int tcp_owner_expired(const struct timespec *now,
+                             const struct timespec *last_used) {
+    if (now->tv_sec < last_used->tv_sec ||
+        (now->tv_sec == last_used->tv_sec && now->tv_nsec < last_used->tv_nsec))
+        return 0;
+
+    time_t seconds = now->tv_sec - last_used->tv_sec;
+    return seconds > TCP_OWNER_MAX_AGE ||
+           (seconds == TCP_OWNER_MAX_AGE && now->tv_nsec >= last_used->tv_nsec);
+}
+
+static int tcp_owner_matches(const struct tcp_owner_entry *entry,
+                             uint32_t gen,
+                             int version,
+                             const void *saddr, uint16_t sport,
+                             const void *daddr, uint16_t dport) {
+    size_t alen = version == 4 ? 4u : 16u;
+    return entry->valid && entry->gen == gen && entry->version == (uint8_t) version &&
+           entry->sport == sport && entry->dport == dport &&
+           memcmp(entry->saddr, saddr, alen) == 0 &&
+           memcmp(entry->daddr, daddr, alen) == 0;
+}
+
+int tcp_owner_lookup(int version,
+                     const void *saddr, uint16_t sport,
+                     const void *daddr, uint16_t dport,
+                     jint *uid) {
+    if ((version != 4 && version != 6) || uid == NULL)
+        return 0;
+
+    struct timespec now;
+    if (!tcp_owner_now(&now))
+        return 0;
+
+    uint32_t gen = atomic_load_explicit(&tcp_owner_gen, memory_order_acquire);
+    struct tcp_owner_entry *set = tcp_owners[route_flow_set(
+            version, IPPROTO_TCP, saddr, sport, daddr, dport)];
+    for (int way = 0; way < TCP_OWNER_WAYS; way++) {
+        struct tcp_owner_entry *entry = &set[way];
+        if (!tcp_owner_matches(entry, gen, version, saddr, sport, daddr, dport))
+            continue;
+        if (tcp_owner_expired(&now, &entry->last_used)) {
+            entry->valid = 0;
+            continue;
+        }
+        entry->last_used = now;
+        *uid = entry->uid;
+        return 1;
+    }
+    return 0;
+}
+
+void tcp_owner_store(int version,
+                     const void *saddr, uint16_t sport,
+                     const void *daddr, uint16_t dport,
+                     jint uid) {
+    if ((version != 4 && version != 6) || uid < 0)
+        return;
+
+    struct timespec now;
+    if (!tcp_owner_now(&now))
+        return;
+
+    size_t alen = version == 4 ? 4u : 16u;
+    uint32_t gen = atomic_load_explicit(&tcp_owner_gen, memory_order_acquire);
+    struct tcp_owner_entry *set = tcp_owners[route_flow_set(
+            version, IPPROTO_TCP, saddr, sport, daddr, dport)];
+    struct tcp_owner_entry *victim = NULL;
+    struct tcp_owner_entry *oldest = NULL;
+    struct tcp_owner_entry *reusable = NULL;
+
+    for (int way = 0; way < TCP_OWNER_WAYS; way++) {
+        struct tcp_owner_entry *entry = &set[way];
+        if (tcp_owner_matches(entry, gen, version, saddr, sport, daddr, dport)) {
+            victim = entry;
+            break;
+        }
+        if (reusable == NULL &&
+            (entry->gen != gen || !entry->valid ||
+             tcp_owner_expired(&now, &entry->last_used)))
+            reusable = entry;
+        if (oldest == NULL ||
+            entry->last_used.tv_sec < oldest->last_used.tv_sec ||
+            (entry->last_used.tv_sec == oldest->last_used.tv_sec &&
+             entry->last_used.tv_nsec < oldest->last_used.tv_nsec))
+            oldest = entry;
+    }
+    if (victim == NULL)
+        victim = reusable;
+    if (victim == NULL)
+        victim = oldest;
+
+    victim->valid = 1;
+    victim->gen = gen;
+    victim->version = (uint8_t) version;
+    victim->sport = sport;
+    victim->dport = dport;
+    memset(victim->saddr, 0, sizeof(victim->saddr));
+    memset(victim->daddr, 0, sizeof(victim->daddr));
+    memcpy(victim->saddr, saddr, alen);
+    memcpy(victim->daddr, daddr, alen);
+    victim->uid = uid;
+    victim->last_used = now;
+}
+
+void tcp_owner_forget(int version,
+                      const void *saddr, uint16_t sport,
+                      const void *daddr, uint16_t dport) {
+    if (version != 4 && version != 6)
+        return;
+
+    uint32_t gen = atomic_load_explicit(&tcp_owner_gen, memory_order_acquire);
+    struct tcp_owner_entry *set = tcp_owners[route_flow_set(
+            version, IPPROTO_TCP, saddr, sport, daddr, dport)];
+    for (int way = 0; way < TCP_OWNER_WAYS; way++) {
+        struct tcp_owner_entry *entry = &set[way];
+        if (tcp_owner_matches(entry, gen, version, saddr, sport, daddr, dport))
+            entry->valid = 0;
+    }
+}
+
+void tcp_owner_reset() {
+    uint32_t next = atomic_fetch_add_explicit(&tcp_owner_gen, 1, memory_order_release) + 1;
+    if (next == 0)
+        atomic_store_explicit(&tcp_owner_gen, 1, memory_order_release);
 }
 
 static int route_flow_matches(const struct route_flow_entry *e, uint32_t gen,

--- a/app/src/test/native/STACK_TESTS.md
+++ b/app/src/test/native/STACK_TESTS.md
@@ -37,8 +37,14 @@ not send load to an external resolver or inject faults into the user's VPN.
 route cache with synthetic TCP and UDP/443 packets. JNI ownership/policy and
 WireGuard writes are observable boundary stubs. It checks policy revalidation,
 negative verdict reuse, reused SYN tuples and unresolved-owner fail-closed
-behaviour. UDP negative-session storage is a fixture stub; this is not a live
-QUIC application test.
+behaviour, including retained numeric TCP owners across policy invalidation
+for IPv4 and IPv6. UDP negative-session storage is a fixture stub; this is not
+a live QUIC application test. The runner wraps `dlopen`/`dlsym` for a synthetic
+policy bridge, checking that cached TCP packets avoid bridge route lookups and
+that refreshed routes and deny decisions still apply to the retained owner.
+`route_flow_test.c` also exercises owner-cache
+generation independence, reset/forget, monotonic expiry, collision bounds and
+IPv6 tuple matching.
 
 `WgbridgeInstrumentedTest` also starts synthetic tunnels through the packaged
 JNI library, with no remote endpoint or saved profile. It checks the five-field

--- a/app/src/test/native/ip_flow_policy_test.c
+++ b/app/src/test/native/ip_flow_policy_test.c
@@ -42,6 +42,44 @@ _Atomic int wg_required = 1;
 static struct context context;
 static struct arguments args;
 
+// Replace only the shared-library boundary; exercise the real C policy cache.
+static int bridge_route_calls;
+static jint bridge_override = -1;
+static int bridge_default = 1;
+
+static int bridge_abi(void) { return 1; }
+static void bridge_set(const jint *uids, int count, int default_tunnel) {
+    CHECK(count <= 1, "fixture supports one routing override");
+    bridge_override = count > 0 ? uids[0] : -1;
+    bridge_default = default_tunnel;
+}
+static void bridge_clear(void) {
+    bridge_override = -1;
+    bridge_default = 1;
+}
+static int bridge_is_tunnel(jint uid) {
+    bridge_route_calls++;
+    return uid == bridge_override ? !bridge_default : bridge_default;
+}
+static int bridge_wants(int local, int dns, int tunnel, int direct_dns) {
+    return local && !dns ? 0 : dns && !direct_dns ? 1 : tunnel;
+}
+void *__wrap_dlopen(const char *name, int flags) {
+    (void) flags;
+    CHECK(strcmp(name, "libwgbridge.so") == 0, "only the policy bridge is loaded");
+    return (void *) (uintptr_t) 1;
+}
+void *__wrap_dlsym(void *handle, const char *name) {
+    (void) handle;
+    if (strcmp(name, "tc_policy_abi_version") == 0) return (void *) bridge_abi;
+    if (strcmp(name, "tc_policy_set_route_uids") == 0) return (void *) bridge_set;
+    if (strcmp(name, "tc_policy_clear_route_uids") == 0) return (void *) bridge_clear;
+    if (strcmp(name, "tc_policy_is_tunnel_uid") == 0) return (void *) bridge_is_tunnel;
+    if (strcmp(name, "tc_policy_wants_tunnel") == 0) return (void *) bridge_wants;
+    CHECK(0, "policy bridge requests a recognised symbol");
+    return NULL;
+}
+
 void log_android(int priority, const char *format, ...) {
     (void) priority;
     (void) format;
@@ -217,6 +255,7 @@ static void reset_fakes(void) {
     configured_uid = 10042;
     policy_allowed = 1;
     route_flow_invalidate();
+    tcp_owner_reset();
 }
 
 static size_t make_tcp(uint8_t *packet, uint16_t source_port, int syn, int ack,
@@ -242,6 +281,31 @@ static size_t make_tcp(uint8_t *packet, uint16_t source_port, int syn, int ack,
     tcp->ack_seq = htonl(2000);
     if (data_length != 0)
         memcpy(packet + sizeof(struct iphdr) + sizeof(struct tcphdr), data, data_length);
+    return length;
+}
+
+static size_t make_tcp6(uint8_t *packet, uint16_t source_port, int syn, int ack,
+                        int psh, const uint8_t *data, size_t data_length) {
+    const size_t length = sizeof(struct ip6_hdr) + sizeof(struct tcphdr) + data_length;
+    memset(packet, 0, length);
+    struct ip6_hdr *ip6 = (struct ip6_hdr *) packet;
+    ip6->ip6_vfc = 0x60;
+    ip6->ip6_plen = htons((uint16_t) (sizeof(struct tcphdr) + data_length));
+    ip6->ip6_nxt = IPPROTO_TCP;
+    inet_pton(AF_INET6, "2001:db8::10", &ip6->ip6_src);
+    inet_pton(AF_INET6, "2001:db8::20", &ip6->ip6_dst);
+
+    struct tcphdr *tcp = (struct tcphdr *) (packet + sizeof(struct ip6_hdr));
+    tcp->source = htons(source_port);
+    tcp->dest = htons(443);
+    tcp->doff = 5;
+    tcp->syn = syn;
+    tcp->ack = ack;
+    tcp->psh = psh;
+    tcp->seq = htonl(1000);
+    tcp->ack_seq = htonl(2000);
+    if (data_length != 0)
+        memcpy(packet + sizeof(struct ip6_hdr) + sizeof(struct tcphdr), data, data_length);
     return length;
 }
 
@@ -292,17 +356,22 @@ static void test_tcp_revalidation_and_fresh_syn(void) {
 
     route_flow_invalidate();
     policy_allowed = 0;
+    configured_uid = 0;
     const size_t data_length = make_tcp(packet, 42000, 0, 1, 1,
                                         (const uint8_t *) "data", 4);
+    ((struct tcphdr *) (packet + sizeof(struct iphdr)))->fin = 1;
     run(packet, data_length);
-    CHECK(policy_calls == 2 && wireguard_writes == 3 && rst_writes == 1,
+    CHECK(policy_calls == 2 && uid_calls == 1 && wireguard_writes == 3 && rst_writes == 1,
           "invalidated established TCP policy blocks before WireGuard and resets once");
+    CHECK(last_policy_uid == 10042,
+          "established TCP ACK/PSH/FIN revalidation uses the retained owner when Android reports zero");
     run(packet, data_length);
     CHECK(policy_calls == 2 && wireguard_writes == 3 && rst_writes == 1,
           "repeated blocked TCP packets skip Java, WireGuard, and duplicate resets");
 
     route_flow_invalidate();
     policy_allowed = 1;
+    configured_uid = 10042;
     run(packet, data_length);
     CHECK(policy_calls == 3 && wireguard_writes == 4,
           "a later invalidation rechecks policy and forwards the established flow");
@@ -328,7 +397,9 @@ static void test_tcp_unknown_owner_fails_closed_then_recovers(void) {
           "unknown-owner regression starts from an allowed tunnelled SYN");
 
     route_flow_invalidate();
-    configured_uid = -1;
+    tcp_owner_forget(4, &((struct iphdr *) syn_packet)->saddr, 42001,
+                     &((struct iphdr *) syn_packet)->daddr, 443);
+    configured_uid = 0;
     run(packet, ack_length);
     int verdict = ROUTE_FLOW_VERDICT_UNKNOWN;
     int tunnel = 0;
@@ -352,6 +423,75 @@ static void test_tcp_unknown_owner_fails_closed_then_recovers(void) {
           "resolving the owner on the next packet permits a fresh policy decision");
 }
 
+static void test_ipv6_tcp_owner_revalidation(void) {
+    _Alignas(struct ip6_hdr) uint8_t syn_packet[256];
+    _Alignas(struct ip6_hdr) uint8_t packet[256];
+    const size_t syn_length = make_tcp6(syn_packet, 42002, 1, 0, 0, NULL, 0);
+    const size_t ack_length = make_tcp6(packet, 42002, 0, 1, 1,
+                                       (const uint8_t *) "v6", 2);
+
+    reset_fakes();
+    run(syn_packet, syn_length);
+    CHECK(policy_calls == 1 && uid_calls == 1 && wireguard_writes == 1,
+          "IPv6 TCP SYN enters the same owner and WireGuard path");
+
+    route_flow_invalidate();
+    configured_uid = 0;
+    run(packet, ack_length);
+    CHECK(policy_calls == 2 && last_policy_uid == 10042 && wireguard_writes == 2,
+          "IPv6 established TCP revalidation uses the retained owner");
+}
+
+static void test_root_and_fresh_syn_owner_rules(void) {
+    _Alignas(struct iphdr) uint8_t syn_packet[256];
+    _Alignas(struct iphdr) uint8_t packet[256];
+
+    reset_fakes();
+    configured_uid = 0;
+    const size_t root_syn_length = make_tcp(syn_packet, 42003, 1, 0, 0, NULL, 0);
+    const size_t root_ack_length = make_tcp(packet, 42003, 0, 1, 1,
+                                            (const uint8_t *) "root", 4);
+    run(syn_packet, root_syn_length);
+    route_flow_invalidate();
+    configured_uid = -1;
+    run(packet, root_ack_length);
+    CHECK(policy_calls == 2 && uid_calls == 1 && last_policy_uid == 0,
+          "root-owned SYN remains valid across policy invalidation without a UID lookup");
+
+    reset_fakes();
+    configured_uid = 10042;
+    const size_t syn_length = make_tcp(syn_packet, 42004, 1, 0, 0, NULL, 0);
+    const size_t ack_length = make_tcp(packet, 42004, 0, 1, 1,
+                                       (const uint8_t *) "new", 3);
+    run(syn_packet, syn_length);
+    configured_uid = 10043;
+    run(syn_packet, syn_length);
+    CHECK(policy_calls == 2 && last_policy_uid == 10043,
+          "fresh SYN on a reused tuple replaces the retained owner");
+    route_flow_invalidate();
+    configured_uid = -1;
+    run(packet, ack_length);
+    CHECK(policy_calls == 3 && last_policy_uid == 10043,
+          "reloaded reused tuple keeps the fresh SYN owner");
+
+    reset_fakes();
+    configured_uid = 10042;
+    const size_t stale_syn_length = make_tcp(syn_packet, 42005, 1, 0, 0, NULL, 0);
+    const size_t stale_ack_length = make_tcp(packet, 42005, 0, 1, 1,
+                                             (const uint8_t *) "stale", 5);
+    run(syn_packet, stale_syn_length);
+    configured_uid = -1;
+    run(syn_packet, stale_syn_length);
+    CHECK(policy_calls == 2 && last_policy_uid == -1,
+          "unresolved fresh SYN does not inherit the previous tuple owner");
+    route_flow_invalidate();
+    configured_uid = 0;
+    int writes_before = wireguard_writes;
+    run(packet, stale_ack_length);
+    CHECK(policy_calls == 2 && wireguard_writes == writes_before,
+          "uncached established zero owner fails closed without policy or WireGuard");
+}
+
 static void test_udp_policy_invalidation_and_negative_state(void) {
     _Alignas(struct iphdr) uint8_t packet[256];
     const uint8_t opaque[] = {0x17, 0x03, 0x03, 0x00, 0x01, 0x7f};
@@ -373,6 +513,45 @@ static void test_udp_policy_invalidation_and_negative_state(void) {
           "repeated blocked UDP packets use negative state without Java or WireGuard");
 }
 
+static void test_selected_route_fast_path(void) {
+    _Alignas(struct iphdr) uint8_t packet[256];
+    reset_fakes();
+    jint override = 10999;
+    set_route_uids(&override, 1, 1, 0);
+    bridge_route_calls = 0;
+    size_t length = make_tcp(packet, 42006, 1, 0, 0, NULL, 0);
+    run(packet, length);
+    CHECK(bridge_route_calls == 1, "SYN resolves the selected-app route once");
+
+    length = make_tcp(packet, 42006, 0, 1, 1, (const uint8_t *) "data", 4);
+    run(packet, length);
+    run(packet, length);
+    CHECK(uid_calls == 1 && bridge_route_calls == 1 && policy_calls == 1,
+          "cached TCP packets avoid both Android ownership and bridge route lookups");
+
+    // Change this app's route and block verdict together. Retaining its owner
+    // must not preserve either the old route or the old allow verdict.
+    override = 10042;
+    set_route_uids(&override, 1, 1, 0);
+    configured_uid = 0;
+    policy_allowed = 0;
+    run(packet, length);
+    CHECK(last_policy_uid == 10042 && uid_calls == 1 && bridge_route_calls > 1,
+          "policy refresh re-evaluates the retained owner's new route");
+    CHECK(policy_calls == 2 && wireguard_writes == 3 && rst_writes == 1,
+          "new deny verdict stops an established connection before forwarding");
+    int tunnel = 1, known = 0;
+    struct iphdr *ip = (struct iphdr *) packet;
+    CHECK(route_flow_lookup(4, IPPROTO_TCP, &ip->saddr, 42006, &ip->daddr, 443,
+                            &tunnel, &known) && !tunnel && known,
+          "new direct route replaces the old tunnel route after refresh");
+    int calls_before = bridge_route_calls;
+    run(packet, length);
+    CHECK(bridge_route_calls == calls_before && policy_calls == 2 && uid_calls == 1,
+          "cached denied packets also avoid repeated route and owner lookups");
+    clear_route_uids();
+}
+
 int main(void) {
     memset(&context, 0, sizeof(context));
     memset(&args, 0, sizeof(args));
@@ -386,7 +565,10 @@ int main(void) {
 
     test_tcp_revalidation_and_fresh_syn();
     test_tcp_unknown_owner_fails_closed_then_recovers();
+    test_ipv6_tcp_owner_revalidation();
+    test_root_and_fresh_syn_owner_rules();
     test_udp_policy_invalidation_and_negative_state();
+    test_selected_route_fast_path();
     if (failures != 0)
         return 1;
     puts("ip_flow_policy_test: all tests passed");

--- a/app/src/test/native/ip_header_failfast.c
+++ b/app/src/test/native/ip_header_failfast.c
@@ -27,5 +27,9 @@ void parse_tls_header(void) { abort(); }
 void is_tunnel_uid(void) { abort(); }
 void route_default_is_tunnel(void) { abort(); }
 void route_flow_store(void) { abort(); }
+void tcp_owner_lookup(void) { abort(); }
+void tcp_owner_store(void) { abort(); }
+void tcp_owner_forget(void) { abort(); }
+void tcp_owner_reset(void) { abort(); }
 void write_tcp(void) { abort(); }
 void hex2bytes(void) { abort(); }

--- a/app/src/test/native/route_flow_test.c
+++ b/app/src/test/native/route_flow_test.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
 
 #include "netguard.h"
 #include "wg_flow_cache.h"
@@ -18,6 +19,17 @@ static int failures;
 
 static const uint8_t source[4] = {192, 0, 2, 10};
 static const uint8_t destination[4] = {198, 51, 100, 10};
+static time_t owner_clock_seconds = 1000;
+
+// policy.c deliberately uses CLOCK_MONOTONIC for owner expiry. Keep the
+// portable CI invocation unchanged while making expiry deterministic here.
+int clock_gettime(clockid_t clock_id, struct timespec *now) {
+    if (clock_id != CLOCK_MONOTONIC)
+        return -1;
+    now->tv_sec = owner_clock_seconds;
+    now->tv_nsec = 0;
+    return 0;
+}
 
 static void store_udp_route(int tunnel, int uid_known) {
     route_flow_store(4, IPPROTO_UDP, source, 41000, destination, 443,
@@ -44,6 +56,110 @@ static int lookup_verdict(int protocol, uint16_t source_port) {
                                    destination, 443, &verdict))
         return ROUTE_FLOW_VERDICT_UNKNOWN;
     return verdict;
+}
+
+static unsigned owner_set(const uint8_t *saddr, uint16_t sport,
+                          const uint8_t *daddr, uint16_t dport) {
+    uint32_t h = 2166136261u;
+    for (size_t i = 0; i < 4; i++) {
+        h = (h ^ saddr[i]) * 16777619u;
+        h = (h ^ daddr[i]) * 16777619u;
+    }
+    h = (h ^ 4u) * 16777619u;
+    h = (h ^ IPPROTO_TCP) * 16777619u;
+    h = (h ^ (uint8_t) (sport & 0xff)) * 16777619u;
+    h = (h ^ (uint8_t) (sport >> 8)) * 16777619u;
+    h = (h ^ (uint8_t) (dport & 0xff)) * 16777619u;
+    h = (h ^ (uint8_t) (dport >> 8)) * 16777619u;
+    return h & 255u;
+}
+
+static void test_tcp_owner_cache(void) {
+    jint uid = -1;
+    owner_clock_seconds = 1000;
+    tcp_owner_reset();
+
+    tcp_owner_store(4, source, 42000, destination, 443, 10042);
+    route_flow_invalidate();
+    CHECK(tcp_owner_lookup(4, source, 42000, destination, 443, &uid) && uid == 10042,
+          "TCP owner survives route-generation invalidation");
+
+    tcp_owner_forget(4, source, 42000, destination, 443);
+    CHECK(!tcp_owner_lookup(4, source, 42000, destination, 443, &uid),
+          "TCP owner forget removes one tuple");
+
+    tcp_owner_store(4, source, 42000, destination, 443, 0);
+    CHECK(tcp_owner_lookup(4, source, 42000, destination, 443, &uid) && uid == 0,
+          "UID 0 remains a valid retained SYN owner");
+
+    owner_clock_seconds = 2000;
+    tcp_owner_reset();
+    tcp_owner_store(4, source, 42000, destination, 443, 10042);
+    owner_clock_seconds += 299;
+    CHECK(tcp_owner_lookup(4, source, 42000, destination, 443, &uid) && uid == 10042,
+          "TCP owner remains valid before the bounded monotonic idle age");
+    owner_clock_seconds = 2000;
+    tcp_owner_reset();
+    tcp_owner_store(4, source, 42000, destination, 443, 10042);
+    owner_clock_seconds += 300;
+    CHECK(!tcp_owner_lookup(4, source, 42000, destination, 443, &uid),
+          "TCP owner expires at the bounded monotonic idle age");
+
+    // Find five tuples in one set and verify the four-way bound evicts the
+    // oldest collision without disturbing unrelated sets.
+    uint16_t ports[5];
+    unsigned set = 0;
+    int found = 0;
+    for (uint32_t port = 1000; port < 65536 && found != 2; port++) {
+        unsigned candidate = owner_set(source, (uint16_t) port, destination, 443);
+        if (found == 0) {
+            set = candidate;
+            ports[0] = (uint16_t) port;
+            found = 1;
+        } else if (candidate == set) {
+            int count = 1;
+            ports[count++] = (uint16_t) port;
+            for (uint32_t next = port + 1; next < 65536 && count < 5; next++) {
+                if (owner_set(source, (uint16_t) next, destination, 443) == set)
+                    ports[count++] = (uint16_t) next;
+                port = next;
+            }
+            if (count == 5)
+                found = 2;
+        }
+    }
+    CHECK(found == 2, "test fixture finds five colliding TCP owner tuples");
+    if (found == 2) {
+        owner_clock_seconds = 3000;
+        tcp_owner_reset();
+        for (int i = 0; i < 5; i++)
+            tcp_owner_store(4, source, ports[i], destination, 443, 20000 + i);
+        CHECK(!tcp_owner_lookup(4, source, ports[0], destination, 443, &uid),
+              "fifth colliding owner evicts the oldest bounded-cache entry");
+        CHECK(tcp_owner_lookup(4, source, ports[4], destination, 443, &uid) && uid == 20004,
+              "newest colliding owner remains available");
+
+        tcp_owner_reset();
+        for (int i = 0; i < 4; i++)
+            tcp_owner_store(4, source, ports[i], destination, 443, 20000 + i);
+        tcp_owner_forget(4, source, ports[0], destination, 443);
+        owner_clock_seconds++;
+        tcp_owner_store(4, source, ports[2], destination, 443, 30002);
+        tcp_owner_store(4, source, ports[4], destination, 443, 20004);
+        CHECK(tcp_owner_lookup(4, source, ports[1], destination, 443, &uid) && uid == 20001,
+              "updating a later matching tuple does not consume an earlier empty slot");
+        CHECK(tcp_owner_lookup(4, source, ports[2], destination, 443, &uid) && uid == 30002,
+              "updating a retained owner replaces the existing tuple");
+    }
+
+    static const uint8_t source6[16] = {
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1};
+    static const uint8_t destination6[16] = {
+        0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 1};
+    tcp_owner_reset();
+    tcp_owner_store(6, source6, 42000, destination6, 443, 10042);
+    CHECK(tcp_owner_lookup(6, source6, 42000, destination6, 443, &uid) && uid == 10042,
+          "IPv6 TCP owner is retained by the same bounded cache");
 }
 
 static void test_default_udp_route_is_reused(void) {
@@ -175,6 +291,7 @@ static void test_syn_clears_reused_tuple_verdict(void) {
 }
 
 int main(void) {
+    test_tcp_owner_cache();
     test_default_udp_route_is_reused();
     test_tcp_verdict_revalidation_and_negative_cache();
     test_unresolved_owner_does_not_pin_policy();

--- a/app/src/test/native/run_defensive_tests.sh
+++ b/app/src/test/native/run_defensive_tests.sh
@@ -42,4 +42,4 @@ compile icmp_socket_test app/src/test/native/icmp_socket_test.c \
 compile ip_flow_policy_test app/src/test/native/ip_flow_policy_test.c \
     app/src/main/jni/netguard/ip.c app/src/main/jni/netguard/policy.c \
     app/src/main/jni/netguard/ip6_ext.c app/src/main/jni/netguard/tls.c \
-    -ldl -pthread
+    -Wl,--wrap=dlopen -Wl,--wrap=dlsym -ldl -pthread


### PR DESCRIPTION
WireGuard policy reloads recheck the owner of established TCP connections. Android can return UID 0 for a closing connection that previously belonged to an ordinary app, causing its tracker activity to appear as “Unidentified app (UID 0)”. Device logs confirmed the same connection changing from Play Store UID 10276 to UID 0 after a reload.

Retain numeric TCP ownership in a bounded cache independent of route and blocking-policy generations. Refreshes still apply current routing and blocking decisions; fresh SYNs discard the previous owner. Uncached established connections with ambiguous UID 0 remain unresolved and fail closed. Atomic cache invalidation avoids a lifecycle race, and cached packets retain the existing route fast path.

Validation:
- Production-bound packet-policy and owner-cache tests pass with ASan/UBSan on the host, covering IPv4/IPv6, root UID, tuple reuse, expiry, collisions and route-call counts.
- Regression checks fail when the original attribution bug or reviewed cache/fast-path bugs are restored.
- Android native regression binaries compile with UBSan; `assembleGithubDebug` passes with all four native ABIs packaged.
- Independent Sol review completed; lifecycle and performance findings were corrected and rechecked.

Final device execution and installation remain unverified because the Pixel disconnected. Existing timeline records are not rewritten.
