### PR TITLE
Resolve remaining locale lint warnings

### DIFF
--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -120,7 +120,7 @@
     <string name="summary_socks5_enabled">سيتم إرسال حركة مرور TCP فقط إلى خادم الوكيل</string>
     <string name="summary_watchdog">تحقق دوريًا مما إذا كان التحكم في التتبع لا يزال قيد التشغيل (أدخل صفرًا لتعطيل هذا الخيار). قد يؤدي هذا إلى زيادة استهلاك البطارية.</string>
     <string name="msg_sure">هل أنت متأكد؟</string>
-    <string name="msg_started">البحث عن أدوات التتبع...</string>
+    <string name="msg_started">البحث عن أدوات التتبع…</string>
     <string name="msg_waiting">انتظار الحدث</string>
     <string name="msg_disabled">استخدم المفتاح أعلاه لتمكين التحكم في التتبع.</string>
     <string name="msg_revoked">تم تعطيل التحكم في التتبع، على الأرجح باستخدام تطبيق آخر يعتمد على VPN</string>

--- a/app/src/main/res/values-cs-rCZ/strings.xml
+++ b/app/src/main/res/values-cs-rCZ/strings.xml
@@ -117,7 +117,7 @@
     <string name="summary_socks5_enabled">Pouze TCP přenosy budou přenášeny skrze proxy server</string>
     <string name="summary_watchdog">Pravidelně kontrolovat, zda TrackerControl stále běží (zadejte nulu pro vypnutí). Toto nastavení může mít vliv na spotřebu.</string>
     <string name="msg_sure">Jste si jistí?</string>
-    <string name="msg_started">Vyhledávání trackerů...</string>
+    <string name="msg_started">Vyhledávání trackerů…</string>
     <string name="msg_waiting">Čekání na událost</string>
     <string name="msg_disabled">Pomocí výše uvedeného přepínače povolte TrackerControl.</string>
     <string name="msg_revoked">TrackerControl byl deaktivován, pravděpodobně jinou aplikací používající VPN rozhraní</string>

--- a/app/src/main/res/values-da-rDK/strings.xml
+++ b/app/src/main/res/values-da-rDK/strings.xml
@@ -71,7 +71,7 @@
     <string name="summary_log_app">Deaktiver for at mindske batteriforbrug. Nye trackere blokeres stadig, men vises ikke.</string>
     <string name="summary_track_usage">Spor antallet af sendte og modtagne bytes for hver app og adresse. Dette kan resultere i ekstra batteriforbrug.</string>
     <string name="msg_sure">Er du sikker?</string>
-    <string name="msg_started">Leder efter trackere...</string>
+    <string name="msg_started">Leder efter trackere…</string>
     <string name="msg_disabled">Brug knappen ovenfor for at aktivere TrackerControl.</string>
     <string name="msg_installed">Problemer med %1$s?</string>
     <string name="msg_installed_tracker_libraries_found">Indeholder %d tracker-biblioteker</string>
@@ -99,7 +99,7 @@
     <string name="yes">Ja</string>
     <string name="no">Nej</string>
     <string name="menu_csv">Eksportér som CSV</string>
-    <string name="exporting">Eksporterer...</string>
+    <string name="exporting">Eksporterer…</string>
     <string name="share_csv">Del</string>
     <!-- App Details -->
     <string name="title_activity_detail">Detaljer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -127,7 +127,7 @@
     <string name="summary_socks5_enabled">Nur TCP-Datenverkehr wird an den Proxyserver gesendet</string>
     <string name="summary_watchdog">In regelmäßigen Abständen überprüfen, ob TrackerControl noch läuft (geben Sie Null ein, um diese Option zu deaktivieren). Kann zu erhöhtem Akkuverbrauch führen.</string>
     <string name="msg_sure">Sind Sie sicher?</string>
-    <string name="msg_started">Suche nach Trackern...</string>
+    <string name="msg_started">Suche nach Trackern…</string>
     <string name="msg_waiting">Auf Ereignis warten</string>
     <string name="msg_disabled">Verwenden Sie den obigen Schalter um TrackerControl zu aktivieren.</string>
     <string name="msg_revoked">TrackerControl wurde deaktiviert, wahrscheinlich durch die Verwendung einer anderen VPN-Anwendung</string>
@@ -247,7 +247,7 @@
     <string name="yes">Ja</string>
     <string name="no">Nein</string>
     <string name="menu_csv">Als CSV-Datei exportieren</string>
-    <string name="exporting">Wird exportiert ...</string>
+    <string name="exporting">Wird exportiert …</string>
     <string name="share_csv">Teilen</string>
     <string name="export_failed">Export fehlgeschlagen</string>
     <string name="exported">In den Speicher exportiert!</string>
@@ -278,7 +278,7 @@
     <string name="google_dpo_mail">data-protection-office@google.com</string>
     <string name="dpas_overview_url">https://edpb.europa.eu/about-edpb/board/members</string>
     <string name="subject_request_data">GDPR Subject Access Request</string>
-    <string name="crash_dialog_text">Entschuldigung. TrackerControl ist abgestürzt ... Wir wären sehr dankbar dafür, wenn Sie uns eine E-Mail mit Details schicken.</string>
+    <string name="crash_dialog_text">Entschuldigung. TrackerControl ist abgestürzt … Wir wären sehr dankbar dafür, wenn Sie uns eine E-Mail mit Details schicken.</string>
     <string name="crash_dialog_comment">Bemerkungen?</string>
     <string name="instructions_monitoring_private_dns">Betätigen Sie den Schalter und nutzen Sie einige Apps. Private DNS muss deaktiviert werden.</string>
     <string name="instructions_monitoring">Betätigen Sie den Schalter und nutzen Sie einige Apps.</string>
