### PR TITLE
Improve DoH setup and recover immediately after endpoint changes

### DIFF
--- a/app/src/androidTest/java/net/kollnig/missioncontrol/dns/StackDeviceTest.java
+++ b/app/src/androidTest/java/net/kollnig/missioncontrol/dns/StackDeviceTest.java
@@ -97,9 +97,7 @@ public class StackDeviceTest {
             for (Socket client : clients) client.close();
             for(int i=0;i<5;i++) {
                 proxy.start();
-                Field circuit = DnsProxyServer.class.getDeclaredField("circuitOpenUntil");
-                circuit.setAccessible(true);
-                circuit.setLong(proxy,System.currentTimeMillis()+60000);
+                proxy.getCurrentCircuitState().trip(System.currentTimeMillis());
                 servfail();
                 proxy.stop();
             }

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -95,8 +95,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
-import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -107,6 +107,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import okhttp3.HttpUrl;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
@@ -342,6 +344,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         // DoH endpoint
         EditTextPreference pref_doh_endpoint = (EditTextPreference) screen.findPreference("doh_endpoint");
         if (pref_doh_endpoint != null) {
+            configureDohEndpointPreference(pref_doh_endpoint);
             pref_doh_endpoint.setSummary(prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT));
         }
 
@@ -797,22 +800,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             ServiceSinkhole.reload("changed " + name, this, false);
 
         } else if ("doh_endpoint".equals(name)) {
-            String endpoint = prefs.getString(name, BuildConfig.DEFAULT_DOH_ENDPOINT);
-            try {
-                // Validate URL format
-                if (!TextUtils.isEmpty(endpoint)) {
-                    new URL(endpoint);
-                    if (!endpoint.startsWith("https://")) {
-                        throw new MalformedURLException("DoH endpoint must use HTTPS");
-                    }
-                }
-            } catch (MalformedURLException ex) {
-                prefs.edit().remove(name).apply();
-                ((EditTextPreference) getPreferenceScreen().findPreference(name)).setText(null);
-                Toast.makeText(ActivitySettings.this, "Invalid DoH URL: " + ex.getMessage(), Toast.LENGTH_LONG).show();
-            }
-            getPreferenceScreen().findPreference(name).setSummary(
-                    prefs.getString(name, BuildConfig.DEFAULT_DOH_ENDPOINT));
+            Preference dohEndpoint = getPreferenceScreen().findPreference(name);
+            if (dohEndpoint != null)
+                dohEndpoint.setSummary(prefs.getString(name, BuildConfig.DEFAULT_DOH_ENDPOINT));
             // Reset DoH client to pick up new endpoint
             net.kollnig.missioncontrol.dns.DnsOverHttpsClient.resetInstance();
             ServiceSinkhole.reload("changed " + name, this, false);
@@ -988,6 +978,58 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
             requestedLocalNetwork = true;
             requestPermissions(new String[] { LocalNetworkAccess.PERMISSION }, REQUEST_LOCAL_NETWORK);
         }
