### PR TITLE
Remove obsolete Android API compatibility paths

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,6 +106,7 @@ android {
     buildTypes {
         release {
             minifyEnabled = true
+            shrinkResources = true
             proguardFiles.add(file('proguard-rules.pro'))
         }
         debug {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -75,9 +75,12 @@
         android:name="android.hardware.touchscreen"
         android:required="false" />
 
+    <!-- appCategory, networkSecurityConfig and resizeableActivity are intentionally retained for their API 24+/26+ behaviour. -->
     <application
         android:name="eu.faircode.netguard.ApplicationEx"
         android:allowBackup="false"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="false"
         android:appCategory="productivity"
         android:description="@string/app_description"
         android:icon="@mipmap/ic_launcher_round"
@@ -85,7 +88,7 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:supportsRtl="true"
         android:theme="@style/AppThemeRed"
-        tools:ignore="ManifestResource"
+        tools:ignore="ManifestResource,UnusedAttribute"
         tools:replace="android:allowBackup,android:theme">
 
         <meta-data
@@ -96,7 +99,7 @@
             android:name="net.kollnig.missioncontrol.ActivityOnboarding"
             android:theme="@style/AppTheme.NoActionBar"
             android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity" />
+            tools:ignore="LockedOrientationActivity,DiscouragedApi" />
 
         <activity
             android:name="eu.faircode.netguard.ActivityMain"
@@ -161,7 +164,6 @@
             android:name="eu.faircode.netguard.ActivityForwardApproval"
             android:configChanges="orientation|screenSize"
             android:exported="true"
-            android:label="@string/app_name"
             android:permission="${applicationId}.permission.ADMIN"
             android:theme="@style/AppDialog">
             <intent-filter>
@@ -281,11 +283,14 @@
             </intent-filter>
         </service>
 
+        <!-- Public command contract: external callers send DOWNLOAD_HOSTS_FILE;
+             adding the app signature permission would break those callers. -->
         <service
             android:name="eu.faircode.netguard.ServiceExternal"
             android:exported="true"
             android:foregroundServiceType="specialUse"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            tools:ignore="ExportedService">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
                 android:value="TrackerControl is a firewall app using the Android VPN service to filter traffic on the device. A foreground service is required to process internet traffic in real-time to be able to allow and block traffic as configured by the user of the app. There is no other way to do this, and other foreground service types are either too limited or not appropriate."  />
@@ -299,6 +304,7 @@
             android:exported="true"
             android:icon="@drawable/ic_rocket_white"
             android:label="@string/app_name"
+            tools:targetApi="n"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE" />

--- a/app/src/main/java/eu/faircode/netguard/ActivityMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivityMain.java
@@ -34,7 +34,6 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.database.Cursor;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.net.VpnService;
 import android.os.AsyncTask;
@@ -46,7 +45,6 @@ import android.provider.Settings;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -74,7 +72,6 @@ import com.google.android.material.materialswitch.MaterialSwitch;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -149,8 +146,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
     private AlertDialog dialogTroubleshooting = null;
 
-    private static final int MIN_SDK = Build.VERSION_CODES.LOLLIPOP_MR1;
-
     public static final String ACTION_RULES_CHANGED = "eu.faircode.netguard.ACTION_RULES_CHANGED";
     public static final String ACTION_PRIVATE_DNS_WARNING_CHANGED =
             "eu.faircode.netguard.ACTION_PRIVATE_DNS_WARNING_CHANGED";
@@ -206,15 +201,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             super.onCreate(savedInstanceState);
             startActivity(new Intent(this, ActivityOnboarding.class));
             finish();
-            return;
-        }
-
-        // Check minimum Android version
-        if (Build.VERSION.SDK_INT < MIN_SDK) {
-            Log.i(TAG, "SDK=" + Build.VERSION.SDK_INT);
-            super.onCreate(savedInstanceState);
-            setContentView(R.layout.android);
-            setCopyright(findViewById(android.R.id.content));
             return;
         }
 
@@ -609,18 +595,16 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Util.logExtras(intent);
         super.onNewIntent(intent);
 
-        if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this))
+        if (Util.hasXposed(this))
             return;
 
         setIntent(intent);
 
-        if (Build.VERSION.SDK_INT >= MIN_SDK) {
-            if (intent.hasExtra(EXTRA_REFRESH))
-                updateApplicationList(intent.getStringExtra(EXTRA_SEARCH));
-            else
-                updateSearch(intent.getStringExtra(EXTRA_SEARCH));
-            checkExtras(intent);
-        }
+        if (intent.hasExtra(EXTRA_REFRESH))
+            updateApplicationList(intent.getStringExtra(EXTRA_SEARCH));
+        else
+            updateSearch(intent.getStringExtra(EXTRA_SEARCH));
+        checkExtras(intent);
     }
 
     @Override