@@ -287,7 +287,7 @@
     <string name="launch_app">Starten &amp; Tracker finden</string>
     <string name="countries">Zielländer</string>
     <string name="countries_explanation">Herausfinden, wohin Ihr Telefon Tracking-Daten sendet.\n\nInformationen basieren auf DNS-Abfragen und IP-Informationen und können ungenau sein.</string>
-    <string name="countries_loading_failed">Hoppla ... Die Karte konnte nicht geladen werden. Bitte wenden Sie sich an tc@kollnig.net.</string>
+    <string name="countries_loading_failed">Hoppla … Die Karte konnte nicht geladen werden. Bitte wenden Sie sich an tc@kollnig.net.</string>
     <string name="tracker_advertising">Werbung</string>
     <string name="tracker_analytics">Analyse</string>
     <string name="tracker_content">Notwendig</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -80,6 +80,7 @@
     <string name="setting_update">Comprobar actualizaciones</string>
     <plurals name="pause">
         <item quantity="one">Pausar por %d min</item>
+        <item quantity="many">Pausar por %d mins</item>
         <item quantity="other">Pausar por %d mins</item>
     </plurals>
     <string name="setting_network_options">Opciones de red</string>
@@ -138,7 +139,7 @@
     <string name="summary_socks5_enabled">Sólo el tráfico TCP será enviado al servidor proxy</string>
     <string name="summary_watchdog">Comprobar periódicamente si TrackerControl sigue funcionando (introducir cero para desactivar esta opción). Esto podría aumentar el consumo de la batería.</string>
     <string name="msg_sure">¿Estás seguro?</string>
-    <string name="msg_started">Buscando rastreadores...</string>
+    <string name="msg_started">Buscando rastreadores…</string>
     <string name="msg_waiting">Esperando evento</string>
     <string name="msg_disabled">Utiliza el interruptor de arriba para activar TrackerControl.</string>
     <string name="msg_revoked">TrackerControl ha sido desactivado, posiblemente por utilizar otra aplicación basada en VPN</string>
@@ -247,10 +248,12 @@ El tráfico de internet no será envíado a un servidor VPN ajeno.</string>
     <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
     <plurals name="n_companies_found_week">
         <item quantity="one">contactó %d empresa la última semana</item>
+        <item quantity="many">contactó %d empresas la última semana</item>
         <item quantity="other">contactó %d empresas la última semana</item>
     </plurals>
     <plurals name="n_companies_found">
         <item quantity="one">contactó %d empresa en total</item>
+        <item quantity="many">contactó %d empresas en total</item>
         <item quantity="other">contactó %d empresas en total</item>
     </plurals>
     <string name="confirm_ipinfo_title">¿Conseguir info de organización?</string>
@@ -335,7 +338,7 @@ Atentamente,\n\n]]></string>
     <string name="launch_app">Lanzar &amp; Buscar rastreadores</string>
     <string name="countries">Países de destino</string>
     <string name="countries_explanation">Averigua a dónde envía tu teléfono los datos de rastreo.\n\nLa información se basa en búsquedas de DNS e información de IP, y podría ser inexacta.</string>
-    <string name="countries_loading_failed">Oops... El mapa del país falló al cargar. Por favor, dígale a tc@kollnig.net cómo sucedió esto.</string>
+    <string name="countries_loading_failed">Oops… El mapa del país falló al cargar. Por favor, dígale a tc@kollnig.net cómo sucedió esto.</string>
     <string name="tracker_advertising">Publicidad</string>
     <string name="tracker_analytics">Datos de análisis</string>
     <string name="tracker_content">Esencial</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -96,7 +96,7 @@
     <string name="vpn_country_selected">Sobib</string>
     <string name="msg_wg_blocked_title">WireGuardi tunnel pole saadaval</string>
     <string name="msg_sure">Kas oled selles kindel?</string>
-    <string name="msg_started">Otsin jälitajaid...</string>
+    <string name="msg_started">Otsin jälitajaid…</string>
     <string name="msg_disabled">TrackerControli sisselülitamiseks kasuta ülal asuvat liugurlülitit.</string>
     <string name="msg_revoked">TrackerControl on lülitatud välja, ilmselt mõne teise VPN-põhise rakenduse tõttu</string>
     <string name="msg_installed_tracker_libraries_found">Sisaldab %d jälitajate teeki</string>
@@ -150,7 +150,7 @@
     <string name="yes">Jah</string>
     <string name="no">Ei</string>
     <string name="menu_csv">Ekspordi CSV-failina</string>
-    <string name="exporting">Ekspordin...</string>
+    <string name="exporting">Ekspordin…</string>
     <string name="share_csv">Jaga</string>
     <string name="export_failed">Eksportimine ei õnenstunud</string>
     <string name="exported">Eksportimine andmeruumi õnnestus!</string>
@@ -180,7 +180,7 @@
     <string name="launch_app_failed">Selle rakenduse käivitamine ei õnnestunud</string>
     <string name="countries">Sihtmaad</string>
     <string name="countries_explanation">Tuvasta maad, kuhu sinu telefon saadab jälitamisega seotud andmeid.\n\nTeave põhineb nimelahenduse päringutel ja IP-aadresside andmekogul ning ei pruugi olla täpne.</string>
