### PR TITLE
Make displayed values locale-safe

### DIFF
--- a/app/src/main/java/eu/faircode/netguard/ActivityDns.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityDns.java
@@ -165,7 +165,7 @@ public class ActivityDns extends AppCompatActivity {
         Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*"); // text/xml
-        intent.putExtra(Intent.EXTRA_TITLE, "netguard_dns_" + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".xml");
+        intent.putExtra(Intent.EXTRA_TITLE, "netguard_dns_" + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".xml");
         return intent;
     }
 

--- a/app/src/main/java/eu/faircode/netguard/ActivityLog.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityLog.java
@@ -63,6 +63,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public class ActivityLog extends AppCompatActivity implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "TrackerControl.Log";
@@ -508,7 +509,7 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
     private String getUidForName(String query) {
         if (query != null && query.length() > 0) {
             for (Rule rule : Rule.getRules(true, ActivityLog.this))
-                if (rule.name != null && rule.name.toLowerCase().contains(query.toLowerCase())) {
+                if (rule.name != null && rule.name.toLowerCase(Locale.ROOT).contains(query.toLowerCase(Locale.ROOT))) {
                     String newQuery = Integer.toString(rule.uid);
                     Log.i(TAG, "Search " + query + " found " + rule.name + " new " + newQuery);
                     return newQuery;
@@ -523,7 +524,7 @@ public class ActivityLog extends AppCompatActivity implements SharedPreferences.
         intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("application/octet-stream");
-        intent.putExtra(Intent.EXTRA_TITLE, "netguard_" + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".pcap");
+        intent.putExtra(Intent.EXTRA_TITLE, "netguard_" + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".pcap");
         return intent;
     }
 

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -852,7 +852,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
                 Uri target = data.getData();
                 if (data.hasExtra("org.openintents.extra.DIR_PATH"))
                     target = Uri.parse(target + "/trackercontrol_log_"
-                            + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".csv");
+                            + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".csv");
                 Log.i(TAG, "Writing URI=" + target);
 
                 try (OutputStream out = getContentResolver().openOutputStream(target)) {
@@ -1314,7 +1314,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
         intent.putExtra(Intent.EXTRA_TITLE,
-                "trackercontrol_log_" + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".csv");
+                "trackercontrol_log_" + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".csv");
         return intent;
     }
 
@@ -1610,7 +1610,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
         // Show version
         tvVersionName.setText(Util.getSelfVersionName(this));
-        tvVersionCode.setText(Integer.toString(Util.getSelfVersionCode(this)));
+        tvVersionCode.setText(String.format(Locale.ROOT, "%d", Util.getSelfVersionCode(this)));
 
         // Handle license
         tvEula.setMovementMethod(LinkMovementMethod.getInstance());

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -105,6 +105,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -1208,7 +1209,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*"); // text/xml
         intent.putExtra(Intent.EXTRA_TITLE,
-                "trackercontrol_" + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".xml");
+                "trackercontrol_" + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".xml");
         return intent;
     }
 
@@ -1232,7 +1233,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
                     Uri target = data.getData();
                     if (data.hasExtra("org.openintents.extra.DIR_PATH"))
                         target = Uri.parse(target + "/trackercontrol_"
-                                + new SimpleDateFormat("yyyyMMdd").format(new Date().getTime()) + ".xml");
+                                + new SimpleDateFormat("yyyyMMdd", Locale.ROOT).format(new Date().getTime()) + ".xml");
                     Log.i(TAG, "Writing URI=" + target);
                     out = getContentResolver().openOutputStream(target);
                     xmlExport(out);