+    }
+
+    static void configureDohEndpointPreference(EditTextPreference preference) {
+        preference.setOnPreferenceChangeListener((changedPreference, newValue) -> {
+            if (!(newValue instanceof String)) {
+                Toast.makeText(changedPreference.getContext(), R.string.msg_invalid_doh_endpoint,
+                        Toast.LENGTH_LONG).show();
+                return false;
+            }
+
+            String endpoint = ((String) newValue).trim();
+            if (!isValidDohEndpoint(endpoint)) {
+                Toast.makeText(changedPreference.getContext(), R.string.msg_invalid_doh_endpoint,
+                        Toast.LENGTH_LONG).show();
+                return false;
+            }
+
+            if (!endpoint.equals(newValue)) {
+                ((EditTextPreference) changedPreference).setText(endpoint);
+                return false;
+            }
+            return true;
+        });
+    }
+
+    private static boolean isValidDohEndpoint(String endpoint) {
+        if (TextUtils.isEmpty(endpoint) || containsWhitespace(endpoint))
+            return false;
+
+        try {
+            URI uri = new URI(endpoint);
+            if (!"https".equalsIgnoreCase(uri.getScheme()) || uri.isOpaque()
+                    || TextUtils.isEmpty(uri.getRawAuthority())
+                    || uri.getRawUserInfo() != null || uri.getRawFragment() != null
+                    || uri.getRawAuthority().indexOf('@') >= 0)
+                return false;
+
+            HttpUrl httpUrl = HttpUrl.parse(endpoint);
+            return httpUrl != null && httpUrl.isHttps() && !TextUtils.isEmpty(httpUrl.host())
+                    && !uri.getRawAuthority().endsWith(":");
+        } catch (URISyntaxException ex) {
+            return false;
+        }
+    }
+
+    private static boolean containsWhitespace(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (Character.isWhitespace(character) || Character.isSpaceChar(character))
+                return true;
+        }
+        return false;
     }
 
     private CharSequence getWireGuardStatusSummary(SharedPreferences prefs) {

--- a/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/dns/DnsProxyServer.java
@@ -31,6 +31,7 @@ import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -66,14 +67,42 @@ public class DnsProxyServer {
     private static final int REQUEST_WORKERS = 16;
     private static final int REQUEST_QUEUE_CAPACITY = 64;
     private final AtomicInteger overloadDrops = new AtomicInteger(0);
-    private final AtomicInteger dohFailures = new AtomicInteger(0);
     // Trips after this many consecutive failed network attempts (not queries):
     // a single failing resolve burns up to three full timeout budgets, so a
     // broken endpoint must stop being hammered within a few bad queries.
     private static final int CIRCUIT_BREAKER_THRESHOLD = 10;
     private static final long CIRCUIT_BREAKER_COOLDOWN_MS = 60_000;
     private static final int FALLBACK_DNS_TIMEOUT_MS = 5000;
-    private volatile long circuitOpenUntil = 0;
+    private final Object circuitBreakerLock = new Object();
+    private CircuitState circuitState;
+
+    static final class CircuitState {
+        final String endpoint;
+        final AtomicInteger failures = new AtomicInteger(0);
+        volatile long openUntil = 0;
+
+        CircuitState(String endpoint) {
+            this.endpoint = endpoint;
+        }
+
+        boolean isOpen(long now) {
+            return now < openUntil;
+        }
+
+        void recordSuccess() {
+            failures.set(0);
+            openUntil = 0;
+        }
+
+        int recordFailure(int failedAttempts) {
+            return failures.addAndGet(Math.max(1, failedAttempts));
+        }
+
+        void trip(long now) {
+            openUntil = now + CIRCUIT_BREAKER_COOLDOWN_MS;
+            failures.set(0);
+        }
+    }
 
     private DnsProxyServer(Context context) {
         this.context = context.getApplicationContext();
@@ -102,6 +131,11 @@ public class DnsProxyServer {
             Log.d(TAG, "DNS proxy already running");
             return;
         }
+
+        // A stopped proxy gets a fresh circuit so disable/enable recovers from
+        // an earlier endpoint outage. Delayed workers still retain the state
+        // captured by their own request and cannot touch this replacement.
+        resetCircuitState();
 
         // Close any existing sockets first (safety for app restart scenarios)
         if (serverSocket != null && !serverSocket.isClosed()) {
@@ -203,6 +237,38 @@ public class DnsProxyServer {
         DnsOverHttpsClient.resetInstance();
 
         Log.i(TAG, "DNS proxy server stopped");
+    }
+
+    private void resetCircuitState() {
+        synchronized (circuitBreakerLock) {
+            circuitState = null;
+        }
+    }
+
+    /**
+     * Select the circuit state for one request. The preference read must stay
+     * inside this lock: otherwise a delayed worker can install an old endpoint
+     * snapshot after a newer endpoint has already been selected.
+     * Package-private for deterministic state tests.
+     */
+    CircuitState getCurrentCircuitState() {
+        synchronized (circuitBreakerLock) {
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
+            String endpoint = prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT);
+            if (circuitState == null || !Objects.equals(circuitState.endpoint, endpoint))
+                circuitState = new CircuitState(endpoint);
+            return circuitState;
+        }
+    }
+
+    private void reportDohCircuitOpen(CircuitState state, String message) {
+        synchronized (circuitBreakerLock) {
+            if (getCurrentCircuitState() != state
+                    || !eu.faircode.netguard.Util.isInternetWorking(context))
+                return;
+            Log.w(TAG, message);
+            eu.faircode.netguard.ServiceSinkhole.dohError(context);
+        }
     }
 
     /**
@@ -350,17 +416,16 @@ public class DnsProxyServer {
             byte[] responseData = null;
 
             // Circuit breaker: skip DoH if we recently had too many failures
-            boolean circuitOpen = System.currentTimeMillis() < circuitOpenUntil;
+            CircuitState state = getCurrentCircuitState();
+            boolean circuitOpen = state.isOpen(System.currentTimeMillis());
             AtomicInteger queryFailedAttempts = new AtomicInteger(0);
             if (!circuitOpen) {
-                String endpoint = prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT);
-                DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, endpoint);
+                DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, state.endpoint);
                 responseData = dohClient.resolve(queryData, queryFailedAttempts::incrementAndGet);
             }
 
             if (responseData != null) {
-                dohFailures.set(0);
-                circuitOpenUntil = 0;
+                state.recordSuccess();
                 DatagramSocket socket = serverSocket;
                 if (socket == null || socket.isClosed()) return;
                 DatagramPacket response = new DatagramPacket(
@@ -373,17 +438,14 @@ public class DnsProxyServer {
                     // three full timeout budgets, and waiting for ten whole
                     // queries before tripping kept ~30s of hung work alive
                     // per query on a dead network.
-                    int failures = dohFailures.addAndGet(Math.max(1, queryFailedAttempts.get()));
+                    int failures = state.recordFailure(queryFailedAttempts.get());
                     Log.w(TAG, "DoH query returned null response after "
                             + queryFailedAttempts.get() + " attempt(s), failures=" + failures);
 
                     if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
-                        circuitOpenUntil = System.currentTimeMillis() + CIRCUIT_BREAKER_COOLDOWN_MS;
-                        dohFailures.set(0);
-                        if (eu.faircode.netguard.Util.isInternetWorking(context)) {
-                            Log.w(TAG, "DoH circuit breaker tripped, skipping DoH for 60s");
-                            eu.faircode.netguard.ServiceSinkhole.dohError(context);
-                        }
+                        state.trip(System.currentTimeMillis());
+                        reportDohCircuitOpen(state,
+                                "DoH circuit breaker tripped, skipping DoH for 60s");
                     }
                 }
 
@@ -528,17 +590,16 @@ public class DnsProxyServer {
             SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(context);
             byte[] responseData = null;
 
-            boolean circuitOpen = System.currentTimeMillis() < circuitOpenUntil;
+            CircuitState state = getCurrentCircuitState();
+            boolean circuitOpen = state.isOpen(System.currentTimeMillis());
             AtomicInteger queryFailedAttempts = new AtomicInteger(0);
             if (!circuitOpen) {
-                String endpoint = prefs.getString("doh_endpoint", BuildConfig.DEFAULT_DOH_ENDPOINT);
-                DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, endpoint);
+                DnsOverHttpsClient dohClient = DnsOverHttpsClient.getInstance(context, state.endpoint);
                 responseData = dohClient.resolve(queryData, queryFailedAttempts::incrementAndGet);
             }
 
             if (responseData != null) {
-                dohFailures.set(0);
-                circuitOpenUntil = 0;
+                state.recordSuccess();
                 out.writeShort(responseData.length);
                 out.write(responseData);
                 out.flush();
@@ -546,14 +607,11 @@ public class DnsProxyServer {
             } else {
                 if (!circuitOpen) {
                     // Same attempt-based accounting as the UDP path above.
-                    int failures = dohFailures.addAndGet(Math.max(1, queryFailedAttempts.get()));
+                    int failures = state.recordFailure(queryFailedAttempts.get());
                     if (failures >= CIRCUIT_BREAKER_THRESHOLD) {
-                        circuitOpenUntil = System.currentTimeMillis() + CIRCUIT_BREAKER_COOLDOWN_MS;
-                        dohFailures.set(0);
-                        if (eu.faircode.netguard.Util.isInternetWorking(context)) {
-                            Log.w(TAG, "DoH circuit breaker tripped (TCP), skipping DoH for 60s");
-                            eu.faircode.netguard.ServiceSinkhole.dohError(context);
-                        }
+                        state.trip(System.currentTimeMillis());
+                        reportDohCircuitOpen(state,
+                                "DoH circuit breaker tripped (TCP), skipping DoH for 60s");
                     }
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -208,8 +208,10 @@
     <string name="warning_beta">Beta feature. May not work as expected.</string>
     <string name="setting_doh_endpoint">DoH Endpoint URL</string>
     <string name="summary_doh_endpoint">HTTPS URL for DNS-over-HTTPS queries</string>
+    <string name="dialog_doh_endpoint">Enter the full HTTPS URL provided by your DNS provider, including its provider-specific path (for example, https://dns.quad9.net/dns-query). Apps excluded from TrackerControl, or using their own encrypted DNS, bypass this setting.</string>
     <string name="setting_doh_dns_fallback">DNS fallback</string>
-    <string name="summary_doh_dns_fallback">Use standard (unencrypted) DNS when DoH is unavailable. Disabling may break apps if the DoH server is down.</string>
+    <string name="summary_doh_dns_fallback">Use standard (unencrypted) DNS when DoH fails. The fallback may use a different DNS provider. Disabling may break apps if the DoH server is down.</string>
+    <string name="msg_invalid_doh_endpoint">Enter a complete HTTPS URL for DNS-over-HTTPS, including the provider\'s path (for example, https://dns.quad9.net/dns-query).</string>
 
     <!-- Block DNS-over-TLS (DoT) -->
     <string name="setting_block_dot">Block Android\'s Private DNS</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -68,6 +68,7 @@
             <EditTextPreference
                 android:defaultValue="https://dns.quad9.net/dns-query"
                 android:dependency="doh_enabled"
+                android:dialogMessage="@string/dialog_doh_endpoint"
                 android:hint="https://dns.quad9.net/dns-query"
                 android:inputType="textUri"
                 android:key="doh_endpoint"

--- a/app/src/test/java/eu/faircode/netguard/ActivitySettingsTest.java
+++ b/app/src/test/java/eu/faircode/netguard/ActivitySettingsTest.java
@@ -17,6 +17,10 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Xml;
 
+import androidx.preference.EditTextPreference;
+import androidx.preference.PreferenceManager;
+import androidx.preference.PreferenceScreen;
+
 import java.io.StringWriter;
 import java.util.Collections;
 import java.util.Set;
@@ -34,6 +38,8 @@ import org.robolectric.RuntimeEnvironment;
 
 @RunWith(RobolectricTestRunner.class)
 public class ActivitySettingsTest {
+    private static final String DOH_ENDPOINT_KEY = "activity_settings_test_doh_endpoint";
+
     private Context context;
 
     @Before
@@ -41,6 +47,7 @@ public class ActivitySettingsTest {
         context = RuntimeEnvironment.getApplication();
         context.getSharedPreferences(TrackerBlocklist.PREF_BLOCKLIST, Context.MODE_PRIVATE)
                 .edit().clear().commit();
+        PreferenceManager.getDefaultSharedPreferences(context).edit().remove(DOH_ENDPOINT_KEY).commit();
         TrackerBlocklist.getInstance(null).clear();
         InternetBlocklist.getInstance(null).clear();
     }
@@ -95,5 +102,72 @@ public class ActivitySettingsTest {
         String xml = writer.toString();
         assertTrue(xml, xml.contains("APPS_BLOCKLIST_PACKAGES_KEY_" + packageName));
         assertTrue(xml, xml.contains("Advertising | Example"));
+    }
+
+    @Test
+    public void dohEndpointListenerAcceptsProviderPathsQueriesAndNormalisesWhitespace() {
+        EditTextPreference preference = dohEndpointPreference("https://old.example/dns-query");
+
+        assertTrue(applyDohEndpoint(preference, "https://dns.quad9.net/dns-query"));
+        assertEquals("https://dns.quad9.net/dns-query", preference.getText());
+        assertEquals("https://dns.quad9.net/dns-query", dohPreferences().getString(DOH_ENDPOINT_KEY, null));
+
+        assertTrue(applyDohEndpoint(preference, "https://dns.example"));
+        assertEquals("https://dns.example", preference.getText());
+        assertTrue(applyDohEndpoint(preference, "https://dns.example/dns-query?ct=application/dns-message"));
+        assertEquals("https://dns.example/dns-query?ct=application/dns-message", preference.getText());
+        assertTrue(applyDohEndpoint(preference, "https://例え.テスト/dns-query"));
+        assertEquals("https://例え.テスト/dns-query", preference.getText());
+
+        assertFalse(applyDohEndpoint(preference, "  https://dns.example/dns-query  "));
+        assertEquals("https://dns.example/dns-query", preference.getText());
+        assertEquals("https://dns.example/dns-query", dohPreferences().getString(DOH_ENDPOINT_KEY, null));
+    }
+
+    @Test
+    public void dohEndpointListenerRejectsInvalidEditsAndPreservesPreviousValue() {
+        EditTextPreference preference = dohEndpointPreference("https://dns.example/dns-query");
+        String[] invalidEndpoints = {
+                "",
+                "  ",
+                "http://dns.example/dns-query",
+                "https:///dns-query",
+                "https://dns.example:invalid/dns-query",
+                "https://dns.example:65536/dns-query",
+                "https://user@dns.example/dns-query",
+                "https://user@例え.テスト/dns-query",
+                "https://dns.example/dns-query#fragment",
+                "https://dns. example/dns-query"
+        };
+
+        for (String invalidEndpoint : invalidEndpoints) {
+            assertFalse(invalidEndpoint, applyDohEndpoint(preference, invalidEndpoint));
+            assertEquals(invalidEndpoint, "https://dns.example/dns-query", preference.getText());
+            assertEquals(invalidEndpoint, "https://dns.example/dns-query",
+                    dohPreferences().getString(DOH_ENDPOINT_KEY, null));
+        }
+    }
+
+    private EditTextPreference dohEndpointPreference(String initialEndpoint) {
+        PreferenceManager manager = new PreferenceManager(context);
+        PreferenceScreen screen = manager.createPreferenceScreen(context);
+        EditTextPreference preference = new EditTextPreference(context);
+        preference.setKey(DOH_ENDPOINT_KEY);
+        screen.addPreference(preference);
+        manager.setPreferences(screen);
+        preference.setText(initialEndpoint);
+        ActivitySettings.configureDohEndpointPreference(preference);
+        return preference;
+    }
+
+    private boolean applyDohEndpoint(EditTextPreference preference, String endpoint) {
+        boolean accepted = preference.callChangeListener(endpoint);
+        if (accepted)
+            preference.setText(endpoint);
+        return accepted;
+    }
+
+    private SharedPreferences dohPreferences() {
+        return PreferenceManager.getDefaultSharedPreferences(context);
     }
 }

--- a/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
+++ b/app/src/test/java/net/kollnig/missioncontrol/dns/DnsProxyServerTest.java
@@ -3,25 +3,83 @@ package net.kollnig.missioncontrol.dns;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import android.content.SharedPreferences;
+
+import androidx.preference.PreferenceManager;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import okio.Buffer;
+
 /**
- * Only covers the query plausibility gate and the SERVFAIL header builder;
- * the rest of DnsProxyServer needs live sockets and a wired VPN context.
+ * Covers the query gates and SERVFAIL builder, plus the endpoint-scoped
+ * circuit breaker through the local UDP and TCP listeners.
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 36)
 public class DnsProxyServerTest {
+    private static final byte[] QUERY = new byte[] {
+            0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    private static final byte[] RESPONSE = new byte[] {
+            0x12, 0x34, (byte) 0x81, (byte) 0x80, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00
+    };
+
+    private SharedPreferences prefs;
+    private DnsProxyServer proxy;
+
+    @Before
+    public void setUp() throws Exception {
+        resetProxySingleton();
+        prefs = PreferenceManager.getDefaultSharedPreferences(RuntimeEnvironment.getApplication());
+        proxy = DnsProxyServer.getInstance(RuntimeEnvironment.getApplication());
+        DnsOverHttpsClient.resetInstance();
+        prefs.edit()
+                .putBoolean("doh_enabled", false)
+                .putBoolean("doh_dns_fallback", false)
+                .remove("doh_endpoint")
+                .commit();
+    }
+
+    @After
+    public void tearDown() {
+        proxy.stop();
+        DnsOverHttpsClient.resetInstance();
+        prefs.edit()
+                .putBoolean("doh_enabled", false)
+                .putBoolean("doh_dns_fallback", false)
+                .remove("doh_endpoint")
+                .commit();
+    }
 
     @Test
     public void rejectsNullAndHeaderlessQueries() {
@@ -104,5 +162,223 @@ public class DnsProxyServerTest {
         ThreadPoolExecutor executor = DnsProxyServer.createRequestExecutor(1, 1);
         executor.shutdownNow();
         assertFalse(DnsProxyServer.tryExecute(executor, () -> { }));
+    }
+
+    @Test
+    public void udpCircuitBreakerSkipsFurtherQueriesForSameEndpoint() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        try {
+            enqueueFailures(server, 12);
+            startProxy(server.url("/dns-query").toString());
+
+            for (int i = 0; i < 4; i++)
+                assertServFail(queryUdp());
+
+            assertEquals(12, server.getRequestCount());
+            assertServFail(queryUdp());
+            assertEquals(12, server.getRequestCount());
+        } finally {
+            proxy.stop();
+            server.close();
+        }
+    }
+
+    @Test
+    public void tcpCircuitBreakerSkipsFurtherQueriesForSameEndpoint() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        try {
+            enqueueFailures(server, 12);
+            startProxy(server.url("/dns-query").toString());
+
+            for (int i = 0; i < 4; i++)
+                assertServFail(queryTcp());
+
+            assertEquals(12, server.getRequestCount());
+            assertServFail(queryTcp());
+            assertEquals(12, server.getRequestCount());
+        } finally {
+            proxy.stop();
+            server.close();
+        }
+    }
+
+    @Test
+    public void changingEndpointGetsImmediateUdpAttempt() throws Exception {
+        MockWebServer oldServer = new MockWebServer();
+        MockWebServer newServer = new MockWebServer();
+        oldServer.start();
+        newServer.start();
+        try {
+            startProxy(oldServer.url("/dns-query").toString());
+            for (int i = 0; i < 10; i++) {
+                oldServer.enqueue(dnsResponse(400, new byte[0]));
+                assertServFail(queryUdp());
+            }
+
+            assertServFail(queryUdp());
+            assertEquals(10, oldServer.getRequestCount());
+
+            String newEndpoint = newServer.url("/dns-query").toString();
+            prefs.edit().putString("doh_endpoint", newEndpoint).commit();
+            newServer.enqueue(dnsResponse(200, RESPONSE));
+
+            assertArrayEquals(RESPONSE, queryUdp());
+            assertEquals(1, newServer.getRequestCount());
+        } finally {
+            proxy.stop();
+            oldServer.close();
+            newServer.close();
+        }
+    }
+
+    @Test
+    public void changingEndpointGetsImmediateTcpAttempt() throws Exception {
+        MockWebServer oldServer = new MockWebServer();
+        MockWebServer newServer = new MockWebServer();
+        oldServer.start();
+        newServer.start();
+        try {
+            startProxy(oldServer.url("/dns-query").toString());
+            for (int i = 0; i < 10; i++) {
+                oldServer.enqueue(dnsResponse(400, new byte[0]));
+                assertServFail(queryTcp());
+            }
+
+            assertServFail(queryTcp());
+            assertEquals(10, oldServer.getRequestCount());
+
+            String newEndpoint = newServer.url("/dns-query").toString();
+            prefs.edit().putString("doh_endpoint", newEndpoint).commit();
+            newServer.enqueue(dnsResponse(200, RESPONSE));
+
+            assertArrayEquals(RESPONSE, queryTcp());
+            assertEquals(1, newServer.getRequestCount());
+        } finally {
+            proxy.stop();
+            oldServer.close();
+            newServer.close();
+        }
+    }
+
+    @Test
+    public void lateOldStateResultsCannotChangeNewEndpointState() {
+        startProxy("https://old.example/dns-query");
+        DnsProxyServer.CircuitState oldState = proxy.getCurrentCircuitState();
+        assertSame(oldState, proxy.getCurrentCircuitState());
+
+        prefs.edit().putString("doh_endpoint", "https://new.example/dns-query").commit();
+        DnsProxyServer.CircuitState newState = proxy.getCurrentCircuitState();
+        assertNotSame(oldState, newState);
+        assertEquals("https://new.example/dns-query", newState.endpoint);
+
+        newState.failures.set(7);
+        newState.openUntil = 123_456;
+        oldState.recordSuccess();
+        oldState.recordFailure(100);
+        oldState.trip(1_000);
+
+        assertEquals(7, newState.failures.get());
+        assertEquals(123_456, newState.openUntil);
+        assertTrue(newState.isOpen(123_455));
+    }
+
+    @Test
+    public void freshStartResetsCircuitState() throws Exception {
+        MockWebServer server = new MockWebServer();
+        server.start();
+        try {
+            String endpoint = server.url("/dns-query").toString();
+            startProxy(endpoint);
+            proxy.getCurrentCircuitState().trip(System.currentTimeMillis());
+            proxy.start(); // Starting an already running proxy must preserve its cooldown.
+
+            assertServFail(queryUdp());
+            assertEquals(0, server.getRequestCount());
+
+            proxy.stop();
+            startProxy(endpoint);
+            server.enqueue(dnsResponse(200, RESPONSE));
+
+            assertArrayEquals(RESPONSE, queryUdp());
+            assertEquals(1, server.getRequestCount());
+        } finally {
+            proxy.stop();
+            server.close();
+        }
+    }
+
+    private void startProxy(String endpoint) {
+        prefs.edit()
+                .putBoolean("doh_enabled", true)
+                .putBoolean("doh_dns_fallback", false)
+                .putString("doh_endpoint", endpoint)
+                .commit();
+        proxy.start();
+        assertTrue(proxy.isRunning());
+    }
+
+    private byte[] queryUdp() throws IOException {
+        try (DatagramSocket socket = new DatagramSocket()) {
+            socket.setSoTimeout(5000);
+            DatagramPacket request = new DatagramPacket(
+                    QUERY, QUERY.length, InetAddress.getByName(DnsProxyServer.DNS_PROXY_ADDRESS),
+                    DnsProxyServer.DNS_PROXY_PORT);
+            socket.send(request);
+
+            byte[] buffer = new byte[65535];
+            DatagramPacket response = new DatagramPacket(buffer, buffer.length);
+            socket.receive(response);
+            return Arrays.copyOf(response.getData(), response.getLength());
+        }
+    }
+
+    private byte[] queryTcp() throws IOException {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(
+                    InetAddress.getByName(DnsProxyServer.DNS_PROXY_ADDRESS),
+                    DnsProxyServer.DNS_PROXY_PORT), 5000);
+            socket.setSoTimeout(5000);
+            DataOutputStream out = new DataOutputStream(socket.getOutputStream());
+            out.writeShort(QUERY.length);
+            out.write(QUERY);
+            out.flush();
+
+            DataInputStream in = new DataInputStream(socket.getInputStream());
+            byte[] response = new byte[in.readUnsignedShort()];
+            in.readFully(response);
+            return response;
+        }
+    }
+
+    private static void assertServFail(byte[] response) {
+        assertTrue(response.length >= 4);
+        assertEquals(QUERY[0], response[0]);
+        assertEquals(QUERY[1], response[1]);
+        assertTrue((response[2] & 0x80) != 0);
+        assertEquals(0x02, response[3] & 0x0F);
+    }
+
+    private static void enqueueFailures(MockWebServer server, int count) {
+        for (int i = 0; i < count; i++)
+            server.enqueue(dnsResponse(503, new byte[0]));
+    }
+
+    private static MockResponse dnsResponse(int status, byte[] body) {
+        return new MockResponse.Builder()
+                .code(status)
+                .addHeader("Content-Type", "application/dns-message")
+                .body(new Buffer().write(body))
+                .build();
+    }
+
+    private static void resetProxySingleton() throws Exception {
+        Field field = DnsProxyServer.class.getDeclaredField("instance");
+        field.setAccessible(true);
+        DnsProxyServer previous = (DnsProxyServer) field.get(null);
+        if (previous != null)
+            previous.stop();
+        field.set(null, null);
     }
 }


### PR DESCRIPTION
Changing a broken DoH endpoint could leave the corrected URL blocked by the previous endpoint's 60-second circuit-breaker cooldown. Invalid URL edits also discarded the selected resolver and reverted to the default.

This change validates endpoint edits before saving, preserves the previous value on rejection, and explains complete endpoint URLs and DNS fallback. UDP and TCP queries now capture endpoint-specific failure state, so a corrected endpoint can be tried immediately and late results from the old endpoint cannot alter its cooldown. Restarting the proxy also clears the previous cooldown; starting an already running proxy preserves it.

Validation: 46 targeted JVM tests passed, including local UDP/TCP socket tests that trip the breaker through failed HTTP requests and then switch to a working endpoint. Android lint completed with 0 errors and 520 warnings. Settings persistence, DNS client behaviour and WireGuard DNS ownership tests passed. No physical-device VPN or notification test was run.

Refs #911. This fixes a recovery failure consistent with the reported sequence; it does not establish the cause of the reporter's Quad9 result, so the issue remains open for confirmation.