-    <string name="countries_loading_failed">Vaat kus lops... Maakaardi laadimine ei õnnestunud. Palun kirjuta sellest tc@kollnig.net aadressile ja kirjelda, kuidas see juhtus.</string>
+    <string name="countries_loading_failed">Vaat kus lops… Maakaardi laadimine ei õnnestunud. Palun kirjuta sellest tc@kollnig.net aadressile ja kirjelda, kuidas see juhtus.</string>
     <string name="tracker_advertising">Reklaam</string>
     <string name="tracker_analytics">Analüütika</string>
     <string name="tracker_content">Põhitarvikud</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -303,7 +303,7 @@ Sincerely,\n\n]]></string>
     <string name="launch_app">Hasi &amp; bilatu aztarnariak</string>
     <string name="countries">Helburu herrialdeak</string>
     <string name="countries_explanation">Jakin ezazu nora bidaltzen dituen zure telefonoak datuak.\n\nInformazioa DNS eta IP eragiketetatik ateratzen da eta agian ez da guztiz zehatza.</string>
-    <string name="countries_loading_failed">Oops... huts egin du mapa kargatzeak. Idatzi tc@kollnig.net helbidera eta esan zer gertatu den mesedez.</string>
+    <string name="countries_loading_failed">Oops… huts egin du mapa kargatzeak. Idatzi tc@kollnig.net helbidera eta esan zer gertatu den mesedez.</string>
     <string name="tracker_advertising">Iragarkiak</string>
     <string name="tracker_analytics">Estatistikak</string>
     <string name="tracker_content">Beharrezkoak</string>

--- a/app/src/main/res/values-fi-rFI/strings.xml
+++ b/app/src/main/res/values-fi-rFI/strings.xml
@@ -115,7 +115,7 @@
     <string name="summary_socks5_enabled">Vain TCP-liikenne lähetetään välityspalvelimeen</string>
     <string name="summary_watchdog">Tarkista säännöllisesti, onko TrackerControl edelleen käynnissä (kirjoita nolla poistaaksesi tämän vaihtoehdon käytöstä). Tämä voi lisätä akun kulutusta.</string>
     <string name="msg_sure">Oletko varma?</string>
-    <string name="msg_started">Etsitään seuraimia...</string>
+    <string name="msg_started">Etsitään seuraimia…</string>
     <string name="msg_waiting">Odottaa tapahtumaa</string>
     <string name="msg_disabled">Ota yllä olevalla kytkimellä TrackerControl käyttöön.</string>
     <string name="msg_revoked">TrackerControl on poistettu käytöstä, todennäköisesti käyttämällä toista VPN-pohjaista sovellusta</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_description">TrackerControl permet aux utilisateurs de surveiller et de contrôler la collecte (cachée et courante) des données relatives à leur comportement dans les applications mobiles (\"tracking\").</string>
     <string name="app_copyright">Copyright \u00A9 2019–2022 Konrad Kollnig\n\nTrackerControl est basé sur NetGuard, développé par Marcel Bokhorst (M66B).</string>
     <string name="app_android">TrackerControl nécessite Android 5.1 ou une version ultérieure</string>
@@ -85,6 +85,7 @@
     <string name="setting_update">Vérifier les mises à jour</string>
     <plurals name="pause">
         <item quantity="one">Suspendre pendant %d min</item>
+        <item quantity="many">Pause pour %d mins</item>
         <item quantity="other">Pause pour %d mins</item>
     </plurals>
     <string name="setting_network_options">Paramètres de réseau</string>
@@ -182,7 +183,7 @@
     <string name="msg_wg_profile_empty">Aucun profil</string>
     <string name="msg_wg_profile_active">Actif</string>
     <string name="msg_wg_profile_set_active">Définir comme actif</string>
-    <string name="msg_wg_profile_config_hint">[Interface]\nClé Privée = ...\nAdresse = ...\n\n[Pair]\nClé publique = ...\nIP autorisées = 0.0.0.0/0, ::/0\nPoint de terminaison = ...</string>
+    <string tools:ignore="TypographyEllipsis" name="msg_wg_profile_config_hint">[Interface]\nClé Privée = ...\nAdresse = ...\n\n[Pair]\nClé publique = ...\nIP autorisées = 0.0.0.0/0, ::/0\nPoint de terminaison = ...</string>
     <string name="msg_wg_mullvad_account">Numéro de compte Mullvad</string>
     <string name="msg_wg_mullvad_recommended">Emplacement recommandé</string>
     <string name="msg_wg_mullvad_failed">Échec de la configuration de Mullvad : %s</string>
@@ -234,15 +235,15 @@
     <string name="vpn_country_load_failed_short">Impossible de charger les pays</string>
     <string name="vpn_choose_country_first">Choisissez un pays d\'abord</string>
     <string name="vpn_choose_profile_first">Choisissez un profil WireGuard d\'abord</string>
-    <string name="vpn_loading_countries">Chargement des pays...</string>
-    <string name="vpn_generating">Création du profil WireGuard ...</string>
+    <string name="vpn_loading_countries">Chargement des pays…</string>
+    <string name="vpn_generating">Création du profil WireGuard …</string>
     <string name="vpn_retry">Réessayer</string>
     <string name="vpn_country_selected">OK</string>
     <string name="msg_wg_blocked_title">Tunnel WireGuard indisponible</string>
     <string name="summary_watchdog">Vérifiez périodiquement si TrackerControl est toujours en cours d\'exécution (saisir zéro pour désactiver cette option). Cela peut entraîner une surconsommation de la batterie.</string>
     <string name="summary_log_logcat">Mode recherche : les traqueurs identifiés sont enregistrés via ADB et l\'extraction SNI est activée pour une meilleure détection de nom d\'hôte. Récupérez les journaux avec la commande adb logcat en utilisant l\'étiquette \'TC-Log\'.</string>
     <string name="msg_sure">Êtes-vous sûr⋅e ?</string>
