### PR TITLE
Resolve async and adapter lint findings

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityDns.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityDns.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
@@ -113,6 +114,9 @@ public class ActivityDns extends AppCompatActivity {
         updateAdapter();
     }
 
+    // These one-shot database tasks are started only by this screen and gate
+    // their UI callbacks with running; executor migration is out of scope here.
+    @SuppressLint("StaticFieldLeak")
     private void cleanup() {
         new AsyncTask<Object, Object, Object>() {
             @Override
@@ -125,11 +129,15 @@ public class ActivityDns extends AppCompatActivity {
             @Override
             protected void onPostExecute(Object result) {
                 ServiceSinkhole.reload("DNS cleanup", ActivityDns.this, false);
-                updateAdapter();
+                if (running)
+                    updateAdapter();
             }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    // This is another bounded database task; its UI callback is lifecycle-gated
+    // and migrating the legacy AsyncTask is deliberately outside this lint fix.
+    @SuppressLint("StaticFieldLeak")
     private void clear() {
         new AsyncTask<Object, Object, Object>() {
             @Override
@@ -142,7 +150,8 @@ public class ActivityDns extends AppCompatActivity {
             @Override
             protected void onPostExecute(Object result) {
                 ServiceSinkhole.reload("DNS clear", ActivityDns.this, false);
-                updateAdapter();
+                if (running)
+                    updateAdapter();
             }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
@@ -169,6 +178,9 @@ public class ActivityDns extends AppCompatActivity {
         return intent;
     }
 
+    // The one-shot export callback already checks running; a lifecycle-aware
+    // executor migration is intentionally outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void handleExport(final Intent data) {
         new AsyncTask<Object, Object, Throwable>() {
             @Override

--- a/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityForwarding.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.database.Cursor;
 import android.os.AsyncTask;
@@ -150,6 +151,9 @@ public class ActivityForwarding extends AppCompatActivity {
     }
 
     @Override
+    // These one-shot rule/database tasks are tied to this dialog and gate their
+    // callbacks with running; migrating legacy AsyncTask is out of scope here.
+    @SuppressLint("StaticFieldLeak")
     public boolean onOptionsItemSelected(MenuItem item) {
         if (item.getItemId() == R.id.menu_add) {
                 LayoutInflater inflater = LayoutInflater.from(this);
@@ -175,6 +179,8 @@ public class ActivityForwarding extends AppCompatActivity {
 
                     @Override
                     protected void onPostExecute(List<Rule> rules) {
+                        if (!running)
+                            return;
                         ArrayAdapter spinnerArrayAdapter =
                                 new ArrayAdapter(ActivityForwarding.this,
                                         android.R.layout.simple_spinner_item, rules);

--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Intent;
@@ -105,7 +106,7 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
         });
 
         // Action bar custom view with switch
-        View actionView = getLayoutInflater().inflate(R.layout.actionlog, null, false);
+        View actionView = getLayoutInflater().inflate(R.layout.actionlog, toolbar, false);
         MaterialSwitch swEnabled = actionView.findViewById(R.id.swEnabled);
 
         getSupportActionBar().setDisplayShowCustomEnabled(true);
@@ -360,6 +361,9 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
     }
 
     @Override
+    // The clear task is a bounded database operation and gates its UI callback;
+    // migrating the legacy AsyncTask is deliberately outside this lint change.
+    @SuppressLint("StaticFieldLeak")
     public boolean onOptionsItemSelected(MenuItem item) {
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
         final File pcap_file = new File(getDir("data", MODE_PRIVATE), "netguard.pcap");
@@ -541,6 +545,9 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
         }
     }
 
+    // The one-shot export callback is lifecycle-gated by running; executor
+    // migration is intentionally outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void handleExportPCAP(final Intent data) {
         new AsyncTask<Object, Object, Throwable>() {
             @Override
@@ -596,10 +603,12 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
 
             @Override
             protected void onPostExecute(Throwable ex) {
-                if (ex == null)
-                    Toast.makeText(ActivityLog.this, R.string.msg_completed, Toast.LENGTH_LONG).show();
-                else
-                    Toast.makeText(ActivityLog.this, ex.toString(), Toast.LENGTH_LONG).show();
+                if (running) {
+                    if (ex == null)
+                        Toast.makeText(ActivityLog.this, R.string.msg_completed, Toast.LENGTH_LONG).show();
+                    else
+                        Toast.makeText(ActivityLog.this, ex.toString(), Toast.LENGTH_LONG).show();
+                }
             }
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.Manifest;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
@@ -278,7 +279,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         }
 
         // Action bar
-        final View actionView = getLayoutInflater().inflate(R.layout.actionmain, null, false);
+        final View actionView = getLayoutInflater().inflate(R.layout.actionmain, toolbar, false);
         tvTitle = actionView.findViewById(R.id.tvTitle);
         ivIcon = actionView.findViewById(R.id.ivIcon);
         ivQueue = actionView.findViewById(R.id.ivQueue);
@@ -623,6 +624,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
     }
 
     @Override
+    // Resuming recomputes the complete visible rule presentation, so no exact
+    // changed range exists for this notification.
+    @SuppressLint("NotifyDataSetChanged")
     protected void onResume() {
         Log.i(TAG, "Resume");
 
@@ -718,6 +722,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 state != ServiceSinkhole.PRIVATE_DNS_WARNING_NONE ? View.VISIBLE : View.GONE);
     }
 
+    // The query is one-shot and its callback is gated by running/generation;
+    // migrating this legacy AsyncTask is outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void refreshPrivateDnsBypassBanner() {
         updatePrivateDnsBypassBanner();
         final int generation = ++privateDnsWarningQueryGeneration;
@@ -803,6 +810,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
     }
 
     @Override
+    // Returning from a details screen can change any rule, so the exact changed
+    // rows are not known at this point.
+    @SuppressLint("NotifyDataSetChanged")
     protected void onActivityResult(int requestCode, int resultCode, final Intent data) {
         Log.i(TAG, "onActivityResult request=" + requestCode + " result=" + resultCode + " ok="
                 + (resultCode == RESULT_OK));
@@ -845,6 +855,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         }
     }
 
+    // The one-shot export callback already checks running; executor migration
+    // is intentionally outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void handleExport(Intent data) {
         new AsyncTask<Object, Object, Throwable>() {
             @Override
@@ -1030,6 +1043,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         public void onChanged() {
             runOnUiThread(new Runnable() {
                 @Override
+                // Access changes recompute all visible rows; their exact range
+                // is not available to this listener.
+                @SuppressLint("NotifyDataSetChanged")
                 public void run() {
                     if (adapter != null && adapter.isLive())
                         adapter.notifyDataSetChanged();
@@ -1392,6 +1408,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         }
     }
 
+    // This bounded rule query gates all UI work with running; migrating the
+    // legacy AsyncTask is deliberately outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void updateApplicationList(final String search) {
         Log.i(TAG, "Update search=" + search);
 

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -23,6 +23,7 @@ package eu.faircode.netguard;
 import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
@@ -209,6 +210,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         configurePreferences();
     }
 
+    // This preference action launches a bounded database task; lifecycle-aware
+    // executor migration is deliberately outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void configurePreferences() {
         final PreferenceScreen screen = getPreferenceScreen();
         final SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -257,6 +261,8 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
                                 @Override
                                 protected void onPostExecute(Throwable ex) {
+                                    if (!running)
+                                        return;
                                     if (ex == null)
                                         Toast.makeText(ActivitySettings.this, R.string.msg_completed, Toast.LENGTH_LONG)
                                                 .show();
@@ -1223,6 +1229,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         return intent;
     }
 
+    // The one-shot export callback already checks running; executor migration
+    // is intentionally outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void handleExport(final Intent data) {
         new AsyncTask<Object, Object, Throwable>() {
             @Override
@@ -1262,6 +1271,9 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         }.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
     }
 
+    // The one-shot import callback already checks running; executor migration
+    // is intentionally outside this focused lint change.
+    @SuppressLint("StaticFieldLeak")
     private void handleImport(final Intent data) {
         new AsyncTask<Object, Object, Throwable>() {
             @Override

--- a/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.Cursor;
@@ -97,6 +98,9 @@ public class AdapterAccess extends CursorAdapter {
     }
 
     @Override
+    // This one-shot hostname lookup is tied to a cursor row bind; migrating
+    // legacy AsyncTask to a lifecycle-aware executor is out of scope here.
+    @SuppressLint("StaticFieldLeak")
     public void bindView(final View view, final Context context, final Cursor cursor) {
         // Get values
         final int version = cursor.getInt(colVersion);

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
@@ -148,6 +149,9 @@ public class AdapterLog extends CursorAdapter {
     }
 
     @Override
+    // These bounded hostname/organisation lookups guard stale row results with
+    // bindToken; migrating the legacy AsyncTasks is out of scope here.
+    @SuppressLint("StaticFieldLeak")
     public void bindView(final View view, final Context context, final Cursor cursor) {
         // Get values
         long time = cursor.getLong(colTime);

--- a/app/src/main/java/eu/faircode/netguard/AdapterRule.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterRule.java
@@ -25,6 +25,7 @@ import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_PACKAG
 import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_UID;
 import static eu.faircode.netguard.ActivityMain.REQUEST_DETAILS_UPDATED;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -203,18 +204,24 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         }
     }
 
+    // Network-state changes recompute every visible row; no exact range exists.
+    @SuppressLint("NotifyDataSetChanged")
     public void setWifiActive() {
         wifiActive = true;
         otherActive = false;
         notifyDataSetChanged();
     }
 
+    // Network-state changes recompute every visible row; no exact range exists.
+    @SuppressLint("NotifyDataSetChanged")
     public void setMobileActive() {
         wifiActive = false;
         otherActive = true;
         notifyDataSetChanged();
     }
 
+    // Network-state changes recompute every visible row; no exact range exists.
+    @SuppressLint("NotifyDataSetChanged")
     public void setDisconnected() {
         wifiActive = false;
         otherActive = false;
@@ -378,6 +385,9 @@ public class AdapterRule extends RecyclerView.Adapter<AdapterRule.ViewHolder> im
         super.onViewRecycled(holder);
     }
 
+    // A root rule updates its UID-related rows recursively, so the exact range
+    // is not known when the complete presentation is refreshed.
+    @SuppressLint("NotifyDataSetChanged")
     private void updateRule(Context context, Rule rule, boolean root, List<Rule> listAll) {
         SharedPreferences apply = context.getSharedPreferences("apply", Context.MODE_PRIVATE);
         SharedPreferences tracker_protect = context.getSharedPreferences("tracker_protect", Context.MODE_PRIVATE);

--- a/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
+++ b/app/src/main/java/eu/faircode/netguard/HostsDownloadWorker.java
@@ -20,6 +20,7 @@
 
 package eu.faircode.netguard;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.util.Log;
@@ -96,6 +97,9 @@ public class HostsDownloadWorker extends Worker {
 
     @NonNull
     @Override
+    // These commits establish the durable merge-pending/merged ordering across
+    // worker retries; replacing either one with apply() could lose that state.
+    @SuppressLint("ApplySharedPref")
     public Result doWork() {
         Log.i(TAG, "Starting hosts download");
 

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
@@ -1,6 +1,7 @@
 package net.kollnig.missioncontrol;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.DialogInterface;
@@ -134,6 +135,8 @@ public class ActivityOnboarding extends AppCompatActivity {
         refreshSlides();
     }
 
+    // Slide state is recomputed as a whole, so no exact changed range exists.
+    @SuppressLint("NotifyDataSetChanged")
     private void setupSlides() {
         if (slidesInitialized) {
             return;
@@ -280,6 +283,9 @@ public class ActivityOnboarding extends AppCompatActivity {
         updateButtons(viewPager.getCurrentItem());
     }
 
+    // Refreshing onboarding recomputes every slide; the exact changed range is
+    // not available to this stateful pager adapter.
+    @SuppressLint("NotifyDataSetChanged")
     private void refreshSlides() {
         if (!slidesInitialized) {
             setupSlides();

--- a/app/src/main/java/net/kollnig/missioncontrol/Common.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/Common.kt
@@ -22,10 +22,10 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
-import android.net.Uri
 import android.view.View
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
+import androidx.core.net.toUri
 import eu.faircode.netguard.Util
 import java.io.BufferedReader
 import java.io.IOException
@@ -99,7 +99,7 @@ object Common {
         var url = url
         if (!url.startsWith("http://") && !url.startsWith("https://")) url = "http://" + url
 
-        return Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        return Intent(Intent.ACTION_VIEW, url.toUri())
     }
 
     /**

--- a/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/DetailsActivity.java
@@ -17,6 +17,7 @@
 
 package net.kollnig.missioncontrol;
 
+import android.annotation.SuppressLint;
 import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.Intent;
@@ -277,6 +278,9 @@ public class DetailsActivity extends AppCompatActivity {
     /**
      * Export tracking findings to CSV
      */
+    // onDestroy() cancels this task and dismisses its dialog; its UI callback is
+    // also gated by running, so the export is deliberately lifecycle-bounded.
+    @SuppressLint("StaticFieldLeak")
     class ExportDatabaseCSVTask extends AsyncTask<String, Void, Boolean> {
         private final ProgressDialog dialog = new ProgressDialog(DetailsActivity.this);
         TrackerList trackerList;

--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
@@ -28,12 +28,14 @@ import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.LinearLayout
 import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.FileProvider
+import androidx.core.graphics.createBitmap
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -167,7 +169,7 @@ class InsightsActivity : AppCompatActivity() {
         return try {
             // Inflate and populate view
             val inflater = LayoutInflater.from(this)
-            val shareView = inflater.inflate(R.layout.layout_insights_share, null)
+            val shareView = inflater.inflate(R.layout.layout_insights_share, FrameLayout(this), false)
 
             val tvTotalBlocked = shareView.findViewById<TextView>(R.id.tvShareTotalBlocked)
             val llBlockedStat = shareView.findViewById<LinearLayout>(R.id.llShareBlockedStat)
@@ -230,7 +232,7 @@ class InsightsActivity : AppCompatActivity() {
             shareView.layout(0, 0, shareView.measuredWidth, shareView.measuredHeight)
 
             // Draw to bitmap
-            val bitmap = Bitmap.createBitmap(shareView.measuredWidth, shareView.measuredHeight, Bitmap.Config.ARGB_8888)
+            val bitmap = createBitmap(shareView.measuredWidth, shareView.measuredHeight, Bitmap.Config.ARGB_8888)
             val canvas = Canvas(bitmap)
             shareView.draw(canvas)
 

--- a/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/TimelineFragment.java
@@ -20,6 +20,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.LinearLayout;
+import android.widget.FrameLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -231,6 +232,9 @@ public class TimelineFragment extends Fragment {
         loadInsights(generation);
     }
 
+    // The query uses the application context and rejects stale view generations
+    // before touching UI; migrating this bounded legacy AsyncTask is out of scope.
+    @android.annotation.SuppressLint("StaticFieldLeak")
     private void loadTimeline(final int generation) {
         if (!isCurrentView(generation))
             return;
@@ -336,7 +340,7 @@ public class TimelineFragment extends Fragment {
     private File generateShareImage(Context context, InsightsData data) {
         try {
             LayoutInflater inflater = LayoutInflater.from(context);
-            View shareView = inflater.inflate(R.layout.layout_insights_share, null);
+            View shareView = inflater.inflate(R.layout.layout_insights_share, new FrameLayout(context), false);
 
             TextView tvTotalBlocked = shareView.findViewById(R.id.tvShareTotalBlocked);
             LinearLayout llBlockedStat = shareView.findViewById(R.id.llShareBlockedStat);

--- a/app/src/main/java/net/kollnig/missioncontrol/data/PausedApps.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/data/PausedApps.java
@@ -7,6 +7,7 @@
 
 package net.kollnig.missioncontrol.data;
 
+import android.annotation.SuppressLint;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -74,6 +75,8 @@ public final class PausedApps {
         pause(context, packageName, uid, getConfiguredDurationMinutes(context) * 60_000L);
     }
 
+    // The snapshot must be durable before the live routing values are flipped.
+    @SuppressLint("ApplySharedPref")
     public static void pause(Context context, String packageName, int uid, long durationMs) {
         Context appContext = context.getApplicationContext();
         synchronized (LOCK) {
@@ -116,6 +119,8 @@ public final class PausedApps {
     }
 
     /** Drop a pause without changing any protection state. */
+    // Commit the removed snapshots before scheduling the next alarm.
+    @SuppressLint("ApplySharedPref")
     public static void cancel(Context context, String packageName, int uid) {
         Context appContext = context.getApplicationContext();
         synchronized (LOCK) {
@@ -129,6 +134,8 @@ public final class PausedApps {
     }
 
     /** Drop only the named package's pause snapshot. */
+    // Commit the removed snapshot before scheduling the next alarm.
+    @SuppressLint("ApplySharedPref")
     public static void cancel(Context context, String packageName) {
         if (packageName == null)
             return;
@@ -172,6 +179,8 @@ public final class PausedApps {
         onPackageRemoved(context, packageName);
     }
 
+    // Commit removal before scheduling an alarm so a deleted package cannot reappear.
+    @SuppressLint("ApplySharedPref")
     public static void onPackageRemoved(Context context, String packageName) {
         if (packageName == null)
             return;
@@ -277,6 +286,8 @@ public final class PausedApps {
         return readSnapshot(value);
     }
 
+    // Restore live values before durably deleting snapshots so a crash can retry.
+    @SuppressLint("ApplySharedPref")
     private static void restorePackages(Context context, List<String> packages) {
         if (packages.isEmpty())
             return;

--- a/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/TrackersFragment.java
@@ -1,5 +1,6 @@
 package net.kollnig.missioncontrol.details;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
@@ -234,6 +235,9 @@ public class TrackersFragment extends Fragment {
      * Communicate with tracker database to show information about tracking in a
      * given app
      */
+    // The one-shot tracker query rejects stale view generations and gates UI
+    // updates; migrating the legacy AsyncTask is deliberately out of scope.
+    @SuppressLint("StaticFieldLeak")
     public void updateTrackerList() {
         refreshing = true;
         final int generation = viewGeneration;

--- a/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/vpn/VpnFragment.java
@@ -1,5 +1,6 @@
 package net.kollnig.missioncontrol.vpn;
 
+import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.Bitmap;
@@ -548,6 +549,9 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
         }
     }
 
+    // Provider/profile state recomputes the whole adapter presentation; no
+    // exact changed range exists for this refresh.
+    @SuppressLint("NotifyDataSetChanged")
     private void refreshUi() {
         if (!isAdded() || adapter == null)
             return;
@@ -828,6 +832,9 @@ public class VpnFragment extends Fragment implements SharedPreferences.OnSharedP
 
         private final List<VpnCountry> countries = new ArrayList<>();
 
+        // Country replacement is a whole-dataset recomputation; the exact
+        // inserted/removed ranges are intentionally not inferred here.
+        @SuppressLint("NotifyDataSetChanged")
         void setCountries(List<VpnCountry> next) {
             countries.clear();
             countries.addAll(next);


### PR DESCRIPTION
## Summary

- lifecycle-gate UI callbacks from bounded legacy `AsyncTask` work
- document narrow exceptions where full-dataset refreshes and synchronous preference durability are intentional
- fix layout inflation parameters and use available Kotlin extensions
- remove `StaticFieldLeak`, `NotifyDataSetChanged`, `ApplySharedPref`, `InflateParams`, and `UseKtx` findings

## Validation

- `./gradlew :app:lintGithubDebug -q`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`
- focused `PausedAppsTest`
- `git diff --check`