--- a/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
@@ -45,6 +45,7 @@ import net.kollnig.missioncontrol.R;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 
 public class AdapterAccess extends CursorAdapter {
     private int colVersion;
@@ -120,7 +121,7 @@ public class AdapterAccess extends CursorAdapter {
         TextView tvTraffic = view.findViewById(R.id.tvTraffic);
 
         // Set values
-        tvTime.setText(new SimpleDateFormat("dd HH:mm").format(time));
+        tvTime.setText(new SimpleDateFormat("dd HH:mm", Locale.getDefault()).format(time));
         if (block < 0) {
             ivBlock.setImageDrawable(null);
             ivBlock.setContentDescription(null);
@@ -157,9 +158,9 @@ public class AdapterAccess extends CursorAdapter {
 
                 @Override
                 protected void onPostExecute(String addr) {
-                    tvDest.setText(
-                            Util.getProtocolName(protocol, version, true) +
-                                    " >" + addr + (dport > 0 ? "/" + dport : ""));
+                    String port = dport > 0 ? String.format(Locale.ROOT, "/%d", dport) : "";
+                    tvDest.setText(String.format(Locale.ROOT, "%s >%s%s",
+                            Util.getProtocolName(protocol, version, true), addr, port));
                     ViewCompat.setHasTransientState(tvDest, false);
                 }
             }.execute(daddr);

--- a/app/src/main/java/eu/faircode/netguard/AdapterDns.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterDns.java
@@ -34,6 +34,7 @@ import net.kollnig.missioncontrol.R;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 public class AdapterDns extends CursorAdapter {
     private int colorExpired;
@@ -89,10 +90,10 @@ public class AdapterDns extends CursorAdapter {
         TextView tvTTL = view.findViewById(R.id.tvTTL);
 
         // Set values
-        tvTime.setText(new SimpleDateFormat("dd HH:mm").format(time));
+        tvTime.setText(new SimpleDateFormat("dd HH:mm", Locale.getDefault()).format(time));
         tvQName.setText(qname);
         tvAName.setText(aname);
         tvResource.setText(resource);
-        tvTTL.setText("+" + Integer.toString(ttl / 1000));
+        tvTTL.setText(String.format(Locale.ROOT, "+%d", ttl / 1000));
     }
 }

--- a/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterForwarding.java
@@ -31,6 +31,8 @@ import android.widget.TextView;
 
 import net.kollnig.missioncontrol.R;
 
+import java.util.Locale;
+
 public class AdapterForwarding extends CursorAdapter {
     private int colProtocol;
     private int colDPort;
@@ -73,9 +75,9 @@ public class AdapterForwarding extends CursorAdapter {
         TextView tvRUid = view.findViewById(R.id.tvRUid);
 
         tvProtocol.setText(Util.getProtocolName(protocol, 0, false));
-        tvDPort.setText(Integer.toString(dport));
+        tvDPort.setText(String.format(Locale.ROOT, "%d", dport));
         tvRAddr.setText(raddr);
-        tvRPort.setText(Integer.toString(rport));
+        tvRPort.setText(String.format(Locale.ROOT, "%d", rport));
         tvRUid.setText(TextUtils.join(", ", Util.getApplicationNames(ruid, context)));
     }
 }

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -53,6 +53,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.text.SimpleDateFormat;
 import java.util.List;
+import java.util.Locale;
 
 public class AdapterLog extends CursorAdapter {
     private static String TAG = "TrackerControl.Log";
@@ -189,7 +190,7 @@ public class AdapterLog extends CursorAdapter {
         ImageView ivInteractive = view.findViewById(R.id.ivInteractive);
 
         // Show time
-        tvTime.setText(new SimpleDateFormat("HH:mm:ss").format(time));
+        tvTime.setText(new SimpleDateFormat("HH:mm:ss", Locale.getDefault()).format(time));
 
         // Show blocked/allowed status as a clear text label (not just the tinted icon)
         if (allowed < 0)
@@ -287,7 +288,7 @@ public class AdapterLog extends CursorAdapter {
         else if (uid == 9999)
             tvUid.setText("-"); // nobody
         else
-            tvUid.setText(Integer.toString(uid));
+            tvUid.setText(String.format(Locale.ROOT, "%d", uid));
 
         // Show source address
         tvSAddr.setText(getKnownAddress(saddr));
@@ -323,7 +324,7 @@ public class AdapterLog extends CursorAdapter {
                             return;
 
                         if (tv.getTag() == bindToken) {
-                            tv.setText(">" + name);
+                            tv.setText(String.format(Locale.ROOT, ">%s", name));
 
                             if (TrackerList.findTracker(name) != null)
                                 tv.setTypeface(null, Typeface.BOLD);

--- a/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
+++ b/app/src/main/java/net/kollnig/missioncontrol/InsightsActivity.kt
@@ -184,7 +184,7 @@ class InsightsActivity : AppCompatActivity() {
             tvBlockedCount.text = nf.format(data.blockedTrackingAttempts)
 
             // Companies count
-            tvCompanies.text = data.uniqueTrackerCompanies.toString()
+            tvCompanies.text = nf.format(data.uniqueTrackerCompanies)
             
             // Top 3 Companies (dynamically added) - use pervasiveTrackers for correct app counts
             val top3 = data.pervasiveTrackers.take(3)

--- a/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/details/CountriesFragment.java
@@ -54,6 +54,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Locale;
 
 import eu.faircode.netguard.DatabaseHelper;
 
@@ -174,7 +175,7 @@ public class CountriesFragment extends Fragment {
 
             final RenderOptions renderOptions = new RenderOptions();
             String countries = TextUtils.join(",#", hostCountriesCount.keySet());
-            renderOptions.css(String.format("#%s { fill: #B71C1C; }", countries.toUpperCase()));
+            renderOptions.css(String.format(Locale.ROOT, "#%s { fill: #B71C1C; }", countries.toUpperCase(Locale.ROOT)));
 
             if (Thread.currentThread().isInterrupted())
                 return; // the screen was left before rendering started


### PR DESCRIPTION
## Summary

- make machine timestamps and identifiers explicitly locale-stable
- format user-facing times and counts with the active locale
- remove `DefaultLocale`, `SimpleDateFormat`, and `SetTextI18n` findings

## Validation

- `./gradlew :app:lintGithubDebug -q`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`
- focused `AdapterLogTest` and `ActivitySettingsTest`
- `git diff --check`