-    <string name="msg_started">Recherche de traqueurs...</string>
+    <string name="msg_started">Recherche de traqueurs…</string>
     <string name="msg_waiting">En attente d\'évènement</string>
     <string name="msg_disabled">Utilisez l\'interrupteur ci-dessus pour activer TrackerControl.</string>
     <string name="msg_revoked">TrackerControl a été désactivé, probablement en utilisant une autre application VPN</string>
@@ -354,10 +355,12 @@ Votre trafic internet n\'est pas envoyé vers un serveur VPN distant.</string>
     <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
     <plurals name="n_companies_found_week">
         <item quantity="one">a contacté %d société la semaine dernière</item>
+        <item quantity="many">a contacté %d sociétés la semaine dernière</item>
         <item quantity="other">a contacté %d sociétés la semaine dernière</item>
     </plurals>
     <plurals name="n_companies_found">
         <item quantity="one">a contacté %d entreprise</item>
+        <item quantity="many">a contacté %d entreprises</item>
         <item quantity="other">a contacté %d entreprises</item>
     </plurals>
     <string name="confirm_ipinfo_title">Récupérer les informations sur l\'organisation?</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -106,7 +106,7 @@
     <string name="summary_socks5_enabled">Csak a TCP forgalom küldése a proxy-szerverre</string>
     <string name="summary_watchdog">Rendszeresen ellenőrzi, ha a TrackerControl fut (a 0 beírása letiltja az opciót). Ez extra akkumulátor használattal járhat.</string>
     <string name="msg_sure">Biztos benne?</string>
-    <string name="msg_started">Nyomkövetők keresése...</string>
+    <string name="msg_started">Nyomkövetők keresése…</string>
     <string name="msg_waiting">Várakozás eseményre</string>
     <string name="msg_disabled">Használja a fenti kapcsolót a TrackerControl engedélyezéséhez.</string>
     <string name="msg_revoked">A TrackerControl le van tiltva, valószínűleg egy másik VPN alapú alkalmazással</string>
@@ -228,7 +228,7 @@ Az Ön internetes forgalmát nem küldi el egy távoli VPN-kiszolgálóra.</stri
     <string name="yes">Igen</string>
     <string name="no">Nem</string>
     <string name="menu_csv">Exportálás CSV-ként</string>
-    <string name="exporting">Exportálás...</string>
+    <string name="exporting">Exportálás…</string>
     <string name="share_csv">Megosztás</string>
     <string name="export_failed">Sikertelen exportálás</string>
     <string name="exported">Exportálva a tárhelyre!</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -46,6 +46,7 @@
     <string name="setting_update">Cerca aggiornamenti</string>
     <plurals name="pause">
         <item quantity="one">Sospendi per %d minuto</item>
+        <item quantity="many">Sospendi per %d minuti</item>
         <item quantity="other">Sospendi per %d minuti</item>
     </plurals>
     <string name="setting_network_options">Opzioni di rete</string>
@@ -212,10 +213,12 @@ Il tuo traffico di rete non è inoltrato verso un server remoto, ma viene monito
     <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
     <plurals name="n_companies_found_week">
         <item quantity="one">ha contattato %d azienda la settimana scorsa</item>
+        <item quantity="many">ha contattato %d aziende la settimana scorsa</item>
         <item quantity="other">ha contattato %d aziende la settimana scorsa</item>
     </plurals>
     <plurals name="n_companies_found">
         <item quantity="one">ha contattato %d azienda in continuazione</item>
+        <item quantity="many">ha contattato %d aziende in continuazione</item>
         <item quantity="other">ha contattato %d aziende in continuazione</item>
     </plurals>
     <string name="confirm_ipinfo_title">Recupera informazioni sull\'organizzazione?</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -220,7 +220,7 @@
     <string name="yes">はい</string>
     <string name="no">いいえ</string>
     <string name="menu_csv">CSV形式でエクスポート</string>
-    <string name="exporting">エクスポート中...</string>
+    <string name="exporting">エクスポート中…</string>
     <string name="share_csv">共有</string>
     <string name="export_failed">エクスポートに失敗しました</string>
     <string name="exported">ストレージにエクスポートされました！</string>
@@ -251,7 +251,7 @@
     <string name="google_dpo_mail">data-protection-office@google.com</string>
     <string name="dpas_overview_url">https://edpb.europa.eu/about-edpb/board/members</string>
     <string name="subject_request_data">GDPRサブジェクトアクセスリクエスト</string>
-    <string name="crash_dialog_text">すみません。TrackerControl がクラッシュしてしまいました... 詳細をメールで送っていただけませんか？</string>
+    <string name="crash_dialog_text">すみません。TrackerControl がクラッシュしてしまいました… 詳細をメールで送っていただけませんか？</string>
     <string name="crash_dialog_comment">コメントはありますか？</string>
     <string name="instructions_monitoring_private_dns">スイッチを切り替えて、いくつかのアプリと連動させます。プライベートDNSを無効にする必要があります。</string>
     <string name="instructions_monitoring">スイッチを切り替えて、いくつかのアプリを操作します。</string>

