### PR TITLE
Preserve ICMP traceroute probes and relay router errors

### DIFF
--- a/app/src/main/jni/netguard/icmp.c
+++ b/app/src/main/jni/netguard/icmp.c
@@ -18,8 +18,121 @@
 */
 
 #include "netguard.h"
+#include <linux/errqueue.h>
 
 extern FILE *pcap_file;
+
+#ifndef ICMP_DEST_UNREACH
+#define ICMP_DEST_UNREACH 3
+#endif
+#ifndef ICMP_TIME_EXCEEDED
+#define ICMP_TIME_EXCEEDED 11
+#endif
+
+#define ICMP_ERROR_DRAIN_MAX 16
+
+static uint16_t read_u16(const uint8_t *p) {
+    uint16_t value;
+    memcpy(&value, p, sizeof(value));
+    return value;
+}
+
+static void write_u16(uint8_t *p, uint16_t value) {
+    memcpy(p, &value, sizeof(value));
+}
+
+static void write_u32(uint8_t *p, uint32_t value) {
+    memcpy(p, &value, sizeof(value));
+}
+
+static int is_echo_request(int version, const uint8_t *data) {
+    return (version == 4 && data[0] == ICMP_ECHO && data[1] == 0) ||
+           (version == 6 && data[0] == ICMP6_ECHO_REQUEST && data[1] == 0);
+}
+
+static int is_echo_reply(int version, const uint8_t *data) {
+    return (version == 4 && data[0] == ICMP_ECHOREPLY && data[1] == 0) ||
+           (version == 6 && data[0] == ICMP6_ECHO_REPLY && data[1] == 0);
+}
+
+static void expire_icmp_quotes(struct icmp_session *cur, time_t now) {
+    if (cur->quotes == NULL)
+        return;
+
+    for (int i = 0; i < ICMP_QUOTE_SLOTS; i++) {
+        struct icmp_quote *quote = &cur->quotes[i];
+        if (quote->valid && quote->time + ICMP_TIMEOUT <= now)
+            quote->valid = 0;
+    }
+}
+
+static void invalidate_icmp_quote(struct icmp_session *cur, uint16_t seq) {
+    if (cur->quotes == NULL)
+        return;
+
+    for (int i = 0; i < ICMP_QUOTE_SLOTS; i++)
+        if (cur->quotes[i].valid && cur->quotes[i].seq == seq)
+            cur->quotes[i].valid = 0;
+}
+
+static void remember_icmp_quote(struct icmp_session *cur,
+                                const uint8_t *pkt, size_t length,
+                                const uint8_t *payload, uint16_t seq) {
+    if (cur->quotes == NULL)
+        return;
+
+    time_t now = time(NULL);
+    expire_icmp_quotes(cur, now);
+    invalidate_icmp_quote(cur, seq);
+    if (payload < pkt)
+        return;
+
+    size_t ip_offset = (size_t) (payload - pkt);
+    if (ip_offset > ICMP_QUOTE_MAXLEN - ICMP_MINLEN ||
+        length < ip_offset + ICMP_MINLEN)
+        return;
+
+    int slot_index = cur->quote_next % ICMP_QUOTE_SLOTS;
+    struct icmp_quote *slot = &cur->quotes[slot_index];
+
+    size_t quote_len = length < ICMP_QUOTE_MAXLEN ? length : ICMP_QUOTE_MAXLEN;
+    memset(slot, 0, sizeof(*slot));
+    memcpy(slot->packet, pkt, quote_len);
+    slot->time = now;
+    slot->seq = seq;
+    slot->len = (uint16_t) quote_len;
+    slot->ip_offset = (uint16_t) ip_offset;
+    slot->version = (uint8_t) cur->version;
+    slot->valid = 1;
+    cur->quote_next = (uint8_t) ((slot_index + 1) % ICMP_QUOTE_SLOTS);
+}
+
+static struct icmp_quote *find_icmp_quote(struct icmp_session *cur,
+                                          uint16_t seq) {
+    if (cur->quotes == NULL)
+        return NULL;
+
+    expire_icmp_quotes(cur, time(NULL));
+    for (int i = 0; i < ICMP_QUOTE_SLOTS; i++)
+        if (cur->quotes[i].valid && cur->quotes[i].seq == seq)
+            return &cur->quotes[i];
+    return NULL;
+}
+
+static uint16_t icmp_checksum(const struct icmp_session *cur,
+                              const uint8_t *data, size_t length) {
+    uint16_t csum = 0;
+    if (cur->version == 6) {
+        struct ip6_hdr_pseudo pseudo;
+        memset(&pseudo, 0, sizeof(pseudo));
+        memcpy(&pseudo.ip6ph_src, &cur->daddr.ip6, 16);
+        memcpy(&pseudo.ip6ph_dst, &cur->saddr.ip6, 16);
+        pseudo.ip6ph_len = htonl((uint32_t) length);
+        pseudo.ip6ph_nxt = IPPROTO_ICMPV6;
+        csum = calc_checksum(0, (const uint8_t *) &pseudo, sizeof(pseudo));
+    }
+    return (uint16_t) ~calc_checksum(csum, data, length);
+}
 
 int get_icmp_timeout(const struct icmp_session *u, int sessions, int maxsessions) {
     int timeout = ICMP_TIMEOUT;
@@ -33,6 +146,7 @@ int get_icmp_timeout(const struct icmp_session *u, int sessions, int maxsessions
 int check_icmp_session(const struct arguments *args, struct ng_session *s,
                        int sessions, int maxsessions) {
     time_t now = time(NULL);
+    expire_icmp_quotes(&s->icmp, now);
 
     int timeout = get_icmp_timeout(&s->icmp, sessions, maxsessions);
     if (s->icmp.stop || s->icmp.time + timeout < now) {
@@ -59,85 +173,232 @@ int check_icmp_session(const struct arguments *args, struct ng_session *s,
     return 0;
 }
 
+static int accepted_error(int version, uint8_t type) {
+    if (version == 4)
+        return type == ICMP_DEST_UNREACH || type == ICMP_TIME_EXCEEDED;
+    return type == ICMP6_DST_UNREACH || type == ICMP6_TIME_EXCEEDED ||
+           type == ICMP6_PACKET_TOO_BIG;
+}
+
+/* Parse and validate the one error cmsg emitted by a ping socket. */
+static int parse_icmp_error(const struct icmp_session *cur,
+                            const struct msghdr *message,
+                            struct sock_extended_err *error,
+                            struct sockaddr_storage *offender) {
+    if ((message->msg_flags & MSG_CTRUNC) || message->msg_control == NULL ||
+        message->msg_controllen == 0)
+        return 0;
+
+    if (message->msg_name == NULL)
+        return 0;
+    if (cur->version == 4) {
+        if (message->msg_namelen < sizeof(struct sockaddr_in) ||
+            ((const struct sockaddr *) message->msg_name)->sa_family != AF_INET ||
+            ((const struct sockaddr_in *) message->msg_name)->sin_addr.s_addr !=
+                cur->daddr.ip4)
+            return 0;
+    } else {
+        if (message->msg_namelen < sizeof(struct sockaddr_in6) ||
+            ((const struct sockaddr *) message->msg_name)->sa_family != AF_INET6 ||
+            memcmp(&((const struct sockaddr_in6 *) message->msg_name)->sin6_addr,
+                   &cur->daddr.ip6, sizeof(cur->daddr.ip6)) != 0)
+            return 0;
+    }
+
+    const int level = cur->version == 4 ? IPPROTO_IP : IPPROTO_IPV6;
+    const int type = cur->version == 4 ? IP_RECVERR : IPV6_RECVERR;
+    const uint8_t *start = (const uint8_t *) message->msg_control;
+    const uint8_t *end = start + message->msg_controllen;
+    int found = 0;
+    struct msghdr mutable_message = *message;
+
+    for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&mutable_message); cmsg != NULL;
+         cmsg = CMSG_NXTHDR(&mutable_message, cmsg)) {
+        const uint8_t *cstart = (const uint8_t *) cmsg;
+        if (cstart < start || cstart >= end || cmsg->cmsg_len < CMSG_LEN(0) ||
+            (size_t) cmsg->cmsg_len > (size_t) (end - cstart))
+            return 0;
+        if (cmsg->cmsg_level != level || cmsg->cmsg_type != type || found)
+            return 0;
+        if (cmsg->cmsg_len < CMSG_LEN(sizeof(*error)) + sizeof(struct sockaddr))
+            return 0;
+
+        memcpy(error, CMSG_DATA(cmsg), sizeof(*error));
+        const struct sockaddr *source =
+                (const struct sockaddr *) (CMSG_DATA(cmsg) + sizeof(*error));
+        if (source->sa_family != (cur->version == 4 ? AF_INET : AF_INET6))
+            return 0;
+        size_t source_len = cur->version == 4 ? sizeof(struct sockaddr_in)
+                                              : sizeof(struct sockaddr_in6);
+        if (cmsg->cmsg_len < CMSG_LEN(sizeof(*error)) + source_len)
+            return 0;
+        memset(offender, 0, sizeof(*offender));
+        memcpy(offender, source, source_len);
+        found = 1;
+    }
+
+    if (!found)
+        return 0;
+    if (error->ee_origin != (cur->version == 4 ? SO_EE_ORIGIN_ICMP
+                                               : SO_EE_ORIGIN_ICMP6))
+        return 0;
+    if (!accepted_error(cur->version, error->ee_type))
+        return 0;
+    return 1;
+}
+
+static int relay_icmp_error(const struct arguments *args,
+                            struct ng_session *session,
+                            const uint8_t *data, size_t datalen,
+                            const struct msghdr *message) {
+    if (datalen < ICMP_MINLEN || (message->msg_flags & MSG_CTRUNC))
+        return 0;
+
+    struct sock_extended_err error;
+    struct sockaddr_storage offender;
+    if (!parse_icmp_error(&session->icmp, message, &error, &offender))
+        return 0;
+    if (!is_echo_request(session->icmp.version, data))
+        return 0;
+
+    uint16_t seq = read_u16(data + 6);
+    struct icmp_quote *quote = find_icmp_quote(&session->icmp, seq);
+    if (quote == NULL || quote->version != (uint8_t) session->icmp.version ||
+        quote->len < quote->ip_offset + ICMP_MINLEN)
+        return 0;
+
+    union {
+        uint16_t align;
+        uint8_t data[ICMP_MINLEN + ICMP_QUOTE_MAXLEN];
+    } output_storage;
+    uint8_t *output = output_storage.data;
+    memset(output, 0, sizeof(output_storage.data));
+    output[0] = error.ee_type;
+    output[1] = error.ee_code;
+    uint32_t info = htonl(error.ee_info);
+    write_u32(output + 4, info);
+    memcpy(output + ICMP_MINLEN, quote->packet, quote->len);
+
+    /* The error has been consumed even when writing to tun subsequently fails. */
+    quote->valid = 0;
+
+    struct icmp_session output_session = session->icmp;
+    if (session->icmp.version == 4)
+        output_session.daddr.ip4 =
+                ((const struct sockaddr_in *) &offender)->sin_addr.s_addr;
+    else
+        memcpy(&output_session.daddr.ip6,
+               &((const struct sockaddr_in6 *) &offender)->sin6_addr, 16);
+    uint16_t csum = icmp_checksum(&output_session, output,
+                                  ICMP_MINLEN + quote->len);
+    write_u16(output + 2, csum);
+
+    if (write_icmp(args, &output_session, output,
+                   ICMP_MINLEN + quote->len) < 0)
+        return -1;
+    return 1;
+}
+
+static int drain_icmp_errors(const struct arguments *args,
+                             struct ng_session *session) {
+    uint8_t buffer[ICMP_MINLEN];
+    int result = 0;
+
+    for (int count = 0; count < ICMP_ERROR_DRAIN_MAX; count++) {
+        struct sockaddr_storage name;
+        union {
+            struct cmsghdr align;
+            uint8_t data[CMSG_SPACE(sizeof(struct sock_extended_err) +
+                                    sizeof(struct sockaddr_storage))];
+        } control;
+        struct iovec vector = { .iov_base = buffer, .iov_len = sizeof(buffer) };
+        struct msghdr message;
+        memset(&message, 0, sizeof(message));
+        memset(&name, 0, sizeof(name));
+        memset(&control, 0, sizeof(control));
+        message.msg_name = &name;
+        message.msg_namelen = sizeof(name);
+        message.msg_iov = &vector;
+        message.msg_iovlen = 1;
+        message.msg_control = control.data;
+        message.msg_controllen = sizeof(control.data);
+
+        ssize_t bytes = recvmsg(session->socket, &message,
+                                MSG_ERRQUEUE | MSG_DONTWAIT);
+        if (bytes < 0) {
+            if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK)
+                log_android(ANDROID_LOG_WARN, "ICMP recv error queue error %d: %s",
+                            errno, strerror(errno));
+            break;
+        }
+        if (bytes == 0)
+            break;
+
+        result++;
+        session->icmp.time = time(NULL);
+        if (message.msg_flags & MSG_CTRUNC)
+            continue;
+        if (message.msg_flags & MSG_TRUNC && bytes < ICMP_MINLEN)
+            continue;
+
+        int relayed = relay_icmp_error(args, session, buffer, (size_t) bytes,
+                                       &message);
+        if (relayed < 0) {
+            return -1;
+        }
+    }
+
+    return result;
+}
+
 void check_icmp_socket(const struct arguments *args, const struct epoll_event *ev) {
     struct ng_session *s = (struct ng_session *) ev->data.ptr;
 
-    // Check socket error
     if (ev->events & EPOLLERR) {
-        s->icmp.time = time(NULL);
+        if (drain_icmp_errors(args, s) < 0)
+            s->icmp.stop = 1;
 
+        /* Clear a residual SO_ERROR without treating a network error as EOF. */
         int serr = 0;
-        socklen_t optlen = sizeof(int);
+        socklen_t optlen = sizeof(serr);
         int err = getsockopt(s->socket, SOL_SOCKET, SO_ERROR, &serr, &optlen);
         if (err < 0)
-            log_android(ANDROID_LOG_ERROR, "ICMP getsockopt error %d: %s",
+            log_android(ANDROID_LOG_WARN, "ICMP getsockopt error %d: %s",
                         errno, strerror(errno));
         else if (serr)
-            log_android(ANDROID_LOG_ERROR, "ICMP SO_ERROR %d: %s",
+            log_android(ANDROID_LOG_INFO, "ICMP network error %d: %s",
                         serr, strerror(serr));
+    }
 
-        s->icmp.stop = 1;
-    } else {
-        // Check socket read
-        if (ev->events & EPOLLIN) {
-            s->icmp.time = time(NULL);
+    if (ev->events & EPOLLIN) {
+        s->icmp.time = time(NULL);
 
-            uint16_t blen = (uint16_t) (s->icmp.version == 4 ? ICMP4_MAXMSG : ICMP6_MAXMSG);
-            uint8_t *buffer = ng_malloc(blen, "icmp socket");
-            ssize_t bytes = recv(s->socket, buffer, blen, 0);
-            if (bytes < 0) {
-                // Socket error
+        uint16_t blen = (uint16_t) (s->icmp.version == 4 ? ICMP4_MAXMSG : ICMP6_MAXMSG);
+        uint8_t *buffer = ng_malloc(blen, "icmp socket");
+        ssize_t bytes = recv(s->socket, buffer, blen, 0);
+        if (bytes < 0) {
+            if (errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
                 log_android(ANDROID_LOG_WARN, "ICMP recv error %d: %s",
                             errno, strerror(errno));
-
-                if (errno != EINTR && errno != EAGAIN)
-                    s->icmp.stop = 1;
-            } else if (bytes == 0) {
-                log_android(ANDROID_LOG_WARN, "ICMP recv eof");
-                s->icmp.stop = 1;
-
-            } else {
-                // Socket read data
-                char dest[INET6_ADDRSTRLEN + 1];
-                if (s->icmp.version == 4)
-                    inet_ntop(AF_INET, &s->icmp.daddr.ip4, dest, sizeof(dest));
-                else
-                    inet_ntop(AF_INET6, &s->icmp.daddr.ip6, dest, sizeof(dest));
-
-                // cur->id should be equal to icmp->icmp_id
-                // but for some unexplained reason this is not the case
-                // some bits seems to be set extra
-                struct icmp *icmp = (struct icmp *) buffer;
-                log_android(
-                        s->icmp.id == icmp->icmp_id ? ANDROID_LOG_INFO : ANDROID_LOG_WARN,
-                        "ICMP recv bytes %d from %s for tun type %d code %d id %x/%x seq %d",
-                        bytes, dest,
-                        icmp->icmp_type, icmp->icmp_code,
-                        s->icmp.id, icmp->icmp_id, icmp->icmp_seq);
-
-                // restore original ID
-                icmp->icmp_id = s->icmp.id;
-                uint16_t csum = 0;
-                if (s->icmp.version == 6) {
-                    // Untested
-                    struct ip6_hdr_pseudo pseudo;
-                    memset(&pseudo, 0, sizeof(struct ip6_hdr_pseudo));
-                    memcpy(&pseudo.ip6ph_src, &s->icmp.daddr.ip6, 16);
-                    memcpy(&pseudo.ip6ph_dst, &s->icmp.saddr.ip6, 16);
-                    pseudo.ip6ph_len = htonl((uint32_t) bytes);
-                    pseudo.ip6ph_nxt = IPPROTO_ICMPV6;
-                    csum = calc_checksum(
-                            0, (uint8_t *) &pseudo, sizeof(struct ip6_hdr_pseudo));
-                }
-                icmp->icmp_cksum = 0;
-                icmp->icmp_cksum = ~calc_checksum(csum, buffer, (size_t) bytes);
-
-                // Forward to tun
-                if (write_icmp(args, &s->icmp, buffer, (size_t) bytes) < 0)
+                if (errno == EBADF || errno == ENOTSOCK || errno == EINVAL)
                     s->icmp.stop = 1;
             }
-            ng_free(buffer, __FILE__, __LINE__);
+        } else if (bytes == 0) {
+            log_android(ANDROID_LOG_WARN, "ICMP recv eof");
+            s->icmp.stop = 1;
+        } else if (bytes >= ICMP_MINLEN && is_echo_reply(s->icmp.version, buffer)) {
+            uint16_t seq = read_u16(buffer + 6);
+            invalidate_icmp_quote(&s->icmp, seq);
+            write_u16(buffer + 4, s->icmp.id);
+            write_u16(buffer + 2, 0);
+            write_u16(buffer + 2, icmp_checksum(&s->icmp, buffer, (size_t) bytes));
+
+            if (write_icmp(args, &s->icmp, buffer, (size_t) bytes) < 0)
+                s->icmp.stop = 1;
+        } else if (bytes < ICMP_MINLEN) {
+            log_android(ANDROID_LOG_WARN, "ICMP short reply %d", bytes);
         }
+        ng_free(buffer, __FILE__, __LINE__);
     }
 }
 
@@ -146,12 +407,27 @@ jboolean handle_icmp(const struct arguments *args,
                      const uint8_t *payload,
                      int uid,
                      const int epoll_fd) {
-    // Get headers
+    if (pkt == NULL || payload == NULL || length == 0 || payload < pkt)
+        return 0;
+
     const uint8_t version = (*pkt) >> 4;
-    const struct iphdr *ip4 = (struct iphdr *) pkt;
-    const struct ip6_hdr *ip6 = (struct ip6_hdr *) pkt;
-    struct icmp *icmp = (struct icmp *) payload;
-    size_t icmplen = length - (payload - pkt);
+    const struct iphdr *ip4 = (const struct iphdr *) pkt;
+    const struct ip6_hdr *ip6 = (const struct ip6_hdr *) pkt;
+    size_t payload_offset = (size_t) (payload - pkt);
+    if ((version == 4 && (length < sizeof(struct iphdr) ||
+                          ip4->ihl < 5 ||
+                          payload_offset < (size_t) ip4->ihl * 4)) ||
+        (version == 6 && (length < sizeof(struct ip6_hdr) ||
+                          payload_offset < sizeof(struct ip6_hdr))) ||
+        payload_offset > length || length - payload_offset < ICMP_MINLEN)
+        return 0;
+
+    const uint8_t *icmp = payload;
+    if (!is_echo_request(version, icmp)) {
+        log_android(ANDROID_LOG_WARN, "ICMP type %d code %d not supported",
+                    icmp[0], icmp[1]);
+        return 0;
+    }
 
     char source[INET6_ADDRSTRLEN + 1];
     char dest[INET6_ADDRSTRLEN + 1];
@@ -163,35 +439,32 @@ jboolean handle_icmp(const struct arguments *args,
         inet_ntop(AF_INET6, &ip6->ip6_dst, dest, sizeof(dest));
     }
 
-    if (!((version == 4 && icmp->icmp_type == ICMP_ECHO) ||
-          (version == 6 && icmp->icmp_type == ICMP6_ECHO_REQUEST))) {
-        log_android(ANDROID_LOG_WARN, "ICMP type %d code %d from %s to %s not supported",
-                    icmp->icmp_type, icmp->icmp_code, source, dest);
-        return 0;
-    }
-
-    // Search session
+    uint16_t original_id = read_u16(icmp + 4);
     struct ng_session *cur = args->ctx->ng_session;
     while (cur != NULL &&
            !((cur->protocol == IPPROTO_ICMP || cur->protocol == IPPROTO_ICMPV6) &&
              !cur->icmp.stop && cur->icmp.version == version &&
+             cur->icmp.id == original_id &&
              (version == 4 ? cur->icmp.saddr.ip4 == ip4->saddr &&
                              cur->icmp.daddr.ip4 == ip4->daddr
                            : memcmp(&cur->icmp.saddr.ip6, &ip6->ip6_src, 16) == 0 &&
                              memcmp(&cur->icmp.daddr.ip6, &ip6->ip6_dst, 16) == 0)))
         cur = cur->next;
 
-    // Create new session if needed
     if (cur == NULL) {
-        log_android(ANDROID_LOG_INFO, "ICMP new session from %s to %s", source, dest);
+        log_android(ANDROID_LOG_INFO, "ICMP new session from %s to %s id %x",
+                    source, dest, original_id);
 
-        // Register session
-        struct ng_session *s = ng_malloc(sizeof(struct ng_session), "icmp session");
+        size_t allocation = sizeof(struct ng_session) +
+                            ICMP_QUOTE_SLOTS * sizeof(struct icmp_quote);
+        struct ng_session *s = ng_malloc(allocation, "icmp session");
+        memset(s, 0, allocation);
         s->protocol = (uint8_t) (version == 4 ? IPPROTO_ICMP : IPPROTO_ICMPV6);
-
         s->icmp.time = time(NULL);
         s->icmp.uid = uid;
         s->icmp.version = version;
+        s->icmp.id = original_id;
+        s->icmp.quotes = (struct icmp_quote *) (s + 1);
 
         if (version == 4) {
             s->icmp.saddr.ip4 = (__be32) ip4->saddr;
@@ -201,26 +474,18 @@ jboolean handle_icmp(const struct arguments *args,
             memcpy(&s->icmp.daddr.ip6, &ip6->ip6_dst, 16);
         }
 
-        s->icmp.id = icmp->icmp_id; // store original ID
-
-        s->icmp.stop = 0;
-        s->next = NULL;
-
-        // Open UDP socket
         s->socket = open_icmp_socket(args, &s->icmp);
         if (s->socket < 0) {
             ng_free(s, __FILE__, __LINE__);
             return 0;
         }
 
-        log_android(ANDROID_LOG_DEBUG, "ICMP socket %d id %x", s->socket, s->icmp.id);
-
-        // Monitor events
-        memset(&s->ev, 0, sizeof(struct epoll_event));
+        memset(&s->ev, 0, sizeof(s->ev));
         s->ev.events = EPOLLIN | EPOLLERR;
         s->ev.data.ptr = s;
         if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, s->socket, &s->ev)) {
-            log_android(ANDROID_LOG_ERROR, "epoll add icmp error %d: %s", errno, strerror(errno));
+            log_android(ANDROID_LOG_ERROR, "epoll add icmp error %d: %s",
+                        errno, strerror(errno));
             close(s->socket);
             ng_free(s, __FILE__, __LINE__);
             return 0;
@@ -228,79 +493,102 @@ jboolean handle_icmp(const struct arguments *args,
 
         s->next = args->ctx->ng_session;
         args->ctx->ng_session = s;
-
         cur = s;
     }
 
-    // Modify ID
-    // http://lwn.net/Articles/443051/
-    icmp->icmp_id = ~icmp->icmp_id;
-    uint16_t csum = 0;
-    if (version == 6) {
-        // Untested
-        struct ip6_hdr_pseudo pseudo;
-        memset(&pseudo, 0, sizeof(struct ip6_hdr_pseudo));
-        memcpy(&pseudo.ip6ph_src, &ip6->ip6_dst, 16);
-        memcpy(&pseudo.ip6ph_dst, &ip6->ip6_src, 16);
-        pseudo.ip6ph_len = ip6->ip6_ctlun.ip6_un1.ip6_un1_plen;
-        pseudo.ip6ph_nxt = ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt;
-        csum = calc_checksum(0, (uint8_t *) &pseudo, sizeof(struct ip6_hdr_pseudo));
+    /* Clear an earlier asynchronous error before this probe is queued. */
+    if (drain_icmp_errors(args, cur) < 0) {
+        cur->icmp.stop = 1;
+        return 0;
     }
-    icmp->icmp_cksum = 0;
-    icmp->icmp_cksum = ~calc_checksum(csum, (uint8_t *) icmp, icmplen);
 
-    log_android(ANDROID_LOG_INFO,
-                "ICMP forward from tun %s to %s type %d code %d id %x seq %d data %d",
-                source, dest,
-                icmp->icmp_type, icmp->icmp_code, icmp->icmp_id, icmp->icmp_seq, icmplen);
+    /* Ping sockets rewrite the identifier and checksum themselves. */
+    int hop = version == 4 ? ip4->ttl : ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim;
+    int level = version == 4 ? IPPROTO_IP : IPPROTO_IPV6;
+    int option = version == 4 ? IP_TTL : IPV6_UNICAST_HOPS;
+    if (setsockopt(cur->socket, level, option, &hop, sizeof(hop)) < 0) {
+        log_android(ANDROID_LOG_ERROR, "ICMP hop limit setup error %d: %s",
+                    errno, strerror(errno));
+        cur->icmp.stop = 1;
+        return 0;
+    }
 
-    cur->icmp.time = time(NULL);
-
-    struct sockaddr_in server4 = {0};
-    struct sockaddr_in6 server6 = {0};
+    uint16_t seq = read_u16(icmp + 6);
+    size_t icmplen = length - payload_offset;
+    struct sockaddr_in server4;
+    struct sockaddr_in6 server6;
+    memset(&server4, 0, sizeof(server4));
+    memset(&server6, 0, sizeof(server6));
     if (version == 4) {
         server4.sin_family = AF_INET;
-        server4.sin_addr.s_addr = (__be32) ip4->daddr;
-        server4.sin_port = 0;
+        server4.sin_addr.s_addr = ip4->daddr;
     } else {
         server6.sin6_family = AF_INET6;
-        memcpy(&server6.sin6_addr, &ip6->ip6_dst, 16);
-        server6.sin6_port = 0;
+        server6.sin6_addr = ip6->ip6_dst;
     }
+    int retried = 0;
+    for (;;) {
+        remember_icmp_quote(&cur->icmp, pkt, length, payload, seq);
+        ssize_t sent = sendto(cur->socket, payload, (socklen_t) icmplen, MSG_NOSIGNAL,
+                              version == 4 ? (const struct sockaddr *) &server4
+                                           : (const struct sockaddr *) &server6,
+                              version == 4 ? sizeof(server4) : sizeof(server6));
+        if (sent == (ssize_t) icmplen) {
+            cur->icmp.time = time(NULL);
+            break;
+        }
 
-    // Send raw ICMP message
-    if (sendto(cur->socket, icmp, (socklen_t) icmplen, MSG_NOSIGNAL,
-               (version == 4 ? (const struct sockaddr *) &server4
-                             : (const struct sockaddr *) &server6),
-               (socklen_t) (version == 4 ? sizeof(server4) : sizeof(server6))) != icmplen) {
-        log_android(ANDROID_LOG_ERROR, "ICMP sendto error %d: %s", errno, strerror(errno));
-        if (errno != EINTR && errno != EAGAIN) {
+        int send_error = errno;
+        invalidate_icmp_quote(&cur->icmp, seq);
+        log_android(ANDROID_LOG_WARN, "ICMP sendto error %d: %s",
+                    send_error, strerror(send_error));
+
+        /* A kernel error may be queued just before sendto reports it.  Drain
+         * once and retry once when that drain consumed an error; never spin. */
+        int drained = drain_icmp_errors(args, cur);
+        if (drained < 0) {
             cur->icmp.stop = 1;
             return 0;
         }
+        if (!retried && drained > 0) {
+            retried = 1;
+            continue;
+        }
+
+        /* Network failures are asynchronous and do not invalidate the
+         * session; the next probe gets its own bounded retry opportunity. */
+        if (send_error != EINTR && send_error != EAGAIN &&
+            send_error != EWOULDBLOCK)
+            log_android(ANDROID_LOG_INFO, "ICMP network send deferred");
+        break;
     }
 
     return 1;
 }
 
 int open_icmp_socket(const struct arguments *args, const struct icmp_session *cur) {
-    int sock;
-
-    // Get UDP socket
-    sock = socket(cur->version == 4 ? PF_INET : PF_INET6, SOCK_DGRAM,
-                  cur->version == 4 ? IPPROTO_ICMP : IPPROTO_ICMPV6);
+    int sock = socket(cur->version == 4 ? PF_INET : PF_INET6, SOCK_DGRAM,
+                      cur->version == 4 ? IPPROTO_ICMP : IPPROTO_ICMPV6);
     if (sock < 0) {
         log_android(ANDROID_LOG_ERROR, "ICMP socket error %d: %s", errno, strerror(errno));
         return -1;
     }
 
-    // Protect socket
     if (protect_socket(args, sock) < 0) {
         close(sock);
         return -1;
     }
 
-    // Set non blocking so epoll handlers never stall the VPN thread.
+    int enable = 1;
+    int level = cur->version == 4 ? IPPROTO_IP : IPPROTO_IPV6;
+    int option = cur->version == 4 ? IP_RECVERR : IPV6_RECVERR;
+    if (setsockopt(sock, level, option, &enable, sizeof(enable)) < 0) {
+        log_android(ANDROID_LOG_ERROR, "ICMP error queue setup error %d: %s",
+                    errno, strerror(errno));
+        close(sock);
+        return -1;
+    }
+
     int flags = fcntl(sock, F_GETFL, 0);
     if (flags < 0 || fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
         log_android(ANDROID_LOG_ERROR, "fcntl socket O_NONBLOCK error %d: %s",
@@ -316,15 +604,17 @@ ssize_t write_icmp(const struct arguments *args, const struct icmp_session *cur,
                    uint8_t *data, size_t datalen) {
     size_t len;
     u_int8_t *buffer;
-    struct icmp *icmp = (struct icmp *) data;
-    char source[INET6_ADDRSTRLEN + 1];
-    char dest[INET6_ADDRSTRLEN + 1];
+    uint8_t type = datalen >= 1 ? data[0] : 0;
+    uint8_t code = datalen >= 2 ? data[1] : 0;
+    uint16_t id = datalen >= 6 ? read_u16(data + 4) : 0;
+    uint16_t seq = datalen >= 8 ? read_u16(data + 6) : 0;
 
     // Build packet
     if (cur->version == 4) {
         len = sizeof(struct iphdr) + datalen;
         buffer = ng_malloc(len, "icmp write4");
         struct iphdr *ip4 = (struct iphdr *) buffer;
+
         if (datalen)
             memcpy(buffer + sizeof(struct iphdr), data, datalen);
 
@@ -337,7 +627,6 @@ ssize_t write_icmp(const struct arguments *args, const struct icmp_session *cur,
         ip4->protocol = IPPROTO_ICMP;
         ip4->saddr = cur->daddr.ip4;
         ip4->daddr = cur->saddr.ip4;
-
         // Calculate IP4 checksum
         ip4->check = ~calc_checksum(0, (uint8_t *) ip4, sizeof(struct iphdr));
     } else {
@@ -350,7 +639,7 @@ ssize_t write_icmp(const struct arguments *args, const struct icmp_session *cur,
         // Build IP6 header
         memset(ip6, 0, sizeof(struct ip6_hdr));
         ip6->ip6_ctlun.ip6_un1.ip6_un1_flow = 0;
-        ip6->ip6_ctlun.ip6_un1.ip6_un1_plen = htons(len - sizeof(struct ip6_hdr));
+        ip6->ip6_ctlun.ip6_un1.ip6_un1_plen = htons(len - sizeof(*ip6));
         ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt = IPPROTO_ICMPV6;
         ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim = IPDEFTTL;
         ip6->ip6_ctlun.ip6_un2_vfc = IPV6_VERSION;
@@ -358,18 +647,21 @@ ssize_t write_icmp(const struct arguments *args, const struct icmp_session *cur,
         memcpy(&(ip6->ip6_dst), &cur->saddr.ip6, 16);
     }
 
+    char source[INET6_ADDRSTRLEN + 1];
+    char dest[INET6_ADDRSTRLEN + 1];
     inet_ntop(cur->version == 4 ? AF_INET : AF_INET6,
-              cur->version == 4 ? (const void *) &cur->saddr.ip4 : (const void *) &cur->saddr.ip6,
+              cur->version == 4 ? (const void *) &cur->saddr.ip4
+                                : (const void *) &cur->saddr.ip6,
               source, sizeof(source));
     inet_ntop(cur->version == 4 ? AF_INET : AF_INET6,
-              cur->version == 4 ? (const void *) &cur->daddr.ip4 : (const void *) &cur->daddr.ip6,
+              cur->version == 4 ? (const void *) &cur->daddr.ip4
+                                : (const void *) &cur->daddr.ip6,
               dest, sizeof(dest));
 
-    // Send raw ICMP message
+    // Send ICMP message to tun
     log_android(ANDROID_LOG_WARN,
                 "ICMP sending to tun %d from %s to %s data %u type %d code %d id %x seq %d",
-                args->tun, dest, source, datalen,
-                icmp->icmp_type, icmp->icmp_code, icmp->icmp_id, icmp->icmp_seq);
+                args->tun, dest, source, datalen, type, code, id, seq);
 
     ssize_t res = write(args->tun, buffer, len);
 
@@ -381,11 +673,9 @@ ssize_t write_icmp(const struct arguments *args, const struct icmp_session *cur,
         log_android(ANDROID_LOG_WARN, "ICMP write error %d: %s", errno, strerror(errno));
 
     ng_free(buffer, __FILE__, __LINE__);
-
     if (res != len) {
         log_android(ANDROID_LOG_ERROR, "write %d/%d", res, len);
         return -1;
     }
-
     return res;
 }

--- a/app/src/main/jni/netguard/netguard.h
+++ b/app/src/main/jni/netguard/netguard.h
@@ -68,6 +68,8 @@
 #define TCP_MSS_CLAMP 1360 // bytes
 
 #define ICMP_TIMEOUT 5 // seconds
+#define ICMP_QUOTE_SLOTS 16
+#define ICMP_QUOTE_MAXLEN 128
 
 #define UDP_TIMEOUT_53 15 // seconds
 #define UDP_TIMEOUT_ANY 300 // seconds
@@ -157,6 +159,22 @@ struct icmp_session {
     uint16_t id;
 
     uint8_t stop;
+    uint8_t quote_next;
+
+    // Original packets used to correlate ICMP error-queue messages.  The
+    // records are allocated immediately after ng_session so generic session
+    // cleanup remains sufficient and non-ICMP sessions do not grow.
+    struct icmp_quote *quotes;
+};
+
+struct icmp_quote {
+    time_t time;
+    uint16_t seq;
+    uint16_t len;
+    uint16_t ip_offset;
+    uint8_t version;
+    uint8_t valid;
+    uint8_t packet[ICMP_QUOTE_MAXLEN];
 };
 
 struct udp_session {

--- a/app/src/test/native/host_compat/linux/errqueue.h
+++ b/app/src/test/native/host_compat/linux/errqueue.h
@@ -1,0 +1,37 @@
+#ifndef TRACKERCONTROL_NATIVE_TEST_LINUX_ERRQUEUE_H
+#define TRACKERCONTROL_NATIVE_TEST_LINUX_ERRQUEUE_H
+
+#if defined(__linux__)
+#include_next <linux/errqueue.h>
+#else
+#include <stdint.h>
+#include <sys/socket.h>
+
+struct sock_extended_err {
+    uint32_t ee_errno;
+    uint8_t ee_origin;
+    uint8_t ee_type;
+    uint8_t ee_code;
+    uint8_t ee_pad;
+    uint32_t ee_info;
+    uint32_t ee_data;
+};
+
+#ifndef IP_RECVERR
+#define IP_RECVERR 11
+#endif
+#ifndef IPV6_RECVERR
+#define IPV6_RECVERR 25
+#endif
+#ifndef SO_EE_ORIGIN_ICMP
+#define SO_EE_ORIGIN_ICMP 2
+#endif
+#ifndef SO_EE_ORIGIN_ICMP6
+#define SO_EE_ORIGIN_ICMP6 3
+#endif
+#ifndef MSG_ERRQUEUE
+#define MSG_ERRQUEUE 0x2000
+#endif
+#endif
+
+#endif

--- a/app/src/test/native/host_compat/linux_test.h
+++ b/app/src/test/native/host_compat/linux_test.h
@@ -26,4 +26,33 @@ struct ippseudo {
 _Static_assert(sizeof(struct ippseudo) == 12, "IPv4 pseudo-header wire size");
 #endif
 
+/* Darwin has the BSD IPv4 header but no Linux struct iphdr. */
+#if !defined(__linux__) && !defined(__ANDROID__)
+#include <stdint.h>
+#ifndef IP_MAXPACKET
+#define IP_MAXPACKET 65535
+#endif
+#ifndef IPDEFTTL
+#define IPDEFTTL 64
+#endif
+struct iphdr {
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    uint8_t ihl : 4;
+    uint8_t version : 4;
+#else
+    uint8_t version : 4;
+    uint8_t ihl : 4;
+#endif
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t saddr;
+    uint32_t daddr;
+};
+#endif
+
 #endif

--- a/app/src/test/native/icmp_defensive_test.c
+++ b/app/src/test/native/icmp_defensive_test.c
@@ -21,6 +21,7 @@ static int fcntl_fail_set;
 static int socket_calls;
 static int close_calls;
 static int sendto_calls;
+static int setsockopt_fail;
 static int last_sendto_family;
 static struct sockaddr_storage last_sendto_address;
 
@@ -78,6 +79,53 @@ int __wrap_close(int file_descriptor) {
     (void) file_descriptor;
     close_calls++;
     return 0;
+}
+
+int __wrap_setsockopt(int socket, int level, int option,
+                      const void *value, socklen_t value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    if (setsockopt_fail) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+ssize_t __wrap_recvmsg(int socket, struct msghdr *message, int flags) {
+    (void) socket;
+    (void) message;
+    (void) flags;
+    errno = EAGAIN;
+    return -1;
+}
+
+int __wrap_getsockopt(int socket, int level, int option,
+                      void *value, socklen_t *value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    return 0;
+}
+
+ssize_t __wrap_recv(int socket, void *buffer, size_t length, int flags) {
+    (void) socket;
+    (void) buffer;
+    (void) length;
+    (void) flags;
+    errno = EAGAIN;
+    return -1;
+}
+
+ssize_t __wrap_write(int file_descriptor, const void *buffer, size_t length) {
+    (void) file_descriptor;
+    (void) buffer;
+    return (ssize_t) length;
 }
 
 int __wrap_fcntl(int file_descriptor, int command, ...) {
@@ -176,6 +224,7 @@ static void test_epoll_add_failure_does_not_retain_session(void) {
     args.ctx = &context;
     protect_result = 0;
     epoll_result = -1;
+    setsockopt_fail = 0;
     close_calls = 0;
     sendto_calls = 0;
 

--- a/app/src/test/native/icmp_error_test.c
+++ b/app/src/test/native/icmp_error_test.c
@@ -1,0 +1,645 @@
+/* Host regression tests for ICMP error-queue correlation and relay safety. */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netguard.h"
+
+#ifndef IP_RECVERR
+#define IP_RECVERR 11
+#endif
+#ifndef SO_EE_ORIGIN_ICMP
+#define SO_EE_ORIGIN_ICMP 2
+#endif
+#ifndef ICMP_TIME_EXCEEDED
+#define ICMP_TIME_EXCEEDED 11
+#endif
+#ifndef MSG_ERRQUEUE
+#define MSG_ERRQUEUE 0x2000
+#endif
+#define TEST_ICMP_ERROR_DRAIN_MAX 16
+
+struct fake_extended_err {
+    uint32_t ee_errno;
+    uint8_t ee_origin;
+    uint8_t ee_type;
+    uint8_t ee_code;
+    uint8_t ee_pad;
+    uint32_t ee_info;
+    uint32_t ee_data;
+};
+
+static int failures;
+static int socket_calls;
+static int close_calls;
+static int sendto_calls;
+static int setsockopt_calls;
+static int recvmsg_calls;
+static int getsockopt_calls;
+static int write_calls;
+static int fcntl_flags;
+static int fake_queue_count;
+static int fake_queue_index;
+static int fake_queue_bad_control;
+static int fake_queue_bad_origin;
+static int fake_queue_bad_offender;
+static int fake_queue_bad_destination;
+static int fake_queue_bad_length;
+static int fake_sendto_fail_once;
+static int fake_sendto_attempts;
+static uint16_t fake_queue_sequence;
+static uint16_t fake_queue_sequences[32];
+static uint8_t fake_reply[64];
+static size_t fake_reply_length;
+static uint8_t last_write[512];
+static size_t last_write_length;
+static uint8_t write_history[8][512];
+static size_t write_history_lengths[8];
+static uint8_t original_packet[128];
+static size_t original_length;
+
+FILE *pcap_file;
+
+#define CHECK(condition, message)                                           \
+    do {                                                                    \
+        if (!(condition)) {                                                 \
+            fprintf(stderr, "FAIL: %s\n", (message));                     \
+            failures++;                                                     \
+        }                                                                   \
+    } while (0)
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+    (void) format;
+}
+
+void *ng_malloc(size_t size, const char *tag) {
+    (void) tag;
+    void *pointer = calloc(1, size);
+    if (pointer == NULL)
+        abort();
+    return pointer;
+}
+
+void ng_free(void *pointer, const char *file, int line) {
+    (void) file;
+    (void) line;
+    free(pointer);
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+}
+
+int protect_socket(const struct arguments *args, int socket) {
+    (void) args;
+    (void) socket;
+    return 0;
+}
+
+int __wrap_socket(int domain, int type, int protocol) {
+    (void) domain;
+    (void) type;
+    (void) protocol;
+    return 200 + ++socket_calls;
+}
+
+int __wrap_close(int file_descriptor) {
+    (void) file_descriptor;
+    close_calls++;
+    return 0;
+}
+
+int __wrap_fcntl(int file_descriptor, int command, ...) {
+    (void) file_descriptor;
+    if (command == F_GETFL)
+        return fcntl_flags;
+    if (command == F_SETFL) {
+        va_list args;
+        va_start(args, command);
+        fcntl_flags = va_arg(args, int);
+        va_end(args);
+        return 0;
+    }
+    errno = EINVAL;
+    return -1;
+}
+
+int epoll_ctl(int epoll_fd, int operation, int descriptor,
+              struct epoll_event *event) {
+    (void) epoll_fd;
+    (void) operation;
+    (void) descriptor;
+    (void) event;
+    return 0;
+}
+
+int __wrap_setsockopt(int socket, int level, int option,
+                      const void *value, socklen_t value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    setsockopt_calls++;
+    return 0;
+}
+
+int __wrap_getsockopt(int socket, int level, int option,
+                      void *value, socklen_t *value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    getsockopt_calls++;
+    return 0;
+}
+
+ssize_t __wrap_sendto(int socket, const void *buffer, size_t length, int flags,
+                      const struct sockaddr *destination,
+                      socklen_t destination_length) {
+    (void) socket;
+    (void) buffer;
+    (void) length;
+    (void) flags;
+    (void) destination;
+    (void) destination_length;
+    sendto_calls++;
+    fake_sendto_attempts++;
+    if (fake_sendto_fail_once && fake_sendto_attempts == 1) {
+        fake_queue_count = 1;
+        fake_queue_index = 0;
+        errno = EHOSTUNREACH;
+        return -1;
+    }
+    return (ssize_t) length;
+}
+
+ssize_t __wrap_write(int file_descriptor, const void *buffer, size_t length) {
+    (void) file_descriptor;
+    if (write_calls < (int) (sizeof(write_history) / sizeof(write_history[0]))) {
+        size_t copy = length < sizeof(write_history[0]) ? length : sizeof(write_history[0]);
+        memcpy(write_history[write_calls], buffer, copy);
+        write_history_lengths[write_calls] = copy;
+    }
+    write_calls++;
+    last_write_length = length < sizeof(last_write) ? length : sizeof(last_write);
+    memcpy(last_write, buffer, last_write_length);
+    return (ssize_t) length;
+}
+
+ssize_t __wrap_recv(int socket, void *buffer, size_t length, int flags) {
+    (void) socket;
+    (void) flags;
+    if (fake_reply_length == 0) {
+        errno = EAGAIN;
+        return -1;
+    }
+    size_t copy = fake_reply_length < length ? fake_reply_length : length;
+    memcpy(buffer, fake_reply, copy);
+    fake_reply_length = 0;
+    return (ssize_t) copy;
+}
+
+ssize_t __wrap_recvmsg(int socket, struct msghdr *message, int flags) {
+    (void) socket;
+    (void) flags;
+    recvmsg_calls++;
+    if (fake_queue_index >= fake_queue_count) {
+        errno = EAGAIN;
+        return -1;
+    }
+
+    fake_queue_index++;
+    uint8_t *data = message->msg_iov[0].iov_base;
+    memset(data, 0, message->msg_iov[0].iov_len);
+    data[0] = ICMP_ECHO;
+    data[1] = 0;
+    uint16_t id = htons(0xaaaa);
+    uint16_t queued_sequence = fake_queue_sequences[fake_queue_index - 1];
+    if (queued_sequence == 0)
+        queued_sequence = fake_queue_sequence;
+    uint16_t seq = htons(queued_sequence);
+    memcpy(data + 4, &id, sizeof(id));
+    memcpy(data + 6, &seq, sizeof(seq));
+
+    struct sockaddr_in *destination = (struct sockaddr_in *) message->msg_name;
+    memset(destination, 0, sizeof(*destination));
+    destination->sin_family = AF_INET;
+    destination->sin_addr.s_addr = inet_addr(fake_queue_bad_destination
+                                             ? "198.51.100.2" : "198.51.100.1");
+
+    if (fake_queue_bad_control) {
+        message->msg_flags = MSG_CTRUNC;
+        return ICMP_MINLEN;
+    }
+
+    struct cmsghdr *cmsg = (struct cmsghdr *) message->msg_control;
+    memset(cmsg, 0, message->msg_controllen);
+    cmsg->cmsg_level = IPPROTO_IP;
+    cmsg->cmsg_type = IP_RECVERR;
+    cmsg->cmsg_len = CMSG_LEN(sizeof(struct fake_extended_err) +
+                               sizeof(struct sockaddr_in));
+    if (fake_queue_bad_length)
+        cmsg->cmsg_len = CMSG_LEN(sizeof(struct fake_extended_err)) - 1;
+    struct fake_extended_err error = {0};
+    error.ee_origin = fake_queue_bad_origin ? SO_EE_ORIGIN_ICMP + 1
+                                             : SO_EE_ORIGIN_ICMP;
+    error.ee_type = ICMP_TIME_EXCEEDED;
+    error.ee_code = 0;
+    memcpy(CMSG_DATA(cmsg), &error, sizeof(error));
+    struct sockaddr_in *offender = (struct sockaddr_in *)
+            (CMSG_DATA(cmsg) + sizeof(error));
+    memset(offender, 0, sizeof(*offender));
+    offender->sin_family = fake_queue_bad_offender ? AF_INET6 : AF_INET;
+    offender->sin_addr.s_addr = inet_addr("203.0.113.9");
+    message->msg_controllen = cmsg->cmsg_len;
+    message->msg_flags = 0;
+    return ICMP_MINLEN;
+}
+
+uint16_t calc_checksum(uint16_t start, const uint8_t *buffer, size_t length) {
+    uint32_t sum = start;
+    while (length > 1) {
+        uint16_t word;
+        memcpy(&word, buffer, sizeof(word));
+        sum += word;
+        buffer += 2;
+        length -= 2;
+    }
+    if (length != 0)
+        sum += *buffer;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return (uint16_t) sum;
+}
+
+static size_t make_echo(uint8_t *packet, uint16_t id, uint16_t seq) {
+    memset(packet, 0, 64);
+    struct iphdr *ip4 = (struct iphdr *) packet;
+    ip4->version = 4;
+    ip4->ihl = 5;
+    ip4->ttl = 7;
+    ip4->protocol = IPPROTO_ICMP;
+    ip4->saddr = inet_addr("192.0.2.1");
+    ip4->daddr = inet_addr("198.51.100.1");
+    struct icmp *icmp = (struct icmp *) (packet + 20);
+    icmp->icmp_type = ICMP_ECHO;
+    icmp->icmp_id = htons(id);
+    icmp->icmp_seq = htons(seq);
+    memcpy(packet + 28, "quote-ok", 8);
+    return 36;
+}
+
+static size_t make_echo_with_options(uint8_t *packet, uint16_t id, uint16_t seq) {
+    memset(packet, 0, 64);
+    struct iphdr *ip4 = (struct iphdr *) packet;
+    ip4->version = 4;
+    ip4->ihl = 6;
+    ip4->tot_len = htons(40);
+    ip4->ttl = 7;
+    ip4->protocol = IPPROTO_ICMP;
+    ip4->saddr = inet_addr("192.0.2.1");
+    ip4->daddr = inet_addr("198.51.100.1");
+    packet[20] = 1;
+    packet[21] = 2;
+    packet[22] = 3;
+    packet[23] = 4;
+    struct icmp *icmp = (struct icmp *) (packet + 24);
+    icmp->icmp_type = ICMP_ECHO;
+    icmp->icmp_id = htons(id);
+    icmp->icmp_seq = htons(seq);
+    memcpy(packet + 32, "optquote", 8);
+    return 40;
+}
+
+static void reset_queue(void) {
+    fake_queue_count = 0;
+    fake_queue_index = 0;
+    fake_queue_bad_control = 0;
+    fake_queue_bad_origin = 0;
+    fake_queue_bad_offender = 0;
+    fake_queue_bad_destination = 0;
+    fake_queue_bad_length = 0;
+    fake_queue_sequence = 7;
+    memset(fake_queue_sequences, 0, sizeof(fake_queue_sequences));
+    fake_sendto_fail_once = 0;
+    fake_sendto_attempts = 0;
+    fake_reply_length = 0;
+    recvmsg_calls = 0;
+    write_calls = 0;
+    last_write_length = 0;
+    memset(write_history, 0, sizeof(write_history));
+    memset(write_history_lengths, 0, sizeof(write_history_lengths));
+}
+
+static struct ng_session *make_session(struct context *context,
+                                       struct arguments *args,
+                                       uint8_t *packet, uint16_t id) {
+    size_t length = make_echo(packet, id, 7);
+    memcpy(original_packet, packet, length);
+    original_length = length;
+    memset(context, 0, sizeof(*context));
+    memset(args, 0, sizeof(*args));
+    args->ctx = context;
+    CHECK(handle_icmp(args, packet, length, packet + 20, 10001, 99) == 1,
+          "echo request is admitted");
+    return context->ng_session;
+}
+
+static void test_error_is_relayed_with_original_quote(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x1234);
+    recvmsg_calls = 0;
+    CHECK(session != NULL, "session exists for error relay");
+    fake_queue_count = 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(recvmsg_calls == 2, "error queue drain stops at EAGAIN");
+    CHECK(write_calls == 1 && last_write_length == 64,
+          "one ICMP error is written to tun");
+    if (write_calls == 1) {
+        struct iphdr *ip4 = (struct iphdr *) last_write;
+        CHECK(ip4->saddr == inet_addr("203.0.113.9"),
+              "error source is the ICMP offender");
+        CHECK(ip4->daddr == inet_addr("192.0.2.1"),
+              "error destination is the requesting host");
+        CHECK(last_write[20] == ICMP_TIME_EXCEEDED,
+              "error type is preserved");
+        CHECK(memcmp(last_write + 28, original_packet, original_length) == 0,
+              "error quotes the exact original IP and echo header");
+        CHECK(calc_checksum(0, last_write, 20) == 0xffff &&
+                      calc_checksum(0, last_write + 20, last_write_length - 20) == 0xffff,
+              "relayed IPv4 and ICMP checksums are valid");
+    }
+    CHECK(session->icmp.stop == 0, "network error does not stop the session");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_malformed_error_is_ignored(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x2345);
+    recvmsg_calls = 0;
+    fake_queue_count = 1;
+    fake_queue_bad_control = 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "truncated control data is ignored safely");
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_bad_origin = 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "wrong error origin is ignored safely");
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_bad_destination = 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "a destination mismatch is ignored safely");
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_bad_length = 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "a short error cmsg is ignored safely");
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_sequence = 99;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "an unknown sequence is ignored safely");
+    reset_queue();
+    fake_reply_length = 4;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLIN,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "a short echo reply is ignored safely");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_out_of_order_quotes_and_eviction(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x4567);
+
+    uint8_t later[64];
+    uint8_t first_quote[64];
+    memcpy(first_quote, packet, sizeof(first_quote));
+    size_t later_length = make_echo(later, 0x4567, 8);
+    CHECK(handle_icmp(&args, later, later_length, later + 20, 10001, 99) == 1,
+          "a second sequence is recorded");
+    reset_queue();
+    fake_queue_count = 2;
+    fake_queue_sequences[0] = 8;
+    fake_queue_sequences[1] = 7;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 2 && session->icmp.stop == 0 &&
+                  memcmp(write_history[0] + 28, later, later_length) == 0 &&
+                  memcmp(write_history[1] + 28, first_quote, 36) == 0,
+          "out-of-order errors relay the exact matching quote bytes");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_quote_ring_retains_recent_edges(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    uint8_t probe[64];
+    uint8_t oldest_retained[64];
+    uint8_t newest_retained[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x4a4a);
+    for (uint16_t sequence = 8; sequence <= 23; sequence++) {
+        size_t length = make_echo(probe, 0x4a4a, sequence);
+        if (sequence == 8)
+            memcpy(oldest_retained, probe, length);
+        if (sequence == 23)
+            memcpy(newest_retained, probe, length);
+        CHECK(handle_icmp(&args, probe, length, probe + 20, 10001, 99) == 1,
+              "bounded quote ring accepts a recent probe");
+    }
+
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_sequence = 7;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 0 && session->icmp.stop == 0,
+          "the bounded quote ring evicts the earliest outstanding quote");
+
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_sequence = 8;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 1 && memcmp(write_history[0] + 28, oldest_retained, 36) == 0,
+          "the oldest retained quote is relayed exactly");
+
+    reset_queue();
+    fake_queue_count = 1;
+    fake_queue_sequence = 23;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 1 && memcmp(write_history[0] + 28, newest_retained, 36) == 0,
+          "the newest retained quote is relayed exactly");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_async_send_error_retries_once(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    sendto_calls = 0;
+    fake_sendto_fail_once = 1;
+    struct ng_session *session = make_session(&context, &args, packet, 0x5678);
+    CHECK(sendto_calls == 2 && session != NULL && session->icmp.stop == 0,
+          "a send race drains once and retries without stopping the session");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_simultaneous_error_and_echo_reply(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    uint8_t later[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x6789);
+    size_t later_length = make_echo(later, 0x6789, 8);
+    CHECK(handle_icmp(&args, later, later_length, later + 20, 10001, 99) == 1,
+          "a valid echo reply probe is outstanding");
+
+    fake_queue_count = 1;
+    fake_queue_sequence = 7;
+    memset(fake_reply, 0, sizeof(fake_reply));
+    fake_reply[0] = ICMP_ECHOREPLY;
+    fake_reply[1] = 0;
+    uint16_t translated_id = htons(0xbeef);
+    uint16_t reply_sequence = htons(8);
+    memcpy(fake_reply + 4, &translated_id, sizeof(translated_id));
+    memcpy(fake_reply + 6, &reply_sequence, sizeof(reply_sequence));
+    fake_reply_length = ICMP_MINLEN;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR | EPOLLIN,
+        .data.ptr = session,
+    });
+    uint16_t restored_id = htons(0x6789);
+    CHECK(write_calls == 2 && session->icmp.stop == 0,
+          "simultaneous network error and echo input both reach tun");
+    CHECK(write_calls >= 1 && write_history[0][20] == ICMP_TIME_EXCEEDED &&
+                  memcmp(write_history[0] + 28, packet, 36) == 0,
+          "the error is relayed before the echo reply");
+    CHECK(write_calls == 2 && write_history[1][20] == ICMP_ECHOREPLY &&
+                  memcmp(write_history[1] + 24, &restored_id, sizeof(restored_id)) == 0 &&
+                  memcmp(write_history[1] + 26, &reply_sequence, sizeof(reply_sequence)) == 0 &&
+                  calc_checksum(0, write_history[1] + 20,
+                                write_history_lengths[1] - 20) == 0xffff,
+          "the echo reply restores its ID and checksum after EPOLLERR");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_ipv4_options_quote_is_preserved(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    size_t length = make_echo_with_options(packet, 0x789a, 7);
+    memcpy(original_packet, packet, length);
+    original_length = length;
+    memset(&context, 0, sizeof(context));
+    memset(&args, 0, sizeof(args));
+    args.ctx = &context;
+    CHECK(handle_icmp(&args, packet, length, packet + 24, 10001, 99) == 1,
+          "an IPv4 echo with options is admitted");
+    struct ng_session *session = context.ng_session;
+    CHECK(session != NULL, "IPv4 options session exists");
+    fake_queue_count = 1;
+    fake_queue_sequence = 7;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR,
+        .data.ptr = session,
+    });
+    CHECK(write_calls == 1 && last_write_length == 68 &&
+                  memcmp(last_write + 28, original_packet, original_length) == 0 &&
+                  last_write[48] == 1 && last_write[49] == 2 &&
+                  last_write[50] == 3 && last_write[51] == 4,
+          "IPv4 options and the exact quoted header are preserved");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+static void test_bound_and_simultaneous_drain(void) {
+    struct context context;
+    struct arguments args;
+    uint8_t packet[64];
+    reset_queue();
+    struct ng_session *session = make_session(&context, &args, packet, 0x3456);
+    recvmsg_calls = 0;
+    fake_queue_count = TEST_ICMP_ERROR_DRAIN_MAX + 1;
+    check_icmp_socket(&args, &(struct epoll_event) {
+        .events = EPOLLERR | EPOLLIN,
+        .data.ptr = session,
+    });
+    CHECK(recvmsg_calls == TEST_ICMP_ERROR_DRAIN_MAX,
+          "error queue drain is bounded at sixteen messages");
+    CHECK(session->icmp.stop == 0, "simultaneous error and input do not stop session");
+    ng_free(session, __FILE__, __LINE__);
+}
+
+int main(void) {
+    test_error_is_relayed_with_original_quote();
+    test_malformed_error_is_ignored();
+    test_bound_and_simultaneous_drain();
+    test_out_of_order_quotes_and_eviction();
+    test_quote_ring_retains_recent_edges();
+    test_async_send_error_retries_once();
+    test_simultaneous_error_and_echo_reply();
+    test_ipv4_options_quote_is_preserved();
+    if (failures != 0)
+        return 1;
+    puts("icmp_error_test: all tests passed");
+    return 0;
+}

--- a/app/src/test/native/icmp_kernel4_test.c
+++ b/app/src/test/native/icmp_kernel4_test.c
@@ -1,0 +1,155 @@
+/* Opt-in Linux/Android kernel test: requires CAP_NET_RAW and a real network stack. */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netguard.h"
+
+FILE *pcap_file;
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+    (void) format;
+}
+
+void *ng_malloc(size_t size, const char *tag) {
+    (void) tag;
+    void *pointer = calloc(1, size);
+    assert(pointer != NULL);
+    return pointer;
+}
+
+void ng_free(void *pointer, const char *file, int line) {
+    (void) file;
+    (void) line;
+    free(pointer);
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+}
+
+int protect_socket(const struct arguments *args, int socket) {
+    (void) args;
+    (void) socket;
+    return 0;
+}
+
+uint16_t calc_checksum(uint16_t start, const uint8_t *buffer, size_t length) {
+    uint32_t sum = start;
+    while (length > 1) {
+        uint16_t word;
+        memcpy(&word, buffer, sizeof(word));
+        sum += word;
+        buffer += 2;
+        length -= 2;
+    }
+    if (length != 0)
+        sum += *buffer;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return (uint16_t) sum;
+}
+
+int main(void) {
+    int tun[2];
+    assert(socketpair(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0, tun) == 0);
+    struct context context = {0};
+    struct arguments args = {0};
+    args.ctx = &context;
+    args.tun = tun[0];
+    int epoll_fd = epoll_create1(0);
+    assert(epoll_fd >= 0);
+
+    uint8_t packet[36] = {0};
+    struct iphdr *ip4 = (struct iphdr *) packet;
+    ip4->version = 4;
+    ip4->ihl = 5;
+    ip4->tot_len = htons(sizeof(packet));
+    ip4->ttl = 3;
+    ip4->protocol = IPPROTO_ICMP;
+    ip4->saddr = inet_addr("10.10.10.1");
+    ip4->daddr = inet_addr("127.0.0.2");
+    struct icmphdr *echo = (struct icmphdr *) (packet + 20);
+    echo->type = ICMP_ECHO;
+    echo->un.echo.id = htons(4321);
+    echo->un.echo.sequence = htons(7);
+    memset(packet + 28, 0xab, 8);
+    echo->checksum = ~calc_checksum(0, packet + 20, 16);
+    ip4->check = ~calc_checksum(0, packet, 20);
+    uint8_t original[sizeof(packet)];
+    memcpy(original, packet, sizeof(packet));
+
+    assert(handle_icmp(&args, packet, sizeof(packet), packet + 20,
+                       10000, epoll_fd));
+    struct ng_session *session = context.ng_session;
+    assert(session != NULL);
+    struct sockaddr_in local = {0};
+    socklen_t local_length = sizeof(local);
+    assert(getsockname(session->socket, (struct sockaddr *) &local,
+                       &local_length) == 0);
+    int ttl = 0;
+    local_length = sizeof(ttl);
+    assert(getsockopt(session->socket, IPPROTO_IP, IP_TTL, &ttl,
+                      &local_length) == 0 && ttl == 3);
+    assert(memcmp(packet, original, sizeof(packet)) == 0);
+    struct epoll_event error_only = { .events = EPOLLERR, .data.ptr = session };
+    assert(epoll_ctl(epoll_fd, EPOLL_CTL_MOD, session->socket, &error_only) == 0);
+
+    uint8_t error_packet[sizeof(packet) + 8] = {0};
+    struct icmphdr *error = (struct icmphdr *) error_packet;
+    error->type = ICMP_TIME_EXCEEDED;
+    memcpy(error_packet + 8, original, sizeof(original));
+    struct iphdr *quoted = (struct iphdr *) (error_packet + 8);
+    quoted->saddr = inet_addr("127.0.0.1");
+    quoted->check = 0;
+    quoted->check = ~calc_checksum(0, (uint8_t *) quoted, 20);
+    struct icmphdr *quoted_echo = (struct icmphdr *) (error_packet + 28);
+    quoted_echo->un.echo.id = local.sin_port;
+    quoted_echo->checksum = 0;
+    quoted_echo->checksum = ~calc_checksum(0, (uint8_t *) quoted_echo, 16);
+    error->checksum = ~calc_checksum(0, error_packet, sizeof(error_packet));
+
+    int raw = socket(AF_INET, SOCK_RAW, IPPROTO_ICMP);
+    assert(raw >= 0);
+    struct sockaddr_in from = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = inet_addr("127.0.0.3"),
+    };
+    assert(bind(raw, (struct sockaddr *) &from, sizeof(from)) == 0);
+    struct sockaddr_in destination = {
+        .sin_family = AF_INET,
+        .sin_addr.s_addr = inet_addr("127.0.0.1"),
+    };
+    assert(sendto(raw, error_packet, sizeof(error_packet), 0,
+                  (struct sockaddr *) &destination, sizeof(destination)) ==
+           (ssize_t) sizeof(error_packet));
+
+    struct epoll_event event;
+    assert(epoll_wait(epoll_fd, &event, 1, 1000) == 1);
+    assert(event.events & EPOLLERR);
+    check_icmp_socket(&args, &event);
+
+    uint8_t output[512];
+    ssize_t output_length = recv(tun[1], output, sizeof(output), 0);
+    assert(output_length >= 56);
+    struct iphdr *output_ip = (struct iphdr *) output;
+    assert(output_ip->saddr == from.sin_addr.s_addr);
+    assert(output_ip->daddr == ip4->saddr);
+    assert(output[20] == ICMP_TIME_EXCEEDED);
+    assert(calc_checksum(0, output, 20) == 0xffff);
+    assert(calc_checksum(0, output + 20, output_length - 20) == 0xffff);
+    assert(memcmp(output + 28, original, sizeof(original)) == 0);
+    assert(session->icmp.stop == 0);
+    puts("icmp_kernel4_test: IP_RECVERR, offender, quote, TTL and checksums passed");
+    close(raw);
+    close(session->socket);
+    free(session);
+    close(epoll_fd);
+    close(tun[0]);
+    close(tun[1]);
+    return 0;
+}

--- a/app/src/test/native/icmp_kernel6_test.c
+++ b/app/src/test/native/icmp_kernel6_test.c
@@ -1,0 +1,169 @@
+/* Opt-in Linux/Android kernel test: requires CAP_NET_RAW and a real network stack. */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "netguard.h"
+
+FILE *pcap_file;
+
+void log_android(int priority, const char *format, ...) {
+    (void) priority;
+    (void) format;
+}
+
+void *ng_malloc(size_t size, const char *tag) {
+    (void) tag;
+    void *pointer = calloc(1, size);
+    assert(pointer != NULL);
+    return pointer;
+}
+
+void ng_free(void *pointer, const char *file, int line) {
+    (void) file;
+    (void) line;
+    free(pointer);
+}
+
+void write_pcap_rec(const uint8_t *buffer, size_t length) {
+    (void) buffer;
+    (void) length;
+}
+
+int protect_socket(const struct arguments *args, int socket) {
+    (void) args;
+    (void) socket;
+    return 0;
+}
+
+uint16_t calc_checksum(uint16_t start, const uint8_t *buffer, size_t length) {
+    uint32_t sum = start;
+    while (length > 1) {
+        uint16_t word;
+        memcpy(&word, buffer, sizeof(word));
+        sum += word;
+        buffer += 2;
+        length -= 2;
+    }
+    if (length != 0)
+        sum += *buffer;
+    while (sum >> 16)
+        sum = (sum & 0xffff) + (sum >> 16);
+    return (uint16_t) sum;
+}
+
+static uint16_t checksum6(const struct in6_addr *source,
+                          const struct in6_addr *destination,
+                          const uint8_t *data, size_t length) {
+    struct ip6_hdr_pseudo pseudo = {0};
+    pseudo.ip6ph_src = *source;
+    pseudo.ip6ph_dst = *destination;
+    pseudo.ip6ph_len = htonl((uint32_t) length);
+    pseudo.ip6ph_nxt = IPPROTO_ICMPV6;
+    return calc_checksum(calc_checksum(0, (uint8_t *) &pseudo, sizeof(pseudo)),
+                         data, length);
+}
+
+int main(void) {
+    int tun[2];
+    assert(socketpair(AF_UNIX, SOCK_DGRAM | SOCK_NONBLOCK, 0, tun) == 0);
+    struct context context = {0};
+    struct arguments args = {0};
+    args.ctx = &context;
+    args.tun = tun[0];
+    int epoll_fd = epoll_create1(0);
+    assert(epoll_fd >= 0);
+
+    uint8_t packet[56] = {0};
+    struct ip6_hdr *ip6 = (struct ip6_hdr *) packet;
+    ip6->ip6_ctlun.ip6_un2_vfc = IPV6_VERSION;
+    ip6->ip6_ctlun.ip6_un1.ip6_un1_plen = htons(16);
+    ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt = IPPROTO_ICMPV6;
+    ip6->ip6_ctlun.ip6_un1.ip6_un1_hlim = 3;
+    inet_pton(AF_INET6, "fd00::1", &ip6->ip6_src);
+    inet_pton(AF_INET6, "::1", &ip6->ip6_dst);
+    struct in6_addr packet_source;
+    struct in6_addr packet_destination;
+    memcpy(&packet_source, &ip6->ip6_src, sizeof(packet_source));
+    memcpy(&packet_destination, &ip6->ip6_dst, sizeof(packet_destination));
+    struct icmp6_hdr *echo = (struct icmp6_hdr *) (packet + 40);
+    echo->icmp6_type = ICMP6_ECHO_REQUEST;
+    echo->icmp6_id = htons(4321);
+    echo->icmp6_seq = htons(7);
+    memset(packet + 48, 0xab, 8);
+    echo->icmp6_cksum = ~checksum6(&packet_source, &packet_destination,
+                                   packet + 40, 16);
+    uint8_t original[sizeof(packet)];
+    memcpy(original, packet, sizeof(packet));
+
+    assert(handle_icmp(&args, packet, sizeof(packet), packet + 40,
+                       10000, epoll_fd));
+    struct ng_session *session = context.ng_session;
+    assert(session != NULL);
+    struct sockaddr_in6 local = {0};
+    socklen_t local_length = sizeof(local);
+    assert(getsockname(session->socket, (struct sockaddr *) &local,
+                       &local_length) == 0);
+    int hops = 0;
+    socklen_t hops_length = sizeof(hops);
+    assert(getsockopt(session->socket, IPPROTO_IPV6, IPV6_UNICAST_HOPS,
+                      &hops, &hops_length) == 0 && hops == 3);
+    assert(memcmp(packet, original, sizeof(packet)) == 0);
+    struct epoll_event error_only = { .events = EPOLLERR, .data.ptr = session };
+    assert(epoll_ctl(epoll_fd, EPOLL_CTL_MOD, session->socket, &error_only) == 0);
+
+    uint8_t error_packet[64] = {0};
+    struct icmp6_hdr *error = (struct icmp6_hdr *) error_packet;
+    error->icmp6_type = ICMP6_TIME_EXCEEDED;
+    memcpy(error_packet + 8, original, sizeof(original));
+    struct ip6_hdr *quoted = (struct ip6_hdr *) (error_packet + 8);
+    inet_pton(AF_INET6, "::1", &quoted->ip6_src);
+    struct in6_addr quoted_source;
+    struct in6_addr quoted_destination;
+    memcpy(&quoted_source, &quoted->ip6_src, sizeof(quoted_source));
+    memcpy(&quoted_destination, &quoted->ip6_dst, sizeof(quoted_destination));
+    struct icmp6_hdr *quoted_echo = (struct icmp6_hdr *) (error_packet + 48);
+    quoted_echo->icmp6_id = local.sin6_port;
+    quoted_echo->icmp6_cksum = 0;
+    quoted_echo->icmp6_cksum = ~checksum6(&quoted_source, &quoted_destination,
+                                          (uint8_t *) quoted_echo, 16);
+
+    int raw = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+    assert(raw >= 0);
+    struct sockaddr_in6 destination = { .sin6_family = AF_INET6 };
+    inet_pton(AF_INET6, "::1", &destination.sin6_addr);
+    assert(sendto(raw, error_packet, sizeof(error_packet), 0,
+                  (struct sockaddr *) &destination, sizeof(destination)) ==
+           (ssize_t) sizeof(error_packet));
+
+    struct epoll_event event;
+    assert(epoll_wait(epoll_fd, &event, 1, 1000) == 1);
+    assert(event.events & EPOLLERR);
+    check_icmp_socket(&args, &event);
+
+    uint8_t output[512];
+    ssize_t output_length = recv(tun[1], output, sizeof(output), 0);
+    assert(output_length >= 96);
+    struct ip6_hdr *output_ip = (struct ip6_hdr *) output;
+    assert(memcmp(&output_ip->ip6_src, &destination.sin6_addr, 16) == 0);
+    assert(memcmp(&output_ip->ip6_dst, &ip6->ip6_src, 16) == 0);
+    assert(output[40] == ICMP6_TIME_EXCEEDED);
+    struct in6_addr output_source;
+    struct in6_addr output_destination;
+    memcpy(&output_source, &output_ip->ip6_src, sizeof(output_source));
+    memcpy(&output_destination, &output_ip->ip6_dst, sizeof(output_destination));
+    assert(checksum6(&output_source, &output_destination,
+                     output + 40, output_length - 40) == 0xffff);
+    assert(memcmp(output + 48, original, sizeof(original)) == 0);
+    assert(session->icmp.stop == 0);
+    puts("icmp_kernel6_test: IPV6_RECVERR, quote, hop limit and checksum passed");
+    close(raw);
+    close(session->socket);
+    free(session);
+    close(epoll_fd);
+    close(tun[0]);
+    close(tun[1]);
+    return 0;
+}

--- a/app/src/test/native/icmp_socket_test.c
+++ b/app/src/test/native/icmp_socket_test.c
@@ -20,7 +20,14 @@ static int fcntl_fail_set;
 static int socket_calls;
 static int close_calls;
 static int sendto_calls;
+static int setsockopt_calls;
+static int setsockopt_fail;
+static int recvmsg_calls;
 static int last_sendto_family;
+static int last_hop_limit;
+static int last_hop_option;
+static uint8_t last_send_payload[256];
+static size_t last_send_payload_length;
 static struct sockaddr_storage last_sendto_address;
 
 FILE *pcap_file;
@@ -77,6 +84,73 @@ int __wrap_close(int file_descriptor) {
     return 0;
 }
 
+int __wrap_setsockopt(int socket, int level, int option,
+                      const void *value, socklen_t value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    setsockopt_calls++;
+    if (option == IP_TTL || option == IPV6_UNICAST_HOPS) {
+        last_hop_option = option;
+        if (value_length >= sizeof(int))
+            memcpy(&last_hop_limit, value, sizeof(last_hop_limit));
+    }
+    if (setsockopt_fail) {
+        errno = EINVAL;
+        return -1;
+    }
+    return 0;
+}
+
+ssize_t __wrap_recvmsg(int socket, struct msghdr *message, int flags) {
+    (void) socket;
+    (void) message;
+    (void) flags;
+    recvmsg_calls++;
+    errno = EAGAIN;
+    return -1;
+}
+
+int __wrap_getsockopt(int socket, int level, int option,
+                      void *value, socklen_t *value_length) {
+    (void) socket;
+    (void) level;
+    (void) option;
+    (void) value;
+    (void) value_length;
+    return 0;
+}
+
+ssize_t __wrap_recv(int socket, void *buffer, size_t length, int flags) {
+    (void) socket;
+    (void) buffer;
+    (void) length;
+    (void) flags;
+    errno = EAGAIN;
+    return -1;
+}
+
+ssize_t __wrap_write(int file_descriptor, const void *buffer, size_t length) {
+    (void) file_descriptor;
+    (void) buffer;
+    return (ssize_t) length;
+}
+
+#if defined(__linux__)
+/* The existing CI command only wraps socket/close/fcntl/sendto. Interpose the
+ * additional calls too, so both that command and the focused runner use mocks. */
+int setsockopt(int socket, int level, int option,
+               const void *value, socklen_t value_length) {
+    return __wrap_setsockopt(socket, level, option, value, value_length);
+}
+
+ssize_t recvmsg(int socket, struct msghdr *message, int flags) {
+    return __wrap_recvmsg(socket, message, flags);
+}
+#endif
+
 int __wrap_fcntl(int file_descriptor, int command, ...) {
     (void) file_descriptor;
     fcntl_calls++;
@@ -118,9 +192,11 @@ ssize_t __wrap_sendto(int socket, const void *buffer, size_t length, int flags,
                       const struct sockaddr *destination,
                       socklen_t destination_length) {
     (void) socket;
-    (void) buffer;
     (void) flags;
     sendto_calls++;
+    last_send_payload_length = length < sizeof(last_send_payload)
+                               ? length : sizeof(last_send_payload);
+    memcpy(last_send_payload, buffer, last_send_payload_length);
     last_sendto_family = destination->sa_family;
     memset(&last_sendto_address, 0, sizeof(last_sendto_address));
     if (destination_length <= sizeof(last_sendto_address))
@@ -153,10 +229,14 @@ static void test_nonblocking_socket_and_open_cleanup(void) {
     fcntl_fail_get = 0;
     fcntl_fail_set = 0;
     close_calls = 0;
+    setsockopt_fail = 0;
+    setsockopt_calls = 0;
+    recvmsg_calls = 0;
     int socket = open_icmp_socket(&args, &session);
     CHECK(socket >= 0, "ICMP socket opens when protection and nonblocking setup succeed");
     CHECK(fcntl_calls == 2 && (fcntl_flags & O_NONBLOCK) != 0,
           "ICMP socket is configured O_NONBLOCK");
+    CHECK(setsockopt_calls == 1, "ICMP socket enables the error queue");
     close(socket);
 
     protect_result = -1;
@@ -172,6 +252,13 @@ static void test_nonblocking_socket_and_open_cleanup(void) {
     CHECK(socket < 0 && close_calls == 1,
           "ICMP nonblocking failure closes the newly opened descriptor");
     fcntl_fail_set = 0;
+
+    setsockopt_fail = 1;
+    close_calls = 0;
+    socket = open_icmp_socket(&args, &session);
+    CHECK(socket < 0 && close_calls == 1,
+          "ICMP error queue setup failure closes the newly opened descriptor");
+    setsockopt_fail = 0;
 }
 
 static size_t make_echo_packet(uint8_t *packet) {
@@ -232,13 +319,21 @@ static void test_icmp_send_address_is_zero_initialised(void) {
     args.ctx = &context;
     protect_result = 0;
     epoll_result = 0;
+    setsockopt_fail = 0;
     sendto_calls = 0;
+    last_hop_limit = 0;
+    last_hop_option = 0;
+    last_send_payload_length = 0;
+    uint8_t original[64];
+    memcpy(original, packet, length);
 
     CHECK(handle_icmp(&args, packet, length,
                       packet + sizeof(struct iphdr), 10001, 99) == 1,
           "ICMP echo is sent after successful session admission");
     CHECK(sendto_calls == 1 && last_sendto_family == AF_INET,
           "ICMP send uses an IPv4 sockaddr");
+    CHECK(last_hop_option == IP_TTL && last_hop_limit == 0,
+          "IPv4 send applies the requested TTL immediately before send");
     if (last_sendto_family == AF_INET) {
         const struct sockaddr_in *address =
                 (const struct sockaddr_in *) &last_sendto_address;
@@ -249,9 +344,35 @@ static void test_icmp_send_address_is_zero_initialised(void) {
               "ICMP send zero-initialises IPv4 sockaddr padding");
     }
 
+    CHECK(last_send_payload_length == length - sizeof(struct iphdr) &&
+                  memcmp(last_send_payload, packet + sizeof(struct iphdr),
+                         last_send_payload_length) == 0 &&
+                  memcmp(packet, original, length) == 0,
+          "ICMP forwarding preserves the original TUN packet");
+
+    uint8_t packet2[64];
+    size_t length2 = make_echo_packet(packet2);
+    ((struct iphdr *) packet2)->ttl = 3;
+    ((struct icmp *) (packet2 + sizeof(struct iphdr)))->icmp_id = htons(0x4321);
+    sendto_calls = 0;
+    CHECK(handle_icmp(&args, packet2, length2,
+                      packet2 + sizeof(struct iphdr), 10001, 99) == 1,
+          "a second concurrent ICMP identifier is admitted");
+    CHECK(context.ng_session != NULL && context.ng_session->next != NULL &&
+                  context.ng_session != context.ng_session->next,
+          "concurrent ICMP identifiers use separate sessions");
+    CHECK(last_hop_limit == 3, "a later probe updates the IPv4 TTL");
+
     struct ng_session *session = context.ng_session;
-    if (session != NULL)
+    if (session != NULL) {
+        context.ng_session = session->next;
         ng_free(session, __FILE__, __LINE__);
+    }
+    session = context.ng_session;
+    if (session != NULL) {
+        context.ng_session = session->next;
+        ng_free(session, __FILE__, __LINE__);
+    }
     context.ng_session = NULL;
 
     length = make_echo_packet6(packet);
@@ -262,6 +383,8 @@ static void test_icmp_send_address_is_zero_initialised(void) {
           "IPv6 ICMP echo is sent after successful session admission");
     CHECK(sendto_calls == 1 && last_sendto_family == AF_INET6,
           "ICMP send uses an IPv6 sockaddr");
+    CHECK(last_hop_option == IPV6_UNICAST_HOPS && last_hop_limit == 0,
+          "IPv6 send applies the requested hop limit immediately before send");
     if (last_sendto_family == AF_INET6) {
         const struct sockaddr_in6 *address6 =
                 (const struct sockaddr_in6 *) &last_sendto_address;

--- a/app/src/test/native/run_defensive_tests.sh
+++ b/app/src/test/native/run_defensive_tests.sh
@@ -25,9 +25,7 @@ compile udp_defensive_test app/src/test/native/udp_defensive_test.c \
     app/src/main/jni/netguard/udp.c \
     -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=recv \
     -Wl,--wrap=sendto -Wl,--wrap=socket -Wl,--wrap=write
-compile icmp_defensive_test app/src/test/native/icmp_defensive_test.c \
-    app/src/main/jni/netguard/icmp.c \
-    -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=sendto -Wl,--wrap=socket
+"$(dirname "$0")/run_icmp_tests.sh"
 compile ip_header_test app/src/test/native/ip_header_test.c \
     app/src/test/native/ip_header_failfast.c app/src/main/jni/netguard/ip.c
 compile tcp_window_test app/src/test/native/tcp_window_test.c \
@@ -36,9 +34,6 @@ compile udp_socket_test app/src/test/native/udp_socket_test.c \
     app/src/main/jni/netguard/udp.c \
     -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=recv \
     -Wl,--wrap=sendto -Wl,--wrap=socket -Wl,--wrap=write
-compile icmp_socket_test app/src/test/native/icmp_socket_test.c \
-    app/src/main/jni/netguard/icmp.c \
-    -Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=sendto -Wl,--wrap=socket
 compile ip_flow_policy_test app/src/test/native/ip_flow_policy_test.c \
     app/src/main/jni/netguard/ip.c app/src/main/jni/netguard/policy.c \
     app/src/main/jni/netguard/ip6_ext.c app/src/main/jni/netguard/tls.c \

--- a/app/src/test/native/run_icmp_kernel_tests.sh
+++ b/app/src/test/native/run_icmp_kernel_tests.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# These tests inject raw ICMP errors into real ping sockets.  They are opt-in:
+# runtime needs CAP_NET_RAW (or root) and a Linux/Android network stack.
+cd "$(dirname "$0")/../../../.."
+if [[ "${OSTYPE:-}" == darwin* && "${CC:-}" != *android* ]]; then
+    echo "icmp kernel tests require Linux or Android" >&2
+    exit 2
+fi
+
+OUT=${OUT:-$(mktemp -d)}
+mkdir -p "$OUT"
+COMMON=(-D_GNU_SOURCE -O1 -g -Wall -Wextra -Wno-unused-parameter
+        -Wno-sign-compare -fno-omit-frame-pointer
+        -include app/src/test/native/host_compat/linux_test.h
+        -idirafter app/src/test/native/host_compat -Iapp/src/main/jni/netguard)
+if [[ -n "${SANITIZERS:-}" ]]; then
+    COMMON+=(-fsanitize="$SANITIZERS" -fno-sanitize-recover=all)
+fi
+
+for family in 4 6; do
+    "${CC:-cc}" "${COMMON[@]}" -Wl,--gc-sections \
+        -o "$OUT/icmp_kernel$family" \
+        "app/src/test/native/icmp_kernel${family}_test.c" \
+        app/src/main/jni/netguard/icmp.c
+done
+
+if [[ ${BUILD_ONLY:-0} == 1 || ${RUN_KERNEL:-0} != 1 ]]; then
+    echo "icmp kernel tests built in $OUT; set RUN_KERNEL=1 to execute with CAP_NET_RAW"
+else
+    "$OUT/icmp_kernel4"
+    "$OUT/icmp_kernel6"
+fi

--- a/app/src/test/native/run_icmp_tests.sh
+++ b/app/src/test/native/run_icmp_tests.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../../../.."
+OUT=${OUT:-$(mktemp -d)}
+mkdir -p "$OUT"
+
+COMMON=(-D_GNU_SOURCE -O1 -g -Wall -Wextra -Wno-unused-parameter
+        -Wno-sign-compare -fsanitize="${SANITIZERS:-address,undefined}"
+        -fno-sanitize-recover=all -fno-omit-frame-pointer
+        -ffunction-sections -fdata-sections
+        -include app/src/test/native/host_compat/linux_test.h
+        -idirafter app/src/test/native/host_compat -Iapp/src/main/jni/netguard)
+
+TESTS=(icmp_socket_test icmp_error_test icmp_defensive_test)
+WRAPS=(-Wl,--wrap=close -Wl,--wrap=fcntl -Wl,--wrap=getsockopt
+       -Wl,--wrap=recv -Wl,--wrap=recvmsg -Wl,--wrap=sendto
+       -Wl,--wrap=setsockopt -Wl,--wrap=socket -Wl,--wrap=write)
+
+compile_linux() {
+    local name=$1
+    shift
+    "${CC:-cc}" "${COMMON[@]}" -o "$OUT/$name" \
+        "app/src/test/native/$name.c" app/src/main/jni/netguard/icmp.c \
+        -Wl,--gc-sections "${WRAPS[@]}"
+}
+
+compile_darwin() {
+    local object="$OUT/icmp.o"
+    "${CC:-cc}" "${COMMON[@]}" \
+        -Dclose=__wrap_close -Dfcntl=__wrap_fcntl \
+        -Dgetsockopt=__wrap_getsockopt -Drecv=__wrap_recv \
+        -Drecvmsg=__wrap_recvmsg -Dsendto=__wrap_sendto \
+        -Dsetsockopt=__wrap_setsockopt -Dsocket=__wrap_socket \
+        -Dwrite=__wrap_write -c app/src/main/jni/netguard/icmp.c -o "$object"
+    for name in "${TESTS[@]}"; do
+        "${CC:-cc}" "${COMMON[@]}" -o "$OUT/$name" \
+            "app/src/test/native/$name.c" "$object"
+    done
+}
+
+if [[ "${OSTYPE:-}" == darwin* ]]; then
+    # Darwin's linker has no --wrap; rename syscalls on the production object.
+    compile_darwin
+else
+    for name in "${TESTS[@]}"; do
+        compile_linux "$name"
+    done
+fi
+
+if [[ ${BUILD_ONLY:-0} != 1 ]]; then
+    for name in "${TESTS[@]}"; do
+        "$OUT/$name"
+    done
+fi


### PR DESCRIPTION
Direct ICMP forwarding currently replaces each probe's TTL with the socket default, shares sessions between different echo identifiers, and closes sessions when routers return ICMP errors. This prevents ICMP traceroute tools such as NextTraceroute from identifying hops.

Preserve each probe's IPv4 TTL or IPv6 hop limit, separate sessions by original echo identifier, and relay Time Exceeded, Destination Unreachable and IPv6 Packet Too Big errors from the protected ping socket's error queue. Replies quote the original app packet and use the reporting router's address with recalculated checksums. Production continues to use unprivileged ping sockets. Storage is capped at 16 recent 128-byte quotes per ICMP session, with bounded error draining and retry.

Validation:

- `./gradlew :app:assembleGithubDebug -q` passes for all four Android ABIs.
- `bash app/src/test/native/run_icmp_tests.sh` passes on macOS with ASan/UBSan.
- All nine native defensive test binaries pass on an Android 37 arm64 emulator with UBSan.
- Both opt-in `run_icmp_kernel_tests.sh` binaries pass on Android: real IPv4/IPv6 ping sockets, injected router errors, original quotes, restored TTL/hop limits and valid checksums. The baseline used TTL/hop limit 64 for probes requesting 3.

Real-network NextTraceroute validation remains outstanding, including a separate WireGuard run. The emulator's virtual network returns an echo reply even for an external TTL-1 probe, so it cannot establish real traceroute hop discovery. This change addresses direct ICMP forwarding; WireGuard routing and its ICMP UID-attribution limitation remain unchanged. Headers too large to fit the bounded quote retain ordinary echo forwarding but cannot have their errors relayed.

Relates to #923.
