### PR TITLE
Release the upstream socket once a TCP session is finished

### DIFF
--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -71,6 +71,29 @@ int tcp_window_probe_delay(struct tcp_session *cur, long long now,
                          : 0;
 }
 
+/* Release the upstream socket once neither direction can carry another byte:
+ * the client's FIN has been consumed (its write half is shut down and nothing
+ * is queued) and the peer has sent EOF.  A fully closed socket left in the
+ * epoll set reports EPOLLHUP, which is delivered whether or not it was
+ * requested, so every epoll_wait() would return immediately and spin the
+ * event loop until the session is reaped — up to TCP_CLOSE_TIMEOUT seconds
+ * when the client never acknowledges our FIN.  Closing the descriptor removes
+ * it from the set; the session itself lives on until check_tcp_session()
+ * accounts and reaps it. */
+static void release_finished_upstream(struct ng_session *s, const char *session) {
+    struct tcp_session *cur = &s->tcp;
+    if (s->socket < 0 || !cur->upstream_read_eof || !cur->client_fin_consumed ||
+        cur->forward != NULL)
+        return;
+
+    if (close(s->socket))
+        log_android(ANDROID_LOG_ERROR, "%s close error %d: %s",
+                    session, errno, strerror(errno));
+    else
+        log_android(ANDROID_LOG_WARN, "%s upstream socket finished", session);
+    s->socket = -1;
+}
+
 static int consume_client_fin(const struct arguments *args,
                                struct ng_session *s, const char *session) {
     struct tcp_session *cur = &s->tcp;
@@ -103,6 +126,7 @@ static int consume_client_fin(const struct arguments *args,
         cur->state = TCP_CLOSE_WAIT;
 
     log_android(ANDROID_LOG_WARN, "%s consumed client FIN", session);
+    release_finished_upstream(s, session);
     return 1;
 }
 
@@ -133,7 +157,9 @@ static int mark_upstream_eof(const struct arguments *args,
     cur->window_probe_delay = 0;
     cur->window_probe_deadline = 0;
     log_android(ANDROID_LOG_WARN, "%s recv eof", session);
-    return send_server_fin(args, s, session) < 0 ? -1 : 1;
+    int sent = send_server_fin(args, s, session);
+    release_finished_upstream(s, session);
+    return sent < 0 ? -1 : 1;
 }
 
 void clear_tcp_data(struct tcp_session *cur) {

--- a/app/src/test/native/tcp_defensive_test.c
+++ b/app/src/test/native/tcp_defensive_test.c
@@ -267,6 +267,15 @@ static void test_tcp_epoll_add_failure_does_not_retain_session(void) {
     epoll_result = 0;
 }
 
+// Whether this host can create an AF_INET6 socket at all.
+static int host_supports_ipv6(void) {
+    int probe = socket(PF_INET6, SOCK_STREAM, 0);
+    if (probe < 0)
+        return 0;
+    close(probe);
+    return 1;
+}
+
 static void test_tcp_connect_address_is_zero_initialised(void) {
     struct tcp_session session = {0};
     session.version = 4;
@@ -296,6 +305,12 @@ static void test_tcp_connect_address_is_zero_initialised(void) {
     inet_pton(AF_INET6, "2001:db8::10", &session.daddr.ip6);
     session.dest = htons(443);
     connect_calls = 0;
+    if (!host_supports_ipv6()) {
+        // Some containers offer no AF_INET6 at all; that is a property of the
+        // host, not of the code under test.
+        puts("SKIP: host has no IPv6 support");
+        return;
+    }
     int socket6 = open_tcp_socket(&args, &session, NULL);
     CHECK(socket6 >= 0 && connect_calls == 1 && last_connect_family == AF_INET6,
           "TCP opener connects with an IPv6 sockaddr");

--- a/app/src/test/native/tcp_half_close_test.c
+++ b/app/src/test/native/tcp_half_close_test.c
@@ -410,6 +410,52 @@ static void test_upstream_eof_keeps_write_half(void) {
     clear_tcp_data(&session.tcp);
 }
 
+static void test_finished_session_releases_upstream_socket(void) {
+    int upstream[2];
+    int tun[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, upstream) == 0,
+          "socketpair for finished session");
+    CHECK(pipe(tun) == 0, "pipe for finished session FINs");
+    if (failures != 0)
+        return;
+    fcntl(tun[0], F_SETFL, O_NONBLOCK);
+
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    make_session(&session, upstream[0], TCP_ESTABLISHED);
+    make_args(&args, &context, &session, tun[1]);
+
+    uint8_t packet[256];
+    size_t length = make_packet(packet, 100, session.tcp.local_seq, 65535,
+                                NULL, 0, 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr), 1, 1,
+                     NULL, -1) == 1, "client FIN is accepted");
+    CHECK(session.tcp.client_fin_consumed && session.socket >= 0,
+          "a consumed client FIN alone keeps the read half open");
+
+    int closed_before = close_calls;
+    CHECK(shutdown(upstream[1], SHUT_WR) == 0, "peer sends EOF after the client FIN");
+    struct epoll_event event = {.events = EPOLLIN, .data.ptr = &session};
+    check_tcp_socket(&args, &event, -1);
+
+    CHECK(session.tcp.upstream_read_eof && session.tcp.server_fin_sent &&
+                  session.tcp.state == TCP_LAST_ACK,
+          "upstream EOF after a consumed FIN sends the last FIN");
+    // A fully closed socket left registered reports EPOLLHUP on every
+    // epoll_wait(), which would spin the event loop until the session is
+    // reaped.  Releasing the descriptor removes it from the epoll set.
+    CHECK(session.socket < 0 && close_calls == closed_before + 1,
+          "a finished session releases its upstream socket once");
+
+    drain_tun(tun[0]);
+    close(upstream[0]);
+    close(upstream[1]);
+    close(tun[0]);
+    close(tun[1]);
+    clear_tcp_data(&session.tcp);
+}
+
 static void test_hup_marks_only_read_half_closed(void) {
     int upstream[2];
     int tun[2];
@@ -621,6 +667,15 @@ static void test_tcp_epoll_add_failure_does_not_retain_session(void) {
     epoll_result = 0;
 }
 
+// Whether this host can create an AF_INET6 socket at all.
+static int host_supports_ipv6(void) {
+    int probe = socket(PF_INET6, SOCK_STREAM, 0);
+    if (probe < 0)
+        return 0;
+    close(probe);
+    return 1;
+}
+
 static void test_tcp_connect_address_is_zero_initialised(void) {
     struct tcp_session session = {0};
     session.version = 4;
@@ -650,6 +705,12 @@ static void test_tcp_connect_address_is_zero_initialised(void) {
     inet_pton(AF_INET6, "2001:db8::10", &session.daddr.ip6);
     session.dest = htons(443);
     connect_calls = 0;
+    if (!host_supports_ipv6()) {
+        // Some containers offer no AF_INET6 at all; that is a property of the
+        // host, not of the code under test.
+        puts("SKIP: host has no IPv6 support");
+        return;
+    }
     int socket6 = open_tcp_socket(&args, &session, NULL);
     CHECK(socket6 >= 0 && connect_calls == 1 && last_connect_family == AF_INET6,
           "TCP opener connects with an IPv6 sockaddr");
@@ -800,6 +861,7 @@ static void test_socks5_stream_fragmentation_and_short_writes(void) {
 int main(void) {
     test_queued_fin_waits_for_gap_and_drains();
     test_upstream_eof_keeps_write_half();
+    test_finished_session_releases_upstream_socket();
     test_hup_marks_only_read_half_closed();
     test_hup_waits_for_unread_data_behind_closed_window();
     test_closed_session_releases_queued_payload();


### PR DESCRIPTION
Follow-up from a review of the recent hot-path fixes (#909, #910, #913, #915, #916, #919, #921, #922, #924, #925, #926).

## The bug

Since the half-close work, the upstream socket is deliberately kept open past the peer's EOF so the client's remaining data can still be written to it. Nothing closes it again once both directions are finished: after the client FIN has been consumed (write half shut down, forward queue empty) and the peer has sent EOF, the descriptor stays registered in the epoll set while the session waits in `TCP_LAST_ACK` for the client's final ACK.

A fully closed socket reports `EPOLLHUP`, and epoll delivers that whether or not it was requested — so `epoll_wait()` returns immediately on every iteration and `handle_events()` re-walks the whole session list instead of sleeping. In the normal case that lasts only the round trip to the app, but a client that never acknowledges the FIN (a killed app, a lost ACK) keeps the loop spinning for the full `TCP_CLOSE_TIMEOUT`.

Before #915 this could not happen: the EOF path closed the socket outright.

## The fix

`release_finished_upstream()` closes the descriptor as soon as neither direction can carry another byte — `upstream_read_eof && client_fin_consumed && forward == NULL` — which removes it from the epoll set. The session itself is untouched and still lives on until `check_tcp_session()` accounts and reaps it; `monitor_tcp_session()` and the `TCP_CLOSING` path already skip a session whose socket is `-1`.

## Tests

- New `test_finished_session_releases_upstream_socket()` in `tcp_half_close_test.c`: fails on the parent commit, passes here.
- Full native defensive suite, plus `tcp_queue`, `tcp_window`, `tcp_half_close`, `tcp_epoll`, `route_flow`, `udp_state`, `wg_flow_cache` and `dns_frame` — all pass.
- The IPv6 opener assertions in `tcp_half_close_test.c` and `tcp_defensive_test.c` now skip when the host cannot create an `AF_INET6` socket at all, so the suite runs on containers without IPv6 (it aborted there before, which is how this was found).

https://claude.ai/code/session_01YRjEng6MN2MmtMDMjEdNRg

---
_Generated by [Claude Code](https://claude.ai/code/session_01YRjEng6MN2MmtMDMjEdNRg)_