--- a/app/src/main/res/values-nl-rNL/strings.xml
+++ b/app/src/main/res/values-nl-rNL/strings.xml
@@ -207,7 +207,7 @@
     <string name="summary_watchdog">Controleer regelmatig of TrackerControl nog actief is (voer nul in om deze optie uit te schakelen). Dit kan leiden tot extra batterijverbruik.</string>
     <string name="summary_log_logcat">Onderzoeksmodus: geïdentificeerde trackers worden gelogd naar ADB en SNI-extractie is ingeschakeld voor betere hostnamendetectie. Bekijk de logs met behulp van adb logcat en de tag \'TC-Log\'.</string>
     <string name="msg_sure">Weet je het zeker?</string>
-    <string name="msg_started">Op zoek naar trackers...</string>
+    <string name="msg_started">Op zoek naar trackers…</string>
     <string name="msg_waiting">Wacht op gebeurtenis</string>
     <string name="msg_disabled">Gebruik bovenstaande schakelaar om TrackerControl te activeren.</string>
     <string name="msg_revoked">TrackerControl is uitgeschakeld, waarschijnlijk door het gebruik van een andere VPN gebaseerde app</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -106,7 +106,7 @@
     <string name="summary_socks5_enabled">Tylko ruch TCP będzie wysyłany do serwera proxy</string>
     <string name="summary_watchdog">Okresowo sprawdzać, czy TrackerControl nadal działa (wpisać zero, aby wyłączyć tę opcję). Może to spowodować dodatkowe zużycie baterii.</string>
     <string name="msg_sure">Jesteś pewien?</string>
-    <string name="msg_started">Wyszukiwanie trackerów...</string>
+    <string name="msg_started">Wyszukiwanie trackerów…</string>
     <string name="msg_waiting">Oczekiwanie na zdarzenie</string>
     <string name="msg_disabled">Użyj powyższego przełącznika, aby włączyć TrackerControl.</string>
     <string name="msg_revoked">TrackerControl został wyłączony, prawdopodobnie przy użyciu innej aplikacji opartej na sieci VPN</string>
@@ -298,7 +298,7 @@ Powodem mojego wniosku o usunięcie danych jest to, że wycofałem lub wycofałe
 Prosimy o dostarczenie odpowiedzi za pomocą bezpiecznych środków pocztą elektroniczną. Z niecierpliwością oczekuję odpowiedzi w ciągu miesiąca od otrzymania mojego wniosku.\n
 \n
 Z poważaniem,\n\n]]></string>
-    <string name="crash_dialog_text">Przepraszam. TrackerControl się rozbił... Mógłbyś wysłać nam e-mail ze szczegółami?</string>
+    <string name="crash_dialog_text">Przepraszam. TrackerControl się rozbił… Mógłbyś wysłać nam e-mail ze szczegółami?</string>
     <string name="crash_dialog_comment">Jakieś uwagi?</string>
     <string name="instructions_monitoring_private_dns">Przełączaj przełącznik i współdziałaj z niektórymi aplikacjami. Prywatny DNS musi być wyłączony.</string>
     <string name="instructions_monitoring">Przełączaj przełącznik i współdziałaj z niektórymi aplikacjami.</string>
@@ -307,7 +307,7 @@ Z poważaniem,\n\n]]></string>
     <string name="launch_app">Launch &amp; Znajdź trackery</string>
     <string name="countries">Kraje docelowe</string>
     <string name="countries_explanation">Dowiedz się, gdzie Twój telefon wysyła dane śledzące.\n\nInformacje są oparte na wyszukiwaniu DNS i informacji IP i mogą być niedokładne.</string>
-    <string name="countries_loading_failed">Oops... Nie udało się załadować mapy kraju. Proszę powiedzieć tc@kollnig.net jak to się stało.</string>
+    <string name="countries_loading_failed">Oops… Nie udało się załadować mapy kraju. Proszę powiedzieć tc@kollnig.net jak to się stało.</string>
     <string name="tracker_advertising">Reklama</string>
     <string name="tracker_analytics">Analityka</string>
     <string name="tracker_content">Istotne</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_description">TrackerControl permite aos usuários monitorar e controlar a coleta de dados global, contínua e oculta em aplicativos móveis sobre o comportamento do usuário (\"tracking\").</string>
-    <string name="app_copyright">Copyright \u00A9 2019-2022 Konrad Kollnig\n\nTrackerControl é baseado no NetGuard, desenvolvido por Marcel Bokhorst (M66B).</string>
+    <string name="app_copyright">Copyright \u00A9 2019–2022 Konrad Kollnig\n\nTrackerControl é baseado no NetGuard, desenvolvido por Marcel Bokhorst (M66B).</string>
     <string name="app_android">TrackerControl requer Android 5.1 ou posterior</string>
     <string name="app_xposed">O Xposed provoca muitos travamentos, o que pode levar à remoção do TrackerControl da Google Play Store, logo, TrackerControl não é suportado enquanto o Xposed está instalado</string>
     <string name="app_eula">O uso deste app está por sua própria conta e risco. Nenhum app pode oferecer 100% de proteção contra rastreamento.</string>
@@ -77,6 +77,7 @@
     <string name="setting_update">Verificar se há atualizações</string>
     <plurals name="pause">
         <item quantity="one">Pausar por %d min</item>
+        <item quantity="many">Pausar por %d mins</item>
         <item quantity="other">Pausar por %d mins</item>
     </plurals>
     <string name="setting_network_options">Opções de rede</string>
