### PR TITLE
Fix TCP close handling and TUN failure recovery qualification

### DIFF
--- a/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/wg/WgConnectivityMonitor.kt
@@ -80,6 +80,7 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
     private var numProds: Int = 0
     private var tunWriteFailuresTotal = 0L
     private var tunWriteFailureStartedAt: Long? = null
+    private var tunWriteFailureRunIdentity: Long? = null
     private var tunWriteFailuresSuspended = false
 
     /**
@@ -145,6 +146,7 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
     fun onSuspended(now: Long) {
         resetProd()
         tunWriteFailureStartedAt = null
+        tunWriteFailureRunIdentity = null
         tunWriteFailuresSuspended = true
         when (val s = state) {
             is ConnState.Connected -> state = s.copy(rxTimestamp = now, txTimestamp = now)
@@ -190,6 +192,12 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
             tunWriteFailuresSuspended = false
             return false
         }
+        if (stats.tunWriteFailuresTotal < 0L || stats.tunWriteFailuresStreak < 0L ||
+            stats.tunWriteFailuresStreak > stats.tunWriteFailuresTotal) {
+            // Negative or impossible samples cannot prove a continuous run.
+            resetTunWriteFailures(stats.tunWriteFailuresTotal)
+            return false
+        }
         if (stats.tunWriteFailuresStreak == 0L) {
             resetTunWriteFailures(stats.tunWriteFailuresTotal)
             return false
@@ -204,12 +212,24 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
             // No newly observed failed write means the previous qualification
             // window has gone stale, even if the native streak is nonzero.
             tunWriteFailureStartedAt = null
+            tunWriteFailureRunIdentity = null
             return false
         }
 
         tunWriteFailuresTotal = stats.tunWriteFailuresTotal
         if (stats.tunWriteFailuresStreak < TUN_WRITE_FAILURE_STREAK_THRESHOLD) {
             tunWriteFailureStartedAt = null
+            tunWriteFailureRunIdentity = null
+            return false
+        }
+
+        // total - streak is the cumulative failure count before this run. It
+        // stays constant across a continuous run and changes after a full
+        // write resets the native streak between samples.
+        val runIdentity = stats.tunWriteFailuresTotal - stats.tunWriteFailuresStreak
+        if (runIdentity != tunWriteFailureRunIdentity) {
+            tunWriteFailureRunIdentity = runIdentity
+            tunWriteFailureStartedAt = now
             return false
         }
         val startedAt = tunWriteFailureStartedAt ?: now.also {
@@ -221,6 +241,7 @@ internal class WgConnectivityChecker(private val prod: () -> Unit) {
     private fun resetTunWriteFailures(total: Long) {
         tunWriteFailuresTotal = total
         tunWriteFailureStartedAt = null
+        tunWriteFailureRunIdentity = null
     }
 
     /**

--- a/app/src/main/jni/netguard/tcp.c
+++ b/app/src/main/jni/netguard/tcp.c
@@ -71,6 +71,29 @@ int tcp_window_probe_delay(struct tcp_session *cur, long long now,
                          : 0;
 }
 
+/* Release the upstream socket once neither direction can carry another byte:
+ * the client's FIN has been consumed (its write half is shut down and nothing
+ * is queued) and the peer has sent EOF.  A fully closed socket left in the
+ * epoll set reports EPOLLHUP, which is delivered whether or not it was
+ * requested, so every epoll_wait() would return immediately and spin the
+ * event loop until the session is reaped — up to TCP_CLOSE_TIMEOUT seconds
+ * when the client never acknowledges our FIN.  Closing the descriptor removes
+ * it from the set; the session itself lives on until check_tcp_session()
+ * accounts and reaps it. */
+static void release_finished_upstream(struct ng_session *s, const char *session) {
+    struct tcp_session *cur = &s->tcp;
+    if (s->socket < 0 || !cur->upstream_read_eof || !cur->client_fin_consumed ||
+        cur->forward != NULL)
+        return;
+
+    if (close(s->socket))
+        log_android(ANDROID_LOG_ERROR, "%s close error %d: %s",
+                    session, errno, strerror(errno));
+    else
+        log_android(ANDROID_LOG_WARN, "%s upstream socket finished", session);
+    s->socket = -1;
+}
+
 static int consume_client_fin(const struct arguments *args,
                                struct ng_session *s, const char *session) {
     struct tcp_session *cur = &s->tcp;
@@ -103,6 +126,7 @@ static int consume_client_fin(const struct arguments *args,
         cur->state = TCP_CLOSE_WAIT;
 
     log_android(ANDROID_LOG_WARN, "%s consumed client FIN", session);
+    release_finished_upstream(s, session);
     return 1;
 }
 
@@ -133,7 +157,9 @@ static int mark_upstream_eof(const struct arguments *args,
     cur->window_probe_delay = 0;
     cur->window_probe_deadline = 0;
     log_android(ANDROID_LOG_WARN, "%s recv eof", session);
-    return send_server_fin(args, s, session) < 0 ? -1 : 1;
+    int sent = send_server_fin(args, s, session);
+    release_finished_upstream(s, session);
+    return sent < 0 ? -1 : 1;
 }
 
 void clear_tcp_data(struct tcp_session *cur) {
@@ -1174,9 +1200,24 @@ jboolean handle_tcp(const struct arguments *args,
             // Queue data to forward
             if (datalen) {
                 if (cur->socket < 0) {
-                    log_android(ANDROID_LOG_ERROR, "%s data while local closed", session);
-                    write_rst(args, &cur->tcp);
-                    return 0;
+                    uint32_t seq = ntohl(tcphdr->seq);
+                    uint32_t end = seq + (uint32_t) datalen;
+                    // A released upstream cannot accept new bytes, but a
+                    // retransmission of bytes consumed before the FIN still
+                    // needs the ordinary FIN/ACK handling below.  Sequence
+                    // comparisons are wrap-safe; datalen is uint16_t, so the
+                    // segment cannot span more than one sequence space.
+                    if (!cur->tcp.client_fin_consumed ||
+                        compare_u32(seq, cur->tcp.client_fin_seq) >= 0 ||
+                        compare_u32(end, cur->tcp.client_fin_seq) > 0) {
+                        log_android(ANDROID_LOG_ERROR,
+                                    "%s data while local closed", session);
+                        write_rst(args, &cur->tcp);
+                        return 0;
+                    }
+                    log_android(ANDROID_LOG_WARN,
+                                "%s duplicate consumed data after local close", session);
+                    datalen = 0;
                 }
                 if (cur->tcp.client_fin_seen) {
                     uint32_t seq = ntohl(tcphdr->seq);

--- a/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityCheckerTest.kt
+++ b/app/src/test/java/net/kollnig/missioncontrol/wg/WgConnectivityCheckerTest.kt
@@ -206,6 +206,67 @@ class WgConnectivityCheckerTest {
         assertEquals(true, c.lastTickSawRx)
     }
 
+    /** A successful write between polls changes total - streak and restarts qualification. */
+    @Test
+    fun hiddenSuccessfulWritesRestartTunFailurePersistence() {
+        val c = newChecker()
+        c.seed(0, stats(0, 0))
+
+        var total = 0L
+        for (second in 1..8) {
+            val streak = 8L
+            total += streak
+            assertEquals(
+                WgVerdict.HEALTHY,
+                c.tick(second * 1000L, stats(second * 100L, second * 10L, true,
+                    total, streak))
+            )
+        }
+        // A second set of bursts has increasing streaks but a successful write
+        // between every poll, so total - streak changes on every sample.
+        for (second in 9..16) {
+            val streak = second.toLong()
+            total += streak
+            assertEquals(
+                WgVerdict.HEALTHY,
+                c.tick(second * 1000L, stats(second * 100L, second * 10L, true,
+                    total, streak))
+            )
+        }
+    }
+
+    /** After a real write reset, a new continuous run needs a fresh five-second window. */
+    @Test
+    fun resumedContinuousTunFailuresNeedFreshPersistenceWindow() {
+        val c = newChecker()
+        c.seed(0, stats(0, 0))
+
+        assertEquals(WgVerdict.HEALTHY, c.tick(1000, stats(100, 10, true, 8, 8)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(2000, stats(100, 10, true, 9, 9)))
+        // A successful write between polls resets the native streak, so the
+        // next burst has a different total - streak identity.
+        assertEquals(WgVerdict.HEALTHY, c.tick(3000, stats(100, 10, true, 17, 8)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(4000, stats(100, 10, true, 18, 9)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(7999, stats(100, 10, true, 22, 13)))
+        assertEquals(WgVerdict.BROKEN, c.tick(8000, stats(100, 10, true, 23, 14)))
+    }
+
+    /** Negative and internally inconsistent native samples cannot qualify a failure run. */
+    @Test
+    fun invalidTunWriteSamplesRequalifyConservatively() {
+        val c = newChecker()
+        c.seed(0, stats(0, 0))
+
+        assertEquals(WgVerdict.HEALTHY, c.tick(1000, stats(100, 10, true, 8, 8)))
+        // Invalid samples must clear an already active qualification window.
+        assertEquals(WgVerdict.HEALTHY, c.tick(2000, stats(100, 10, true, -1, 8)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(3000, stats(100, 10, true, 9, -1)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(4000, stats(100, 10, true, 7, 8)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(5000, stats(100, 10, true, 8, 8)))
+        assertEquals(WgVerdict.HEALTHY, c.tick(9999, stats(100, 10, true, 12, 12)))
+        assertEquals(WgVerdict.BROKEN, c.tick(10_000, stats(100, 10, true, 13, 13)))
+    }
+
     /** Continuous two-way traffic never trips the watchdog. */
     @Test
     fun continuousTrafficStaysHealthy() {

--- a/app/src/test/native/tcp_defensive_test.c
+++ b/app/src/test/native/tcp_defensive_test.c
@@ -267,6 +267,15 @@ static void test_tcp_epoll_add_failure_does_not_retain_session(void) {
     epoll_result = 0;
 }
 
+// Whether this host can create an AF_INET6 socket at all.
+static int host_supports_ipv6(void) {
+    int probe = socket(PF_INET6, SOCK_STREAM, 0);
+    if (probe < 0)
+        return 0;
+    close(probe);
+    return 1;
+}
+
 static void test_tcp_connect_address_is_zero_initialised(void) {
     struct tcp_session session = {0};
     session.version = 4;
@@ -296,6 +305,12 @@ static void test_tcp_connect_address_is_zero_initialised(void) {
     inet_pton(AF_INET6, "2001:db8::10", &session.daddr.ip6);
     session.dest = htons(443);
     connect_calls = 0;
+    if (!host_supports_ipv6()) {
+        // Some containers offer no AF_INET6 at all; that is a property of the
+        // host, not of the code under test.
+        puts("SKIP: host has no IPv6 support");
+        return;
+    }
     int socket6 = open_tcp_socket(&args, &session, NULL);
     CHECK(socket6 >= 0 && connect_calls == 1 && last_connect_family == AF_INET6,
           "TCP opener connects with an IPv6 sockaddr");

--- a/app/src/test/native/tcp_epoll_test.c
+++ b/app/src/test/native/tcp_epoll_test.c
@@ -1,15 +1,245 @@
 #define main existing_harness_main
 #define epoll_ctl mocked_epoll_ctl
+#define __wrap_close tcp_half_close_mock_close
 #include "tcp_half_close_test.c"
+#undef __wrap_close
 #undef main
 #undef epoll_ctl
+#include <errno.h>
+#include <fcntl.h>
 #include <time.h>
 extern int epoll_ctl(int, int, int, struct epoll_event *);
 extern int __real_close(int);
 
+int __wrap_close(int file_descriptor) {
+    close_calls++;
+    return __real_close(file_descriptor);
+}
+
 static long now_ms(void) {
     struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t);
     return t.tv_sec*1000L+t.tv_nsec/1000000;
+}
+
+static void close_real_fd(int *file_descriptor) {
+    if (*file_descriptor >= 0) {
+        __real_close(*file_descriptor);
+        *file_descriptor = -1;
+    }
+}
+
+static void finish_real_epoll_session(struct ng_session *session,
+                                      struct arguments *args,
+                                      int epoll_fd,
+                                      int upstream_fd,
+                                      int close_count_before,
+                                      int expected_state) {
+    struct epoll_event event;
+    CHECK(epoll_wait(epoll_fd, &event, 1, 100) == 0,
+          "finished upstream socket is removed from real epoll");
+    CHECK(session->socket < 0 && close_calls == close_count_before + 1,
+          "finished upstream socket closes exactly once");
+    errno = 0;
+    CHECK(fcntl(upstream_fd, F_GETFD) < 0 && errno == EBADF,
+          "finished upstream descriptor is closed in the kernel");
+    CHECK(session->tcp.state == expected_state,
+          "TCP session remains pending after upstream descriptor release");
+
+    session->tcp.time = time(NULL);
+    CHECK(check_tcp_session(args, session, 0, SESSION_MAX) == 0 &&
+                  session->tcp.state == expected_state,
+          "pending TCP session survives an immediate timeout check");
+}
+
+static void real_client_fin_then_upstream_eof(void) {
+    int upstream[2] = {-1, -1};
+    int tun[2] = {-1, -1};
+    int epoll_fd = -1;
+    int close_count_start = close_calls;
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, upstream) == 0,
+          "client-first real socketpair");
+    CHECK(pipe2(tun, O_NONBLOCK) == 0, "client-first real TUN surrogate");
+    epoll_fd = epoll_create1(0);
+    CHECK(epoll_fd >= 0, "client-first real epoll");
+    if (upstream[0] < 0 || upstream[1] < 0 || tun[0] < 0 || tun[1] < 0 ||
+        epoll_fd < 0)
+        goto cleanup;
+
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    make_session(&session, upstream[0], TCP_ESTABLISHED);
+    make_args(&args, &context, &session, tun[1]);
+    session.ev.events = EPOLLERR;
+    session.ev.data.ptr = &session;
+    CHECK(epoll_ctl(epoll_fd, EPOLL_CTL_ADD, upstream[0], &session.ev) == 0,
+          "client-first real epoll registration");
+
+    uint8_t packet[256];
+    uint8_t queued[50];
+    memset(queued, 'g', sizeof(queued));
+    size_t length = make_packet(packet, 150, session.tcp.local_seq, 65535,
+                                queued, sizeof(queued), 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "client-first out-of-order data is queued");
+    drain_tun(tun[0]);
+
+    length = make_packet(packet, 200, session.tcp.local_seq, 65535,
+                         NULL, 0, 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "client-first FIN is retained behind the data gap");
+    CHECK(session.tcp.client_fin_seen && !session.tcp.client_fin_consumed,
+          "client-first FIN is not consumed before the gap drains");
+    drain_tun(tun[0]);
+
+    uint8_t prefix[50];
+    memset(prefix, 'p', sizeof(prefix));
+    length = make_packet(packet, 100, session.tcp.local_seq, 65535,
+                         prefix, sizeof(prefix), 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "client-first gap-filling data is accepted");
+    drain_tun(tun[0]);
+    monitor_tcp_session(&args, &session, epoll_fd);
+
+    struct epoll_event event;
+    CHECK(epoll_wait(epoll_fd, &event, 1, 1000) == 1,
+          "client-first queued data becomes writable");
+    if (session.socket >= 0)
+        check_tcp_socket(&args, &event, epoll_fd);
+    uint8_t received[100];
+    CHECK(recv(upstream[1], received, sizeof(received), MSG_DONTWAIT) == 100,
+          "client-first queued data drains before FIN consumption");
+    CHECK(session.tcp.client_fin_consumed && session.tcp.upstream_write_shutdown,
+          "client-first FIN is consumed after the gap drains");
+    CHECK(session.socket >= 0 && close_calls == close_count_start,
+          "client-first keeps the socket until upstream EOF");
+
+    CHECK(shutdown(upstream[1], SHUT_WR) == 0,
+          "client-first peer sends upstream EOF");
+    monitor_tcp_session(&args, &session, epoll_fd);
+    CHECK(epoll_wait(epoll_fd, &event, 1, 1000) == 1,
+          "client-first upstream EOF reaches real epoll");
+    int close_count_before = close_calls;
+    if (session.socket >= 0)
+        check_tcp_socket(&args, &event, epoll_fd);
+    finish_real_epoll_session(&session, &args, epoll_fd, upstream[0],
+                              close_count_before, TCP_LAST_ACK);
+    upstream[0] = -1;
+
+    // The final ACK is deliberately delayed until after the no-spin check.
+    length = make_packet(packet, session.tcp.remote_seq, session.tcp.local_seq,
+                         65535, NULL, 0, 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1 &&
+                  session.tcp.server_fin_acked && session.tcp.state == TCP_CLOSING,
+          "client-first final ACK advances LAST_ACK to CLOSING");
+    drain_tun(tun[0]);
+    clear_tcp_data(&session.tcp);
+
+cleanup:
+    close_real_fd(&upstream[0]);
+    close_real_fd(&upstream[1]);
+    close_real_fd(&tun[0]);
+    close_real_fd(&tun[1]);
+    close_real_fd(&epoll_fd);
+}
+
+static void real_upstream_eof_then_client_fin(void) {
+    int upstream[2] = {-1, -1};
+    int tun[2] = {-1, -1};
+    int epoll_fd = -1;
+    int close_count_start = close_calls;
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, upstream) == 0,
+          "upstream-first real socketpair");
+    CHECK(pipe2(tun, O_NONBLOCK) == 0, "upstream-first real TUN surrogate");
+    epoll_fd = epoll_create1(0);
+    CHECK(epoll_fd >= 0, "upstream-first real epoll");
+    if (upstream[0] < 0 || upstream[1] < 0 || tun[0] < 0 || tun[1] < 0 ||
+        epoll_fd < 0)
+        goto cleanup;
+
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    make_session(&session, upstream[0], TCP_ESTABLISHED);
+    make_args(&args, &context, &session, tun[1]);
+    session.ev.events = EPOLLERR;
+    session.ev.data.ptr = &session;
+    CHECK(epoll_ctl(epoll_fd, EPOLL_CTL_ADD, upstream[0], &session.ev) == 0,
+          "upstream-first real epoll registration");
+
+    CHECK(shutdown(upstream[1], SHUT_WR) == 0,
+          "upstream-first peer sends EOF");
+    monitor_tcp_session(&args, &session, epoll_fd);
+    struct epoll_event event;
+    CHECK(epoll_wait(epoll_fd, &event, 1, 1000) == 1,
+          "upstream-first EOF reaches real epoll");
+    if (session.socket >= 0)
+        check_tcp_socket(&args, &event, epoll_fd);
+    CHECK(session.tcp.upstream_read_eof && session.tcp.server_fin_sent &&
+                  session.tcp.state == TCP_FIN_WAIT1,
+          "upstream-first EOF sends a FIN while the client direction remains open");
+    CHECK(session.socket >= 0 && close_calls == close_count_start,
+          "upstream-first keeps the socket before client FIN consumption");
+    drain_tun(tun[0]);
+
+    uint8_t packet[256];
+    uint8_t queued[50];
+    memset(queued, 'g', sizeof(queued));
+    uint32_t withheld_ack = session.tcp.local_seq - 1;
+    size_t length = make_packet(packet, 150, withheld_ack, 65535,
+                                queued, sizeof(queued), 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "upstream-first out-of-order data is queued");
+    drain_tun(tun[0]);
+    length = make_packet(packet, 200, withheld_ack, 65535,
+                         NULL, 0, 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "upstream-first FIN is retained behind the data gap");
+    drain_tun(tun[0]);
+    uint8_t prefix[50];
+    memset(prefix, 'p', sizeof(prefix));
+    length = make_packet(packet, 100, withheld_ack, 65535,
+                         prefix, sizeof(prefix), 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, epoll_fd) == 1,
+          "upstream-first gap-filling data is accepted");
+    drain_tun(tun[0]);
+    monitor_tcp_session(&args, &session, epoll_fd);
+    CHECK(epoll_wait(epoll_fd, &event, 1, 1000) == 1,
+          "upstream-first queued data becomes writable");
+    int close_count_before = close_calls;
+    if (session.socket >= 0)
+        check_tcp_socket(&args, &event, epoll_fd);
+    uint8_t received[100];
+    CHECK(recv(upstream[1], received, sizeof(received), MSG_DONTWAIT) == 100,
+          "upstream-first queued data drains before FIN consumption");
+    CHECK(session.tcp.client_fin_consumed && session.tcp.upstream_write_shutdown,
+          "upstream-first FIN is consumed after the gap drains");
+    CHECK(session.tcp.state == TCP_FIN_WAIT1,
+          "upstream-first remains FIN_WAIT1 while the final ACK is withheld");
+
+    finish_real_epoll_session(&session, &args, epoll_fd, upstream[0],
+                              close_count_before, TCP_FIN_WAIT1);
+    upstream[0] = -1;
+    session.tcp.time = time(NULL) - TCP_CLOSE_TIMEOUT - 1;
+    CHECK(check_tcp_session(&args, &session, 0, SESSION_MAX) == 0 &&
+                  session.tcp.state == TCP_CLOSE,
+          "upstream-first session closes on its FIN timeout without an ACK");
+    drain_tun(tun[0]);
+    clear_tcp_data(&session.tcp);
+
+cleanup:
+    close_real_fd(&upstream[0]);
+    close_real_fd(&upstream[1]);
+    close_real_fd(&tun[0]);
+    close_real_fd(&tun[1]);
+    close_real_fd(&epoll_fd);
 }
 
 static void real_stream(uint32_t start) {
@@ -93,5 +323,7 @@ static void real_closed_window(void) {
 int main(void) {
     real_stream(100); real_stream(UINT32_MAX-16000);
     real_closed_window();
+    real_client_fin_then_upstream_eof();
+    real_upstream_eof_then_client_fin();
     return failures?1:0;
 }

--- a/app/src/test/native/tcp_half_close_test.c
+++ b/app/src/test/native/tcp_half_close_test.c
@@ -288,6 +288,42 @@ static void drain_tun(int fd) {
         ;
 }
 
+static void finish_data_fin_session(struct ng_session *session,
+                                    struct context *context,
+                                    struct arguments *args,
+                                    int upstream[2], int tun[2],
+                                    uint32_t sequence,
+                                    const uint8_t *data, size_t data_len) {
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, upstream) == 0,
+          "socketpair for consumed DATA+FIN");
+    CHECK(pipe(tun) == 0, "pipe for consumed DATA+FIN ACKs");
+    if (failures != 0)
+        return;
+    fcntl(tun[0], F_SETFL, O_NONBLOCK);
+
+    make_session(session, upstream[0], TCP_ESTABLISHED);
+    make_args(args, context, session, tun[1]);
+    session->tcp.remote_seq = sequence;
+    session->tcp.remote_start = sequence;
+    uint8_t packet[256];
+    size_t length = make_packet(packet, sequence, session->tcp.local_seq,
+                                65535, data, data_len, 1);
+    CHECK(handle_tcp(args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 1,
+          "in-order DATA+FIN is accepted");
+    struct epoll_event event = {.events = EPOLLOUT, .data.ptr = session};
+    check_tcp_socket(args, &event, -1);
+    CHECK(session->tcp.client_fin_consumed && session->tcp.remote_seq ==
+                  sequence + (uint32_t) data_len + 1,
+          "DATA drains before the client FIN is consumed");
+    CHECK(shutdown(upstream[1], SHUT_WR) == 0,
+          "peer sends EOF after consumed DATA+FIN");
+    event.events = EPOLLIN;
+    check_tcp_socket(args, &event, -1);
+    CHECK(session->socket < 0 && session->tcp.state == TCP_LAST_ACK,
+          "upstream EOF releases the finished DATA+FIN socket");
+}
+
 static void test_queued_fin_waits_for_gap_and_drains(void) {
     int upstream[2];
     int tun[2];
@@ -401,6 +437,156 @@ static void test_upstream_eof_keeps_write_half(void) {
           "simultaneous FIN shuts down only the upstream write half");
     CHECK(session.tcp.remote_seq == 117 && session.tcp.state == TCP_CLOSING,
           "simultaneous FIN closes after the packet ACKs the upstream FIN");
+
+    drain_tun(tun[0]);
+    close(upstream[0]);
+    close(upstream[1]);
+    close(tun[0]);
+    close(tun[1]);
+    clear_tcp_data(&session.tcp);
+}
+
+static void test_finished_session_releases_upstream_socket(void) {
+    int upstream[2];
+    int tun[2];
+    CHECK(socketpair(AF_UNIX, SOCK_STREAM, 0, upstream) == 0,
+          "socketpair for finished session");
+    CHECK(pipe(tun) == 0, "pipe for finished session FINs");
+    if (failures != 0)
+        return;
+    fcntl(tun[0], F_SETFL, O_NONBLOCK);
+
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    make_session(&session, upstream[0], TCP_ESTABLISHED);
+    make_args(&args, &context, &session, tun[1]);
+
+    uint8_t packet[256];
+    size_t length = make_packet(packet, 100, session.tcp.local_seq, 65535,
+                                NULL, 0, 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr), 1, 1,
+                     NULL, -1) == 1, "client FIN is accepted");
+    CHECK(session.tcp.client_fin_consumed && session.socket >= 0,
+          "a consumed client FIN alone keeps the read half open");
+
+    int closed_before = close_calls;
+    CHECK(shutdown(upstream[1], SHUT_WR) == 0, "peer sends EOF after the client FIN");
+    struct epoll_event event = {.events = EPOLLIN, .data.ptr = &session};
+    check_tcp_socket(&args, &event, -1);
+
+    CHECK(session.tcp.upstream_read_eof && session.tcp.server_fin_sent &&
+                  session.tcp.state == TCP_LAST_ACK,
+          "upstream EOF after a consumed FIN sends the last FIN");
+    // A fully closed socket left registered reports EPOLLHUP on every
+    // epoll_wait(), which would spin the event loop until the session is
+    // reaped.  Releasing the descriptor removes it from the epoll set.
+    CHECK(session.socket < 0 && close_calls == closed_before + 1,
+          "a finished session releases its upstream socket once");
+
+    drain_tun(tun[0]);
+    close(upstream[0]);
+    close(upstream[1]);
+    close(tun[0]);
+    close(tun[1]);
+    clear_tcp_data(&session.tcp);
+}
+
+static void test_closed_socket_discards_consumed_data_only(void) {
+    const uint8_t payload[] = {'D', 'A', 'T', 'A'};
+    int upstream[2] = {-1, -1};
+    int tun[2] = {-1, -1};
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    finish_data_fin_session(&session, &context, &args, upstream, tun,
+                            100, payload, sizeof(payload));
+    if (failures != 0)
+        return;
+
+    uint8_t packet[256];
+    uint32_t consumed_remote = session.tcp.remote_seq;
+    drain_tun(tun[0]);
+    size_t length = make_packet(packet, 100, 500, 65535,
+                                payload, sizeof(payload), 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 1 && session.tcp.state == TCP_LAST_ACK &&
+                  session.socket < 0 && session.tcp.forward == NULL &&
+                  session.tcp.remote_seq == consumed_remote,
+          "duplicate consumed DATA+FIN is acknowledged without reopening or requeueing");
+
+    length = make_packet(packet, 100, 500, 65535,
+                         payload, sizeof(payload), 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 1 && session.tcp.state == TCP_LAST_ACK &&
+                  session.socket < 0 && session.tcp.forward == NULL &&
+                  session.tcp.remote_seq == consumed_remote,
+          "duplicate consumed payload without FIN is ignored after socket release");
+
+    uint8_t fresh = 'x';
+    length = make_packet(packet, 104, 500, 65535, &fresh, 1, 0);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 0 && session.tcp.state == TCP_CLOSING,
+          "new payload after a consumed FIN is rejected after socket release");
+
+    drain_tun(tun[0]);
+    close(upstream[0]);
+    close(upstream[1]);
+    close(tun[0]);
+    close(tun[1]);
+    clear_tcp_data(&session.tcp);
+}
+
+static void test_closed_socket_duplicate_data_wraps_sequence_space(void) {
+    const uint8_t payload[32] = {0};
+    const uint32_t sequence = UINT32_MAX - 15;
+    int upstream[2] = {-1, -1};
+    int tun[2] = {-1, -1};
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    finish_data_fin_session(&session, &context, &args, upstream, tun,
+                            sequence, payload, sizeof(payload));
+    if (failures != 0)
+        return;
+
+    uint8_t packet[256];
+    uint32_t consumed_remote = session.tcp.remote_seq;
+    drain_tun(tun[0]);
+    size_t length = make_packet(packet, sequence, 500, 65535,
+                                payload, sizeof(payload), 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 1 && session.tcp.state == TCP_LAST_ACK &&
+                  session.socket < 0 && session.tcp.forward == NULL &&
+                  session.tcp.remote_seq == consumed_remote,
+          "wraparound duplicate DATA+FIN is acknowledged without sequence movement");
+
+    drain_tun(tun[0]);
+    close(upstream[0]);
+    close(upstream[1]);
+    close(tun[0]);
+    close(tun[1]);
+    clear_tcp_data(&session.tcp);
+}
+
+static void test_closed_socket_conflicting_fin_is_rejected(void) {
+    const uint8_t payload[] = {'D', 'A', 'T', 'A'};
+    int upstream[2] = {-1, -1};
+    int tun[2] = {-1, -1};
+    struct ng_session session;
+    struct context context;
+    struct arguments args;
+    finish_data_fin_session(&session, &context, &args, upstream, tun,
+                            100, payload, sizeof(payload));
+    if (failures != 0)
+        return;
+
+    uint8_t packet[256];
+    size_t length = make_packet(packet, 100, 500, 65535,
+                                payload, sizeof(payload) - 1, 1);
+    CHECK(handle_tcp(&args, packet, length, packet + sizeof(struct iphdr),
+                     1, 1, NULL, -1) == 0 && session.tcp.state == TCP_CLOSING,
+          "conflicting FIN sequence is rejected after socket release");
 
     drain_tun(tun[0]);
     close(upstream[0]);
@@ -621,6 +807,15 @@ static void test_tcp_epoll_add_failure_does_not_retain_session(void) {
     epoll_result = 0;
 }
 
+// Whether this host can create an AF_INET6 socket at all.
+static int host_supports_ipv6(void) {
+    int probe = socket(PF_INET6, SOCK_STREAM, 0);
+    if (probe < 0)
+        return 0;
+    close(probe);
+    return 1;
+}
+
 static void test_tcp_connect_address_is_zero_initialised(void) {
     struct tcp_session session = {0};
     session.version = 4;
@@ -650,6 +845,12 @@ static void test_tcp_connect_address_is_zero_initialised(void) {
     inet_pton(AF_INET6, "2001:db8::10", &session.daddr.ip6);
     session.dest = htons(443);
     connect_calls = 0;
+    if (!host_supports_ipv6()) {
+        // Some containers offer no AF_INET6 at all; that is a property of the
+        // host, not of the code under test.
+        puts("SKIP: host has no IPv6 support");
+        return;
+    }
     int socket6 = open_tcp_socket(&args, &session, NULL);
     CHECK(socket6 >= 0 && connect_calls == 1 && last_connect_family == AF_INET6,
           "TCP opener connects with an IPv6 sockaddr");
@@ -800,6 +1001,10 @@ static void test_socks5_stream_fragmentation_and_short_writes(void) {
 int main(void) {
     test_queued_fin_waits_for_gap_and_drains();
     test_upstream_eof_keeps_write_half();
+    test_finished_session_releases_upstream_socket();
+    test_closed_socket_discards_consumed_data_only();
+    test_closed_socket_duplicate_data_wraps_sequence_space();
+    test_closed_socket_conflicting_fin_is_rejected();
     test_hup_marks_only_read_half_closed();
     test_hup_waits_for_unread_data_behind_closed_window();
     test_closed_session_releases_queued_payload();


### PR DESCRIPTION
Finished TCP sessions can retain an upstream descriptor that continuously reports `EPOLLHUP`, spinning the event loop while the final ACK is outstanding. Release that descriptor once both directions finish, while accepting retransmissions of already-consumed payload and FIN without resetting the session. New payload and conflicting FINs remain rejected.

The WireGuard connectivity checker can also mistake separate TUN-write failure bursts for one sustained failure when successful writes occur between polls. Track the existing `total - streak` identity so each new failure run gets its own persistence window. Sustained failures still trigger recovery even with fresh handshakes and advancing receive counters.

This incorporates and extends #941. Testing #941 alone exposed a regression: retransmitted DATA+FIN after descriptor release changes `LAST_ACK` to a reset. This PR includes the correction and can replace #941. DNS socket lifetime and DNS cache invalidation policies are unchanged.

### Validation

- Eleven native regression suites passed on an isolated Android API 37 ARM64 emulator with NDK 27.2.12479018 and UBSan.
- Real-epoll regressions fail before #941 and pass with the socket-release fix; retransmission regressions fail with #941 alone and pass here. Coverage includes both FIN orderings, queued data, delayed ACKs, timeout and sequence wraparound.
- All 40 connectivity checker/monitor JVM tests passed; ten DNS cache/attribution tests also passed.
- All 101 Rust workspace tests passed.
- GitHub debug APK assembled successfully. ELF headers of both packaged native libraries match all four Android ABIs.

Real-device battery, throughput and DNS burst-loss profiling remain outstanding. No TrackerControl installation or real-device VPN configuration was changed during validation.