@@ -630,7 +614,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
     protected void onResume() {
         Log.i(TAG, "Resume");
 
-        if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this)) {
+        if (Util.hasXposed(this)) {
             super.onResume();
             return;
         }
@@ -678,7 +662,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Log.i(TAG, "Pause");
         super.onPause();
 
-        if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this))
+        if (Util.hasXposed(this))
             return;
 
         DatabaseHelper.getInstance(this).removeAccessChangedListener(accessChangedListener);
@@ -689,7 +673,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Log.i(TAG, "Config");
         super.onConfigurationChanged(newConfig);
 
-        if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this))
+        if (Util.hasXposed(this))
             return;
 
         int horizontalPadding = getResources().getDimensionPixelSize(
@@ -758,7 +742,7 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         Log.i(TAG, "Destroy");
 
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
-        if (Build.VERSION.SDK_INT < MIN_SDK || Util.hasXposed(this) || !Util.canFilter(this)
+        if (Util.hasXposed(this) || !Util.canFilter(this)
                 || prefs.getInt("onboarding_version", 0) < ActivityOnboarding.ONBOARDING_VERSION) {
             super.onDestroy();
             return;
@@ -1113,9 +1097,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
-        if (Build.VERSION.SDK_INT < MIN_SDK)
-            return false;
-
         PackageManager pm = getPackageManager();
 
         MenuInflater inflater = getMenuInflater();
@@ -1469,13 +1450,15 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
 
         // Battery optimization button
         View btnBattery = view.findViewById(R.id.btnBattery);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Util.batteryOptimizing(this)) {
+        if (Util.batteryOptimizing(this)) {
             btnBattery.setVisibility(View.VISIBLE);
             btnBattery.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     try {
                         if (!Util.isPlayStoreInstall()) {
+                            // This is an explicit user recovery action for the VPN service.
+                            //noinspection BatteryLife
                             startActivity(new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS)
                                     .setData(Uri.parse("package:" + getPackageName())));
                         } else {
@@ -1526,6 +1509,9 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
             @Override
             public void onClick(View v) {
                 try {
+                    // Android exposes this settings action from API 24; the string is
+                    // intentionally inlined for the API 23 fallback path.
+                    //noinspection InlinedApi
                     startActivity(new Intent(Settings.ACTION_VPN_SETTINGS));
                 } catch (Throwable ex) {
                     Log.e(TAG, ex.toString());
@@ -1559,12 +1545,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
     }
 
     private void menu_legend() {
-        TypedValue tv = new TypedValue();
-        getTheme().resolveAttribute(R.attr.colorOn, tv, true);
-        int colorOn = tv.data;
-        getTheme().resolveAttribute(R.attr.colorOff, tv, true);
-        int colorOff = tv.data;
-
         // Create view
         LayoutInflater inflater = LayoutInflater.from(this);
         View view = inflater.inflate(R.layout.legend, null, false);
@@ -1575,24 +1555,6 @@ public class ActivityMain extends AppCompatActivity implements SharedPreferences
         ImageView ivScreenOn = view.findViewById(R.id.ivScreenOn);
         ImageView ivHostAllowed = view.findViewById(R.id.ivHostAllowed);
         ImageView ivHostBlocked = view.findViewById(R.id.ivHostBlocked);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            Drawable wrapWifiOn = DrawableCompat.wrap(ivWifiOn.getDrawable());
-            Drawable wrapWifiOff = DrawableCompat.wrap(ivWifiOff.getDrawable());
-            Drawable wrapOtherOn = DrawableCompat.wrap(ivOtherOn.getDrawable());
-            Drawable wrapOtherOff = DrawableCompat.wrap(ivOtherOff.getDrawable());
-            Drawable wrapScreenOn = DrawableCompat.wrap(ivScreenOn.getDrawable());
-            Drawable wrapHostAllowed = DrawableCompat.wrap(ivHostAllowed.getDrawable());
-            Drawable wrapHostBlocked = DrawableCompat.wrap(ivHostBlocked.getDrawable());
-
-            DrawableCompat.setTint(wrapWifiOn, colorOn);
-            DrawableCompat.setTint(wrapWifiOff, colorOff);
-            DrawableCompat.setTint(wrapOtherOn, colorOn);
-            DrawableCompat.setTint(wrapOtherOff, colorOff);
-            DrawableCompat.setTint(wrapScreenOn, colorOn);
-            DrawableCompat.setTint(wrapHostAllowed, colorOn);
-            DrawableCompat.setTint(wrapHostBlocked, colorOff);
-        }
-
         // Show dialog
         dialogLegend = new MaterialAlertDialogBuilder(this)
                 .setView(view)

--- a/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
+++ b/app/src/main/java/eu/faircode/netguard/ActivitySettings.java
@@ -24,7 +24,6 @@ import static net.kollnig.missioncontrol.data.TrackerBlocklist.PREF_BLOCKLIST;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.Context;
@@ -666,7 +665,6 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
     }
 
     @Override
-    @TargetApi(Build.VERSION_CODES.M)
     public void onSharedPreferenceChanged(SharedPreferences prefs, String name) {
         if ("show_stats".equals(name)) {
             ((TwoStatePreference) getPreferenceScreen().findPreference(name)).setChecked(prefs.getBoolean(name, false));
@@ -1127,7 +1125,6 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
         ServiceSinkhole.reload("bulk tracker protect changed", this, false);
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
     private boolean checkPermissions(String name) {
         PreferenceScreen screen = getPreferenceScreen();
         SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -1221,10 +1218,7 @@ public class ActivitySettings extends AppCompatActivity implements SharedPrefere
 
     private Intent getIntentOpenExport() {
         Intent intent;
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT)
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
-        else
-            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+        intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*"); // text/xml
         return intent;

--- a/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterAccess.java
@@ -24,9 +24,7 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.database.Cursor;
-import android.graphics.drawable.Drawable;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.text.SpannableString;
 import android.text.style.UnderlineSpan;
 import android.util.TypedValue;
@@ -38,7 +36,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.ViewCompat;
 
 import net.kollnig.missioncontrol.R;
@@ -132,10 +129,6 @@ public class AdapterAccess extends CursorAdapter {
         } else {
             ivBlock.setImageResource(block > 0 ? R.drawable.host_blocked : R.drawable.host_allowed);
             ivBlock.setContentDescription(context.getString(block > 0 ? R.string.blocked : R.string.allowed));
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                Drawable wrap = DrawableCompat.wrap(ivBlock.getDrawable());
-                DrawableCompat.setTint(wrap, block > 0 ? colorOff : colorOn);
-            }
         }
 
         String dest = Util.getProtocolName(protocol, version, true) +

--- a/app/src/main/java/eu/faircode/netguard/AdapterLog.java
+++ b/app/src/main/java/eu/faircode/netguard/AdapterLog.java
@@ -27,10 +27,8 @@ import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Typeface;
-import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.TypedValue;
@@ -41,7 +39,6 @@ import android.widget.CursorAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.ViewCompat;
 import androidx.preference.PreferenceManager;
 
@@ -222,10 +219,6 @@ public class AdapterLog extends CursorAdapter {
                 ivConnection.setImageResource(connection == 1 ? R.drawable.wifi_off : R.drawable.other_off);
         }
         ivConnection.setContentDescription(connectionDescription);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            Drawable wrap = DrawableCompat.wrap(ivConnection.getDrawable());
-            DrawableCompat.setTint(wrap, allowed > 0 ? colorOn : colorOff);
-        }
 
         // Show if screen on
         if (interactive <= 0) {
@@ -234,10 +227,6 @@ public class AdapterLog extends CursorAdapter {
         } else {
             ivInteractive.setImageResource(R.drawable.screen_on);
             ivInteractive.setContentDescription(context.getString(R.string.log_screen_on));
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-                Drawable wrap = DrawableCompat.wrap(ivInteractive.getDrawable());
-                DrawableCompat.setTint(wrap, colorOn);
-            }
         }
 
         // Show protocol name

--- a/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
+++ b/app/src/main/java/eu/faircode/netguard/ApplicationEx.java
@@ -22,7 +22,6 @@ package eu.faircode.netguard;
 
 import static org.acra.data.StringFormat.KEY_VALUE_LIST;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Application;
 import android.app.Notification;
@@ -43,6 +42,7 @@ import androidx.activity.EdgeToEdge;
 import androidx.activity.SystemBarStyle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
@@ -266,7 +266,7 @@ public class ApplicationEx extends Application {
         return BlockingMode.getDefaultMode();
     }
 
-    @TargetApi(Build.VERSION_CODES.O)
+    @RequiresApi(Build.VERSION_CODES.O)
     private void createNotificationChannels() {
         NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 

--- a/app/src/main/java/eu/faircode/netguard/Rule.java
+++ b/app/src/main/java/eu/faircode/netguard/Rule.java
@@ -682,9 +682,7 @@ public class Rule {
     private static List<String> getHandlingPackages(PackageManager pm, Intent intent) {
         List<String> packagesList = new ArrayList<>();
 
-        int flag = 0;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            flag = PackageManager.MATCH_ALL;
+        int flag = PackageManager.MATCH_ALL;
         List<ResolveInfo> activityList = pm.queryIntentActivities(intent, flag);
         for (ResolveInfo info : activityList)
             packagesList.add(info.activityInfo.packageName);

--- a/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceSinkhole.java
@@ -26,7 +26,6 @@ import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_PACKAG
 import static net.kollnig.missioncontrol.DetailsActivity.INTENT_EXTRA_APP_UID;
 import static eu.faircode.netguard.WidgetAdmin.INTENT_PAUSE;
 
-import android.annotation.TargetApi;
 import android.app.AlarmManager;
 import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.Notification;
@@ -73,6 +72,7 @@ import android.util.Pair;
 import android.util.TypedValue;
 import android.widget.RemoteViews;
 
+import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
@@ -871,27 +871,11 @@ public class ServiceSinkhole extends VpnService {
             List<Rule> listAllowed = getAllowedRules(listRule);
             ServiceSinkhole.Builder builder = getBuilder(listAllowed, listRule);
 
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP_MR1) {
-                last_builder = builder;
-                Log.i(TAG, "Legacy restart");
-
-                if (vpn != null) {
-                    stopNative(vpn);
-                    stopVPN(vpn);
-                    vpn = null;
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException ignored) {
-                    }
-                }
-                vpn = startVPN(last_builder);
-
-            } else {
-                if (vpn != null && builder.equals(last_builder)) {
+            if (vpn != null && builder.equals(last_builder)) {
                     Log.i(TAG, "Native restart");
                     stopNative(vpn);
 
-                } else {
+            } else {
                     last_builder = builder;
 
                     if (vpn == null)
@@ -921,7 +905,6 @@ public class ServiceSinkhole extends VpnService {
                             throw ex;
                         }
                     }
-                }
             }
 
             if (vpn == null)
@@ -1605,9 +1588,8 @@ public class ServiceSinkhole extends VpnService {
                     .setOngoing(true)
                     .setAutoCancel(false);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                        .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
 
             if (state == State.none || state == State.waiting) {
                 if (state != State.none) {
@@ -1790,7 +1772,6 @@ public class ServiceSinkhole extends VpnService {
         return listDns;
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private ParcelFileDescriptor startVPN(Builder builder) throws SecurityException {
         try {
             ParcelFileDescriptor pfd = builder.establish();
@@ -1848,9 +1829,6 @@ public class ServiceSinkhole extends VpnService {
         // Set underlying network so Android can correctly assess connectivity,
         // metering, and network scoring for the VPN.
         // Mirrors DuckDuckGo ATP approach (Apache 2.0).
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
-            return;
-
         try {
             Network active = getActiveNetwork();
             if (active == null) {
@@ -1938,19 +1916,18 @@ public class ServiceSinkhole extends VpnService {
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            try {
-                ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-                Network active = (cm == null ? null : cm.getActiveNetwork());
-                LinkProperties props = (active == null ? null : cm.getLinkProperties(active));
-                String domain = (props == null ? null : props.getDomains());
-                if (domain != null) {
-                    Log.i(TAG, "Using search domain=" + domain);
-                    builder.addSearchDomain(domain);
-                }
-            } catch (Throwable ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+        try {
+            ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+            Network active = (cm == null ? null : cm.getActiveNetwork());
+            LinkProperties props = (active == null ? null : cm.getLinkProperties(active));
+            String domain = (props == null ? null : props.getDomains());
+            if (domain != null) {
+                Log.i(TAG, "Using search domain=" + domain);
+                builder.addSearchDomain(domain);
             }
+        } catch (Throwable ex) {
+            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+        }
 
         // WireGuard AllowedIPs can opt RFC 1918 ranges into the VPN routes;
         // without WireGuard, private and reserved ranges remain excluded.
@@ -2097,23 +2074,21 @@ public class ServiceSinkhole extends VpnService {
         builder.setMtu(mtu);
 
         // Add list of allowed applications
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            try {
-                builder.addDisallowedApplication(getPackageName());
-            } catch (PackageManager.NameNotFoundException ex) {
-                Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-            }
-            for (Rule rule : listRule)
-                // Exclude from VPN if explicitly excluded OR if system app and includeSystem is
-                // false
-                if (!rule.apply || (!includeSystem && rule.system))
-                    try {
-                        Log.i(TAG, "Not routing " + rule.packageName);
-                        builder.addDisallowedApplication(rule.packageName);
-                    } catch (PackageManager.NameNotFoundException ex) {
-                        Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-                    }
+        try {
+            builder.addDisallowedApplication(getPackageName());
+        } catch (PackageManager.NameNotFoundException ex) {
+            Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
         }
+        for (Rule rule : listRule)
+            // Exclude from VPN if explicitly excluded OR if system app and includeSystem is
+            // false
+            if (!rule.apply || (!includeSystem && rule.system))
+                try {
+                    Log.i(TAG, "Not routing " + rule.packageName);
+                    builder.addDisallowedApplication(rule.packageName);
+                } catch (PackageManager.NameNotFoundException ex) {
+                    Log.e(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
+                }
 
         // Build configure intent
         Intent configure = new Intent(this, ActivityMain.class);
@@ -2853,7 +2828,7 @@ public class ServiceSinkhole extends VpnService {
     }
 
     // Called from native code
-    @TargetApi(Build.VERSION_CODES.Q)
+    @RequiresApi(Build.VERSION_CODES.Q)
     private int getUidQ(int version, int protocol, String saddr, int sport, String daddr, int dport) {
         if (protocol != 6 /* TCP */ && protocol != 17 /* UDP */)
             return Process.INVALID_UID;
@@ -3343,7 +3318,6 @@ public class ServiceSinkhole extends VpnService {
 
     private BroadcastReceiver userReceiver = new BroadcastReceiver() {
         @Override
-        @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
         public void onReceive(Context context, Intent intent) {
             Log.i(TAG, "Received " + intent);
             Util.logExtras(intent);
@@ -3369,7 +3343,6 @@ public class ServiceSinkhole extends VpnService {
 
     private BroadcastReceiver idleStateReceiver = new BroadcastReceiver() {
         @Override
-        @TargetApi(Build.VERSION_CODES.M)
         public void onReceive(Context context, Intent intent) {
             Log.i(TAG, "Received " + intent);
             Util.logExtras(intent);
@@ -3402,7 +3375,6 @@ public class ServiceSinkhole extends VpnService {
 
     private BroadcastReceiver apStateReceiver = new BroadcastReceiver() {
         @Override
-        @TargetApi(Build.VERSION_CODES.M)
         public void onReceive(Context context, Intent intent) {
             Log.i(TAG, "Received " + intent);
             Util.logExtras(intent);
@@ -3414,12 +3386,10 @@ public class ServiceSinkhole extends VpnService {
         @Override
         public void onReceive(Context context, Intent intent) {
             // Filter VPN connectivity changes
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                int networkType = intent.getIntExtra(ConnectivityManager.EXTRA_NETWORK_TYPE,
-                        ConnectivityManager.TYPE_DUMMY);
-                if (networkType == ConnectivityManager.TYPE_VPN)
-                    return;
-            }
+            int networkType = intent.getIntExtra(ConnectivityManager.EXTRA_NETWORK_TYPE,
+                    ConnectivityManager.TYPE_DUMMY);
+            if (networkType == ConnectivityManager.TYPE_VPN)
+                return;
 
             // Reload rules
             Log.i(TAG, "Received " + intent);
@@ -3542,11 +3512,9 @@ public class ServiceSinkhole extends VpnService {
                                         mapValidated.put(network, new Date().getTime());
                                     }
                                     mapValidateFailure.remove(network);
-                                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                                        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-                                        cm.reportNetworkConnectivity(network, true);
-                                        Log.i(TAG, "Reported " + network + " " + ni);
-                                    }
+                                    ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+                                    cm.reportNetworkConnectivity(network, true);
+                                    Log.i(TAG, "Reported " + network + " " + ni);
                                 } catch (IOException ex) {
                                     Log.e(TAG, ex.toString());
                                     Log.i(TAG, "No connectivity " + network + " " + ni);
@@ -3748,9 +3716,8 @@ public class ServiceSinkhole extends VpnService {
                     PendingIntent.FLAG_UPDATE_CURRENT);
             builder.addAction(0, getString(R.string.uninstall), piUninstall);
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-                builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                        .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
             // Show notification
             if (internet) {
@@ -3852,21 +3819,17 @@ public class ServiceSinkhole extends VpnService {
         net.kollnig.missioncontrol.wg.WgEgress.INSTANCE.addStateListener(wgStateListener);
 
         // Listen for user switches
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-            IntentFilter ifUser = new IntentFilter();
-            ifUser.addAction(Intent.ACTION_USER_BACKGROUND);
-            ifUser.addAction(Intent.ACTION_USER_FOREGROUND);
-            ContextCompat.registerReceiver(this, userReceiver, ifUser, ContextCompat.RECEIVER_NOT_EXPORTED);
-            registeredUser = true;
-        }
+        IntentFilter ifUser = new IntentFilter();
+        ifUser.addAction(Intent.ACTION_USER_BACKGROUND);
+        ifUser.addAction(Intent.ACTION_USER_FOREGROUND);
+        ContextCompat.registerReceiver(this, userReceiver, ifUser, ContextCompat.RECEIVER_NOT_EXPORTED);
+        registeredUser = true;
 
         // Listen for idle mode state changes
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            IntentFilter ifIdle = new IntentFilter();
-            ifIdle.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
-            ContextCompat.registerReceiver(this, idleStateReceiver, ifIdle, ContextCompat.RECEIVER_NOT_EXPORTED);
-            registeredIdleState = true;
-        }
+        IntentFilter ifIdle = new IntentFilter();
+        ifIdle.addAction(PowerManager.ACTION_DEVICE_IDLE_MODE_CHANGED);
+        ContextCompat.registerReceiver(this, idleStateReceiver, ifIdle, ContextCompat.RECEIVER_NOT_EXPORTED);
+        registeredIdleState = true;
 
         IntentFilter ifAp = new IntentFilter();
         ifAp.addAction("android.net.wifi.WIFI_AP_STATE_CHANGED");
@@ -3881,15 +3844,12 @@ public class ServiceSinkhole extends VpnService {
         ContextCompat.registerReceiver(this, packageChangedReceiver, ifPackage, ContextCompat.RECEIVER_NOT_EXPORTED);
         registeredPackageChanged = true;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            try {
-                listenNetworkChanges();
-            } catch (Throwable ex) {
-                Log.w(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
-                listenConnectivityChanges();
-            }
-        else
+        try {
+            listenNetworkChanges();
+        } catch (Throwable ex) {
+            Log.w(TAG, ex.toString() + "\n" + Log.getStackTraceString(ex));
             listenConnectivityChanges();
+        }
 
         // Monitor networks
         ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
@@ -3916,7 +3876,6 @@ public class ServiceSinkhole extends VpnService {
         initialized = true;
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void listenNetworkChanges() {
         // Listen for network changes
         Log.i(TAG, "Starting listening to network changes");
@@ -4066,20 +4025,17 @@ public class ServiceSinkhole extends VpnService {
         if (cm == null)
             return null;
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Network active = cm.getActiveNetwork();
-            if (active == null) {
-                Log.i(TAG, "getActiveNetwork: no active network");
-                return null;
-            }
-
-            NetworkCapabilities caps = cm.getNetworkCapabilities(active);
-            if (caps != null && caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
-                return active;
-            else
-                Log.w(TAG, "getActiveNetwork: active network is VPN");
-
+        Network active = cm.getActiveNetwork();
+        if (active == null) {
+            Log.i(TAG, "getActiveNetwork: no active network");
+            return null;
         }
+
+        NetworkCapabilities activeCapabilities = cm.getNetworkCapabilities(active);
+        if (activeCapabilities != null && activeCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_NOT_VPN))
+            return active;
+        else
+            Log.w(TAG, "getActiveNetwork: active network is VPN");
 
         NetworkInfo ani = cm.getActiveNetworkInfo();
         if (ani == null)
@@ -4353,7 +4309,6 @@ public class ServiceSinkhole extends VpnService {
         super.onDestroy();
     }
 
-    @TargetApi(Build.VERSION_CODES.LOLLIPOP)
     private void unlistenNetworkChanges() {
         ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
         cm.unregisterNetworkCallback((ConnectivityManager.NetworkCallback) networkCallback);
@@ -4384,10 +4339,9 @@ public class ServiceSinkhole extends VpnService {
             builder.setContentTitle(getString(R.string.app_name))
                     .setContentText(getString(R.string.msg_started));
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET)
-                    .setPriority(NotificationCompat.PRIORITY_MIN);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET)
+                .setPriority(NotificationCompat.PRIORITY_MIN);
 
         if (allowed >= 0)
             last_allowed = allowed;
@@ -4470,9 +4424,8 @@ public class ServiceSinkhole extends VpnService {
                 .setOngoing(false)
                 .setAutoCancel(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(getString(R.string.msg_revoked));
@@ -4497,9 +4450,8 @@ public class ServiceSinkhole extends VpnService {
                 .setOngoing(false)
                 .setAutoCancel(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(getString(R.string.msg_autostart));
@@ -4532,9 +4484,8 @@ public class ServiceSinkhole extends VpnService {
                 .setOngoing(false)
                 .setAutoCancel(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(text);
@@ -4565,9 +4516,8 @@ public class ServiceSinkhole extends VpnService {
                 .setAutoCancel(true)
                 .setOnlyAlertOnce(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(getString(R.string.msg_doh_unreachable));
@@ -4601,9 +4551,8 @@ public class ServiceSinkhole extends VpnService {
                 .setOngoing(true)
                 .setAutoCancel(false);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(detail);
@@ -4633,9 +4582,8 @@ public class ServiceSinkhole extends VpnService {
                 .setColor(getResources().getColor(R.color.colorTrackerControl))
                 .setAutoCancel(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(detail);
@@ -4669,9 +4617,8 @@ public class ServiceSinkhole extends VpnService {
                 // Rebuilt on every network change; alert once, then sit quietly.
                 .setOnlyAlertOnce(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(detail);
@@ -4709,9 +4656,8 @@ public class ServiceSinkhole extends VpnService {
                 // Rebuilt on every network change; alert once, then sit quietly.
                 .setOnlyAlertOnce(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(detail);
@@ -4819,9 +4765,8 @@ public class ServiceSinkhole extends VpnService {
                 .setAutoCancel(true)
                 .setOnlyAlertOnce(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         NotificationCompat.BigTextStyle notification = new NotificationCompat.BigTextStyle(builder);
         notification.bigText(detail);
@@ -4849,9 +4794,8 @@ public class ServiceSinkhole extends VpnService {
                 .setOngoing(false)
                 .setAutoCancel(true);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         Util.notify(this, NOTIFY_UPDATE, builder.build());
     }
@@ -4875,7 +4819,7 @@ public class ServiceSinkhole extends VpnService {
         private Builder() {
             super();
             ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-            activeNetwork = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M ? null : cm.getActiveNetwork());
+            activeNetwork = cm.getActiveNetwork();
             networkInfo = cm.getActiveNetworkInfo();
         }
 

--- a/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
+++ b/app/src/main/java/eu/faircode/netguard/ServiceTileMain.java
@@ -20,7 +20,6 @@
 
 package eu.faircode.netguard;
 
-import android.annotation.TargetApi;
 import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -33,10 +32,11 @@ import android.service.quicksettings.TileService;
 import android.util.Log;
 
 import androidx.preference.PreferenceManager;
+import androidx.annotation.RequiresApi;
 
 import net.kollnig.missioncontrol.R;
 
-@TargetApi(Build.VERSION_CODES.N)
+@RequiresApi(Build.VERSION_CODES.N)
 public class ServiceTileMain extends TileService implements SharedPreferences.OnSharedPreferenceChangeListener {
     private static final String TAG = "TrackerControl.TileMain";
 

--- a/app/src/main/java/eu/faircode/netguard/Util.java
+++ b/app/src/main/java/eu/faircode/netguard/Util.java
@@ -22,7 +22,6 @@ package eu.faircode.netguard;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
 import android.app.Notification;
 import android.app.ApplicationErrorReport;
 import android.content.Context;
@@ -52,6 +51,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
 
+import androidx.annotation.RequiresApi;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.app.ActivityCompat;
@@ -294,11 +294,8 @@ public class Util {
     }
 
     public static boolean hasPhoneStatePermission(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            return (context
-                    .checkSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED);
-        else
-            return true;
+        return (context
+                .checkSelfPermission(Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED);
     }
 
     public static List<String> getDefaultDNS(Context context) {
@@ -336,10 +333,7 @@ public class Util {
 
     public static boolean isInteractive(Context context) {
         PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT_WATCH)
-            return (pm != null && pm.isScreenOn());
-        else
-            return (pm != null && pm.isInteractive());
+        return (pm != null && pm.isInteractive());
     }
 
     public static boolean isPackageInstalled(String packageName, Context context) {
@@ -836,10 +830,8 @@ public class Util {
         }
 
         PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            sb.append(String.format("Power saving %B\r\n", pm.isPowerSaveMode()));
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
-            sb.append(String.format("Battery optimizing %B\r\n", batteryOptimizing(context)));
+        sb.append(String.format("Power saving %B\r\n", pm.isPowerSaveMode()));
+        sb.append(String.format("Battery optimizing %B\r\n", batteryOptimizing(context)));
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
             sb.append(String.format("Data saving %B\r\n", dataSaving(context)));
 
@@ -856,14 +848,11 @@ public class Util {
         NetworkInfo ani = cm.getActiveNetworkInfo();
         List<NetworkInfo> listNI = new ArrayList<>();
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
-            listNI.addAll(Arrays.asList(cm.getAllNetworkInfo()));
-        else
-            for (Network network : cm.getAllNetworks()) {
-                NetworkInfo ni = cm.getNetworkInfo(network);
-                if (ni != null)
-                    listNI.add(ni);
-            }
+        for (Network network : cm.getAllNetworks()) {
+            NetworkInfo ni = cm.getNetworkInfo(network);
+            if (ni != null)
+                listNI.add(ni);
+        }
 
         for (NetworkInfo ni : listNI) {
             sb.append(ni.getTypeName()).append('/').append(ni.getSubtypeName())
@@ -905,13 +894,12 @@ public class Util {
         return sb.toString();
     }
 
-    @TargetApi(Build.VERSION_CODES.M)
     public static boolean batteryOptimizing(Context context) {
         PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
         return !pm.isIgnoringBatteryOptimizations(context.getPackageName());
     }
 
-    @TargetApi(Build.VERSION_CODES.N)
+    @RequiresApi(Build.VERSION_CODES.N)
     public static boolean dataSaving(Context context) {
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         return (cm.getRestrictBackgroundStatus() == ConnectivityManager.RESTRICT_BACKGROUND_STATUS_ENABLED);

--- a/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
+++ b/app/src/main/java/eu/faircode/netguard/WidgetAdmin.java
@@ -83,10 +83,7 @@ public class WidgetAdmin extends ReceiverAutostart {
                 int auto = Integer.parseInt(prefs.getString("pause", "10"));
                 if (!enabled && auto > 0 && INTENT_PAUSE.equals(intent.getAction())) {
                     Log.i(TAG, "Scheduling enabled after minutes=" + auto);
-                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
-                        am.set(AlarmManager.RTC_WAKEUP, new Date().getTime() + auto * 60 * 1000L, pi);
-                    else
-                        am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, new Date().getTime() + auto * 60 * 1000L, pi);
+                    am.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, new Date().getTime() + auto * 60 * 1000L, pi);
                 }
             }
         } catch (Throwable ex) {

--- a/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/ActivityOnboarding.java
@@ -342,6 +342,8 @@ public class ActivityOnboarding extends AppCompatActivity {
                 } else {
                     slide.actionListener = v -> {
                         ActivityCompat.requestPermissions(ActivityOnboarding.this,
+                                // API-gated request; the permission name is an inlined constant.
+                                //noinspection InlinedApi
                                 new String[] { Manifest.permission.POST_NOTIFICATIONS }, 1);
                     };
                 }
@@ -398,6 +400,9 @@ public class ActivityOnboarding extends AppCompatActivity {
                     if (lockdownEnabled) {
                         slide.actionListener = v -> {
                             try {
+                                // Android exposes this settings action from API 24; the string is
+                                // intentionally inlined for the API 23 fallback path.
+                                //noinspection InlinedApi
                                 Intent intent = new Intent(Settings.ACTION_VPN_SETTINGS);
                                 startActivity(intent);
                             } catch (Throwable ex) {
@@ -413,6 +418,9 @@ public class ActivityOnboarding extends AppCompatActivity {
                     slide.warningResId = 0;
                     slide.actionListener = v -> {
                         try {
+                            // Android exposes this settings action from API 24; the string is
+                            // intentionally inlined for the API 23 fallback path.
+                            //noinspection InlinedApi
                             Intent intent = new Intent(Settings.ACTION_VPN_SETTINGS);
                             startActivity(intent);
                         } catch (Throwable ex) {
@@ -482,6 +490,9 @@ public class ActivityOnboarding extends AppCompatActivity {
                 .setPositiveButton(R.string.onboarding_vpn_blocked_action,
                         (DialogInterface.OnClickListener) (dialog, which) -> {
                             try {
+                                // This is a user-facing recovery action; the settings action is
+                                // intentionally inlined for API 23 devices.
+                                //noinspection InlinedApi
                                 startActivity(new Intent(Settings.ACTION_VPN_SETTINGS));
                             } catch (Throwable ex) {
                                 Log.e("Onboarding", ex.toString());

--- a/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
+++ b/app/src/main/java/net/kollnig/missioncontrol/analysis/TrackerAnalysisWorker.java
@@ -28,7 +28,6 @@ import android.content.Intent;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
 
@@ -168,9 +167,8 @@ public class TrackerAnalysisWorker extends Worker {
                 PendingIntent.FLAG_UPDATE_CURRENT);
         builder.addAction(0, context.getString(R.string.uninstall), piUninstall);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-            builder.setCategory(NotificationCompat.CATEGORY_STATUS)
-                    .setVisibility(NotificationCompat.VISIBILITY_SECRET);
+        builder.setCategory(NotificationCompat.CATEGORY_STATUS)
+                .setVisibility(NotificationCompat.VISIBILITY_SECRET);
 
         return builder.build();
     }

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Keep cloud backup and device-to-device transfer disabled, matching allowBackup=false. -->
+<data-extraction-rules xmlns:android="http://schemas.android.com/apk/res/android">
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <exclude domain="root" path="." />
+    </cloud-backup>
+    <device-transfer>
+        <exclude domain="root" path="." />
+    </device-transfer>
+</data-extraction-rules>


### PR DESCRIPTION
## Summary

- remove branches unreachable with the current API 23 minimum
- replace obsolete API annotations where requirements genuinely propagate
- preserve the public external-service and battery-recovery contracts with narrow documented lint exceptions
- keep cloud backup and device transfer disabled using current extraction rules
- enable resource shrinking alongside release minification

## Validation

- `./gradlew :app:testGithubDebugUnitTest -q`
- `./gradlew :app:lintGithubDebug -q`
- `./gradlew :app:compileGithubDebugJavaWithJavac -q`
- `./gradlew assembleGithubDebug assembleGithubRelease -q`
- `git diff --check`

Risk: `ServiceSinkhole.java` is a high-churn core VPN file with 36 dependants and no device validation in this run. An independent review and API-23+ device smoke test are recommended before merge.