@@ -147,7 +148,7 @@
     <string name="summary_watchdog">Verificar periodicamente se TrackerControl ainda está sendo executado (digite zero para desativar essa opção). Isso pode resultar em uso extra de bateria.</string>
     <string name="summary_log_logcat">Modo de pesquisa: rastreadores identificados estão conectados ao ADB e a extração SNI está ativada para melhor detecção de nome de hosts. Recuperar logs com adb logcat usando a tag \'TC-Log\'.</string>
     <string name="msg_sure">Você tem certeza?</string>
-    <string name="msg_started">Procurando por rastreadores...</string>
+    <string name="msg_started">Procurando por rastreadores…</string>
     <string name="msg_waiting">Aguardando evento</string>
     <string name="msg_disabled">Use o interruptor acima para habilitar o TrackerControl.</string>
     <string name="msg_revoked">O TrackerControl foi desativado, provavelmente outro aplicativo baseado em VPN está sendo utilizado</string>
@@ -259,10 +260,12 @@ O seu tráfego de internet não está sendo enviado para um servidor VPN remoto.
     <!-- Dynamic content description for the home-screen widget toggle (accessibility follow-up, issue #636) -->
     <plurals name="n_companies_found_week">
         <item quantity="one">contactou %d empresa na semana passada</item>
+        <item quantity="many">contactou %d empresas na semana passada</item>
         <item quantity="other">contactou %d empresas na semana passada</item>
     </plurals>
     <plurals name="n_companies_found">
         <item quantity="one">contatou %d empresa o tempo todo</item>
+        <item quantity="many">contatou %d empresas o tempo todo</item>
         <item quantity="other">contatou %d empresas o tempo todo</item>
     </plurals>
     <string name="confirm_ipinfo_title">Obter informações da organização?</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_description">O TrackerControl permite que os utilizadores monitorem e controlem a coleta de dados generalizada, contínua e oculta em aplicativos móveis sobre o comportamento do utilizador (\'rastreamento\').</string>
-    <string name="app_copyright">Direitos de autor \u00A9 2019-2022 Konrad Kollnig\n\nTrackerControl é baseado em NetGuard, desenvolvido por Marcel Bokhorst (M66B).</string>
+    <string name="app_copyright">Direitos de autor \u00A9 2019–2022 Konrad Kollnig\n\nTrackerControl é baseado em NetGuard, desenvolvido por Marcel Bokhorst (M66B).</string>
     <string name="app_android">TrackerControl requer Android 5.1 ou superior</string>
     <string name="app_xposed">Xposed causa muitos erros, que podem resultar na remoção do TrackerControl da Google Play Store, portanto, TrackerControl não é suportado enquanto o Xposed está instalado</string>
     <string name="app_eula">O uso desta aplicação está no seu próprio risco. Nenhuma aplicação pode oferecer 100% de proteção contra rastreamento.</string>
@@ -73,6 +73,7 @@
     <string name="setting_update">Verificar por atualizações</string>
     <plurals name="pause">
         <item quantity="one">Pausar por %d min</item>
+        <item quantity="many">Pausar para %d min</item>
         <item quantity="other">Pausar para %d min</item>
     </plurals>
     <string name="setting_network_options">Opções de rede</string>
@@ -327,7 +328,7 @@ A razão da minha solicitação de remoção é que eu retiro ou retirei minha a
 Por favor, forneça sua resposta por meio de e-mail com segurança. Aguardo com expectativa uma resposta dentro de um mês a contar da recepção do meu pedido.\n
 \n
 disso,\n\n]]></string>
-    <string name="crash_dialog_text">Desculpe. O TrackerControl acabou de cair... Você se importaria de nos enviar um e-mail com detalhes?</string>
+    <string name="crash_dialog_text">Desculpe. O TrackerControl acabou de cair… Você se importaria de nos enviar um e-mail com detalhes?</string>
     <string name="crash_dialog_comment">Algum comentário?</string>
     <string name="instructions_monitoring_private_dns">Alternar o interruptor e interagir com algumas aplicações. O DNS privado deve ser desativado.</string>
     <string name="instructions_monitoring">Alternar o interruptor e interagir com algumas aplicações.</string>
@@ -336,7 +337,7 @@ disso,\n\n]]></string>
     <string name="launch_app">Lançamento &amp; Localizar rastreadores</string>
     <string name="countries">Países de destino</string>
     <string name="countries_explanation">Descubra onde seu telefone envia dados de rastreamento.\n\nA informação é baseada nas pesquisas de DNS e nas informações de IP, e pode ser impreciso.</string>
-    <string name="countries_loading_failed">Oops... O mapa do país não conseguiu carregar. Por favor, diga a tc@kollnig.net como isso aconteceu.</string>
+    <string name="countries_loading_failed">Oops… O mapa do país não conseguiu carregar. Por favor, diga a tc@kollnig.net como isso aconteceu.</string>
     <string name="tracker_advertising">Publicidade</string>
     <string name="tracker_analytics">Analíticos</string>
     <string name="tracker_content">Essencial</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -153,7 +153,7 @@
     <string name="summary_watchdog">Периодически проверять, запущен ли TrackerControl (введите ноль, чтобы отключить эту опцию). Это может привести к большему расходу батареи.</string>
     <string name="summary_log_logcat">Режим исследования: идентифицированные трекеры записываются в ADB и SNI извлечение включено для лучшего определения имени хоста. Восстановите логи с adb logcat с помощью тега \'TC-Log\'.</string>
     <string name="msg_sure">Вы уверены?</string>
-    <string name="msg_started">Поиск трекеров...</string>
+    <string name="msg_started">Поиск трекеров…</string>
     <string name="msg_waiting">Ожидание события</string>
     <string name="msg_disabled">Для включения TrackerControl используйте переключатель выше.</string>
     <string name="msg_revoked">TrackerControl был отключен, скорее всего, из-за применения другого VPN-подключения</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -104,7 +104,7 @@
     <string name="summary_socks5_enabled">Sadece TCP trafiği vekil sunucuya gönderilecek</string>
     <string name="summary_watchdog">TrackerControl\'ün hala çalışıp çalışmadığını periyodik olarak kontrol edin (bu seçeneği devre dışı bırakmak için sıfır girin). Bu, fazladan pil kullanımına neden olabilir.</string>
     <string name="msg_sure">Emin misiniz?</string>
-    <string name="msg_started">Takipçiler aranıyor...</string>
+    <string name="msg_started">Takipçiler aranıyor…</string>
     <string name="msg_waiting">Eylem bekleniyor</string>
     <string name="msg_disabled">TrackerControl\'ü etkinleştirmek için yukarıdaki anahtarı kullanın.</string>
     <string name="msg_revoked">TrackerControl, muhtemelen başka bir VPN tabanlı uygulama kullanılarak devre dışı bırakıldı</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_description">TrackerControl дозволяє користувачам відстежувати та контролювати широко розповсюджений, постійний, прихований збір даних у мобільних застосунках про поведінку користувачів (\"стеження\").</string>
     <string name="app_copyright">Авторське право \u00A9 2019–2022 Конрад Колльніг\n\nTrackerControl базується на NetGuard, розробленому Марселем Бокхорстом (M66B).</string>
     <string name="app_android">TrackerControl потребує Android 5.1 або новішої версії</string>
@@ -193,7 +193,7 @@
     <string name="msg_wg_profile_empty">Поки що немає профілів</string>
     <string name="msg_wg_profile_active">Активний</string>
     <string name="msg_wg_profile_set_active">Встановити як активний</string>
-    <string name="msg_wg_profile_config_hint">[Interface]\nПриватний ключ = ...\nАдреса = ...\n\n[Peer]\nПублічний ключ = ...\nДозволені Ip-адреси = 0.0.0.0/0, ::/0\nКінцева точка = ...</string>
+    <string tools:ignore="TypographyEllipsis" name="msg_wg_profile_config_hint">[Interface]\nПриватний ключ = ...\nАдреса = ...\n\n[Peer]\nПублічний ключ = ...\nДозволені Ip-адреси = 0.0.0.0/0, ::/0\nКінцева точка = ...</string>
     <string name="msg_wg_profile_delete_confirm">Видалити цей профіль WireGuard?</string>
     <string name="msg_wg_mullvad_account">Номер облікового запису Mullvad</string>
     <string name="msg_wg_mullvad_recommended">Рекомендоване місце розташування</string>
@@ -254,8 +254,8 @@
     <string name="vpn_choose_country_first">Спочатку виберіть країну</string>
     <string name="vpn_choose_profile_first">Спочатку виберіть профіль WireGuard</string>
     <string name="vpn_setup_required">Спочатку налаштуйте Mullvad або імпортуйте профіль WireGuard</string>
-    <string name="vpn_loading_countries">Завантаження країн...</string>
-    <string name="vpn_generating">Створення профілю WireGuard...</string>
+    <string name="vpn_loading_countries">Завантаження країн…</string>
+    <string name="vpn_generating">Створення профілю WireGuard…</string>
     <string name="vpn_generation_failed">Не вдалося налаштувати VPN: %s</string>
     <string name="vpn_retry">Повторити спробу</string>
     <string name="vpn_country_selected">Гаразд</string>
@@ -265,7 +265,7 @@
     <string name="summary_watchdog">Періодично перевіряйте, чи TrackerControl все ще працює (введіть нуль, щоб вимкнути цю опцію). Це може призвести до додаткового споживання заряду акумулятора.</string>
     <string name="summary_log_logcat">Режим дослідження: виявлені трекери записуються в ADB, а для кращого виявлення імен хостів увімкнено вилучення SNI. Отримайте журнали за допомогою adb logcat, використовуючи тег «TC-Log».</string>
     <string name="msg_sure">Ви впевнені?</string>
-    <string name="msg_started">Шукаю трекери...</string>
+    <string name="msg_started">Шукаю трекери…</string>
     <string name="msg_waiting">Очікування події</string>
     <string name="msg_disabled">Використайте перемикач вище, щоб увімкнути TrackerControl.</string>
     <string name="msg_revoked">TrackerControl було вимкнено, ймовірно, за допомогою іншого додатка на основі VPN</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -156,8 +156,8 @@
     <string name="vpn_choose_country_first">Chọn một quốc gia trước</string>
     <string name="vpn_choose_profile_first">Chọn một hồ sơ WireGuard trước</string>
     <string name="vpn_setup_required">Thiết lập hồ sơ Mullvad hoặc nhập một hồ sơ WireGuard trước</string>
-    <string name="vpn_loading_countries">Đang tải các quốc gia...</string>
-    <string name="vpn_generating">Đang tạo hồ số WireGuard...</string>
+    <string name="vpn_loading_countries">Đang tải các quốc gia…</string>
+    <string name="vpn_generating">Đang tạo hồ số WireGuard…</string>
     <string name="vpn_generation_failed">Thiết lập VPN đã thất bại: %s</string>
     <string name="vpn_retry">Thử lại</string>
     <string name="vpn_country_selected">OK</string>
@@ -321,7 +321,7 @@
     <string name="launch_app">Chạy &amp; tìm trình theo dõi</string>
     <string name="countries">Các quốc gia đích</string>
     <string name="countries_explanation">Tìm ra nơi mà điện thoại của bạn gửi dữ liệu theo dõi đến.\n\nThông tin được dựa trên tra cứu DNS và thông tin IP, và có thể không chính xác.</string>
-    <string name="countries_loading_failed">Ối... Tải bản đồ quốc gia thất bại. Vui lòng nói cho tc@kollnig.net làm thế nào mà việc này xảy ra.</string>
+    <string name="countries_loading_failed">Ối… Tải bản đồ quốc gia thất bại. Vui lòng nói cho tc@kollnig.net làm thế nào mà việc này xảy ra.</string>
     <string name="tracker_advertising">Quảng cáo</string>
     <string name="tracker_analytics">Phân tích</string>
     <string name="tracker_content">Thiết yếu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_description">TrackerControl允许用户监视和控制移动应用程序中有关用户行为的广泛的、正在进行的隐藏数据收集(‘跟踪’)。</string>
-    <string name="app_copyright">版权所有 \u00A9 2019-2022 Konrad Kollnig\n\nTrackerControl 基于 NetGuard, 由 Marcel Bokhorst (M66B) 开发。</string>
+    <string name="app_copyright">版权所有 \u00A9 2019–2022 Konrad Kollnig\n\nTrackerControl 基于 NetGuard, 由 Marcel Bokhorst (M66B) 开发。</string>
     <string name="app_android">TrackerControl需要Android 5.1或更高版本</string>
     <string name="app_xposed">Xposed会造成过多的崩溃，这可能导致TrackerControl从GooglePlay商店被移除，因此在安装xposed情况下不支持使用TrackerControl</string>
     <string name="app_eula">使用本应用程序的风险由您自行承担。没有应用程序可以提供对网络跟踪100%的保护。</string>
@@ -239,7 +239,7 @@
     <string name="msg_wg_profile_empty">暂无配置</string>
     <string name="msg_wg_profile_active">活跃</string>
     <string name="msg_wg_profile_set_active">设置为活跃</string>
-    <string name="msg_wg_profile_config_hint">[Interface]\nPrivateKey = ...\nAddress = ...\n\n[Peer]\nPublicKey = ...\nAllowedIPs = 0.0.0.0/0, ::/0\nEndpoint = ...</string>
+    <string tools:ignore="TypographyEllipsis" name="msg_wg_profile_config_hint">[Interface]\nPrivateKey = ...\nAddress = ...\n\n[Peer]\nPublicKey = ...\nAllowedIPs = 0.0.0.0/0, ::/0\nEndpoint = ...</string>
     <string name="msg_wg_profile_delete_confirm">删除这个WireGuard配置文件吗？</string>
     <string name="msg_wg_profile_scan_hint">将相机指向您的 VPN 提供商显示的 WireGuard QR 码。扫描发生在您的设备上。</string>
     <string name="msg_wg_profile_scan_no_camera">此设备没有可用来扫描的相机</string>
@@ -309,7 +309,7 @@
     <string name="vpn_choose_country_first">先选择一个地区</string>
     <string name="vpn_choose_profile_first">请先选择一个WireGuard配置</string>
     <string name="vpn_setup_required">设置Mullvad或先导入WireGuard 配置文件</string>
-    <string name="vpn_loading_countries">正在加载地区...</string>
+    <string name="vpn_loading_countries">正在加载地区…</string>
     <string name="vpn_generating">正在创建WireGuard配置文件……</string>
     <string name="vpn_generation_failed">VPN 设置失败: %s</string>
     <string name="vpn_retry">重试</string>
@@ -324,7 +324,7 @@
     <string name="summary_watchdog">定期检查TrackerControl是否仍在运行(输入零禁用此选项)。这可能会导致额外的电池使用。</string>
     <string name="summary_log_logcat">研究模式：已识别的追踪器会记录到 ADB 并启用 SNI 提取以更好地检测主机名。用 TC-Log 标签通过 adb logcat 获取日志。</string>
     <string name="msg_sure">你确定吗？</string>
-    <string name="msg_started">正在查找追踪器...</string>
+    <string name="msg_started">正在查找追踪器…</string>
     <string name="msg_waiting">等待事件</string>
     <string name="msg_disabled">使用上面的开关来启用TrackerControl</string>
     <string name="msg_revoked">TrackerControl已被禁用，可能是通过使用另一个基于VPN的应用程序</string>
@@ -468,7 +468,7 @@
     <string name="yes">是</string>
     <string name="no">否</string>
     <string name="menu_csv">导出为CSV</string>
-    <string name="exporting">正在导出...</string>
+    <string name="exporting">正在导出…</string>
     <string name="share_csv">分享</string>
     <string name="export_failed">导出失败</string>
     <string name="exported">已导出到存储！</string>


### PR DESCRIPTION
## Summary

- add the missing CLDR plural forms in existing translations
- use Android-recommended ellipsis and dash typography in locale prose
- preserve literal `...` in copyable WireGuard examples with narrow suppressions

Depends on #940.

## Validation

- `./gradlew :app:lintGithubDebug -q`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`
- XML resource-key and placeholder audit
- `git diff --check`